### PR TITLE
[Issue #12] Updated for builds on Ubuntu 16.04

### DIFF
--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
@@ -64,17 +64,6 @@
 #include "common/khstl.h"
 #include "common/notify.h"
 
-
-
-namespace {
-void AddStringToProto(const std::string& str,
-                      keyhole::dbroot::StringIdOrValueProto* proto) {
-  proto->clear_string_id();
-  proto->set_value(str);
-}
-}  // namespace
-
-
 DbManifest::DbManifest(std::string* db_path)
   : db_path_(*db_path),
     search_prefix_(khGetSearchPrefix(db_path_)),

--- a/earth_enterprise/src/fusion/gecrawler/comparevector.cpp
+++ b/earth_enterprise/src/fusion/gecrawler/comparevector.cpp
@@ -31,17 +31,6 @@ struct OffsetSize {
   uint32 size;
 };
 
-bool CompareDataHeaders(const etDataHeader& header_a,
-                        const etDataHeader& header_b);
-bool ComparePolyLinePackets(etPolyLinePacketData* pak_a,
-                            etPolyLinePacketData* pak_b);
-bool CompareStreetPackets(etStreetPacketData* pak_a,
-                          etStreetPacketData* pak_b);
-bool CompareLandmarkPackets(etLandmarkPacketData* pak_a,
-                            etLandmarkPacketData* pak_b);
-bool ComparePolygonPackets(etPolygonPacketData* pak_a,
-                           etPolygonPacketData* pak_b);
-
 inline bool IsAlmostEqual(double a, double b, double epsilon) {
   return (fabs(a-b) < epsilon) ? true : false;
 }

--- a/earth_enterprise/src/fusion/gemaptilegen/Generator.cpp
+++ b/earth_enterprise/src/fusion/gemaptilegen/Generator.cpp
@@ -29,7 +29,8 @@
 
 
 namespace {
-
+//#define USE_DEBUG // Uncomment this line to use the following debug function
+#ifdef USE_DEBUG 
 // To print a png file for debugging.
 // Usage: WritePngFileDebug(&context.render_tile_.pixelBuf[0],
 //          task_config_.fusion_tilespace_.tileSize, item->qt_path_.AsString())
@@ -47,7 +48,7 @@ void WritePngFileDebug(char* pixel_buffer, uint tile_size,
   khWriteSimpleFile(file_prefix + ".png",
                     png_compressor->data(), png_compressor->dataLen());
 }
-
+#endif
 }  // namespace
 
 

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -104,19 +104,6 @@ void AppendMultiPartManifestParam(const std::vector<ManifestEntry> &entries,
   *args += file_sizes;
 }
 
-void AppendMultiPartStringsParam(const std::string &param_prefix,
-                                 const std::vector<std::string> &entries,
-                                 std::string *args) {
-  if (entries.empty())
-    return;
-
-  *args += param_prefix;
-  *args += entries[0];  // Add first item without delimiter.
-  for (size_t i = 1; i < entries.size(); ++i) {
-    *args += kMultiPartParameterDelimiter + entries[i];
-  }
-}
-
 }  // namespace
 
 

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -242,25 +242,6 @@ void SetFusionHost(PublisherClient* client,
   client->SetFusionHost(fusion_host.empty() ? default_host : fusion_host);
 }
 
-void CreateApacheFile(std::string path, std::string data) {
-  std::string tmp_file = khTmpFilename(std::string(), 0600);
-  if (!khWriteSimpleFile(tmp_file, data.c_str(), data.size())) {
-    fprintf(stderr, "Unable to create tmp file.");
-    exit(0);
-  }
-  if (!khMove(tmp_file, path)) {
-    fprintf(stderr, "Unable to create %s.\n", path.c_str());
-    exit(0);
-  }
-  std::string system_cmd =  "chown "
-      + ApacheUserNameServerOnly() + ":" + UserGroupnameServerOnly()
-      + " " + path;
-  int ret_status = system(system_cmd.c_str());
-  if (ret_status) {
-    exit(ret_status);
-  }
-}
-
 void DisableCutter() {
   int ret_status =
     system("cd /opt/google/bin; "


### PR DESCRIPTION
Fixes: https://github.com/google/earthenterprise/issues/12
The main issue is that the Ubuntu 16.04 compiler is more strict with its warnings, which in most cases are treated as errors. These are pretty much all related to unused functions. Instead of turning off the warning I have fixed the code. 

Tested this build on Ubuntu 14.04, 16.04, and RHEL 7.3.