### PR TITLE
I19: Portable Build Windows Fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.glc filter=lfs diff=lfs merge=lfs -text
 *.glm filter=lfs diff=lfs merge=lfs -text
-earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test_data/ binary
+earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test_data/* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.glc filter=lfs diff=lfs merge=lfs -text
 *.glm filter=lfs diff=lfs merge=lfs -text
+earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test_data/ binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.glc filter=lfs diff=lfs merge=lfs -text
 *.glm filter=lfs diff=lfs merge=lfs -text
-earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test_data/* binary
+earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test_data/** binary

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
@@ -2,5 +2,5 @@ copy /Y ..\shared\* .
 copy /Y ..\Windows\khTypes.h .
 swig -python -c++ glc_unpacker.i
 g++ -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
-g++ -c glc_unpacker_wrap.cxx -I c:\Python27\include
-g++ -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L c:\Python27\libs -l python27
+g++ -c glc_unpacker_wrap.cxx -I{exec_prefix}\include
+g++ -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L{exec_prefix}\libs -lpython27

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -62,29 +62,29 @@ def RunTests():
   shutil.copyfile("../test.py", "test.py")
 
   old_path = sys.path
-  sys.path = sys.path + [os.getcwd()]
+  sys.path = [os.getcwd()] + sys.path
   import test
   sys.path = old_path
 
   test.main()
 
-def main():
+def main(argv):
   """Main for build and test."""
-  if (len(sys.argv) != 2 or
-      sys.argv[1].lower() not in ["mac", "windows", "linux"]):
+  if (len(argv) != 2 or
+      argv[1].lower() not in ["mac", "windows", "linux"]):
     print "Usage: build_and_test.py <OS_target>"
     print
     print "<OS_target> can be Mac, Windows, or Linux"
     return
 
-  os.chdir(sys.path[0])
-  os_dir = "%s%s" % (sys.argv[1][0:1].upper(), sys.argv[1][1:].lower())
+  os.chdir(os.path.dirname(os.path.realpath(__file__)))
+  os_dir = "%s%s" % (argv[1][0:1].upper(), argv[1][1:].lower())
   print "Build and test file unpacker library for %s Portable Server." % os_dir
 
-  if BuildLibrary(os_dir, sys.argv[1].lower()=="windows"):
+  if BuildLibrary(os_dir, argv[1].lower()=="windows"):
     print "Library built."
     RunTests()
 
 
 if __name__ == "__main__":
-  main()
+  main(sys.argv)

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -38,8 +38,12 @@ def BuildLibrary(os_dir, ignore_results):
 
   os.chdir("dist")
   fp = open("../%s/build_lib" % os_dir)
+  build_vars = {
+      'prefix': sys.prefix,
+      'exec_prefix': sys.exec_prefix
+    }
   for line in fp:
-    result = util.ExecuteCmd(line, use_shell=True)
+    result = util.ExecuteCmd(line.format(**build_vars), use_shell=True)
     if result:
       if ignore_results:
         print result

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -39,9 +39,9 @@ def BuildLibrary(os_dir, ignore_results):
   os.chdir("dist")
   fp = open("../%s/build_lib" % os_dir)
   build_vars = {
-      'prefix': sys.prefix,
-      'exec_prefix': sys.exec_prefix
-    }
+    'prefix': sys.prefix,
+    'exec_prefix': sys.exec_prefix
+  }
   for line in fp:
     result = util.ExecuteCmd(line.format(**build_vars), use_shell=True)
     if result:

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -28,8 +28,7 @@ import os.path
 import shutil
 import sys
 
-SELF_PATH = os.path.realpath(__file__)
-SELF_DIR = os.path.dirname(SELF_PATH)
+SELF_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def ensure_directory(path):

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -144,7 +144,7 @@ class Builder(object):
             with open(path, 'r') as input_file:
                 while True:
                     base_version = input_file.readline().strip()
-                    if not base_version.startswith('#'):
+                    if base_version and not base_version.startswith('#'):
                         break
             self.base_version = base_version
 

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -114,7 +114,7 @@ class Builder(object):
         entries = [f
                    for f in os.listdir(servers_dir)
                    if f.lower() not in exclude_entries]
-        copy_from_dir_to_dir(servers_dir, self.server_dir, entries)
+        copy_from_dir_to_dir(servers_dir, self.server_dir, entries=entries)
         copy_from_dir_to_dir(
             os.path.join(servers_dir, self.platform), self.server_dir)
 
@@ -178,14 +178,16 @@ class Builder(object):
         build_and_test.main(['build_and_test.py', self.platform])
 
         # Copy library to package directory:
-        exclude_files = ['test.py', 'util.py']
+        exclude_entries = ['test.py', 'util.py']
         dist_dir = os.path.join(task_build_dir, 'dist')
         entries = [
             f
             for f in os.listdir(dist_dir)
-            if os.path.splitext(f)[1].lower() in ['.so', '.pyd', '.dll', '.py'] \
-                and f not in exclude_files]
-        copy_from_dir_to_dir(dist_dir, self.server_dir, entries)
+            if os.path.splitext(f)[1].lower() in
+            ['.so', '.pyd', '.dll', '.py']
+        ]
+        copy_from_dir_to_dir(dist_dir, self.server_dir, entries=entries,
+            exclude_entries=exclude_entries)
 
     def obtain_sample_globes(self):
         """Copies tutorial globe and map cuts to <data/>."""
@@ -234,7 +236,7 @@ def main(argv):
         platform = 'linux'
     elif platform.startswith('win'):
         platform = 'windows'
-    elif platform.startswith('darwin'):
+    elif platform.startswith('darwin') or platform.startswith('mac'):
         platform = 'mac'
     else:
         raise ValueError(

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -1,0 +1,230 @@
+#! /usr/bin/python
+#-*- Python -*-
+#
+# Copyright 2017 GEE Open Source Team <github.com/google/earthenterprise>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Builds Portable server for the Linux platform.
+"""
+
+import datetime
+import distutils.dir_util
+import os
+import os.path
+import shutil
+import sys
+import tarfile
+
+SELF_PATH = os.path.realpath(__file__)
+SELF_DIR = os.path.dirname(SELF_PATH)
+
+
+def ensure_directory(path):
+    """Makes sure a given directory exists."""
+
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+def copy_from_dir_to_dir(
+    source_dir, destination_dir, entries=None, exclude_entries=None):
+    """Copies given directory entries from one directory to another."""
+
+    if entries is None:
+        entries = os.listdir(source_dir)
+    if exclude_entries is not None:
+        entries = [e for e in entries if e not in exclude_entries]
+    for entry in entries:
+        source_path = os.path.join(source_dir, entry)
+        destination_path = os.path.join(destination_dir, entry)
+        if os.path.isdir(source_path):
+            distutils.dir_util.copy_tree(source_path, destination_path)
+        else:
+            shutil.copy2(source_path, destination_path)
+
+class Builder(object):
+    """Builds Portable server."""
+
+    def __init__(self, build_dir, source_dir, platform):
+        self.build_dir = build_dir
+        self.source_dir = source_dir
+        self.platform = platform
+
+        self.base_version = None
+        self.build_date = None
+        self.version_string = None
+        self.get_version()
+
+        self.package_dir = os.path.join(
+            self.build_dir, 'portableglobe-{}'.format(self.version_string))
+        self.resources_dir = os.path.join(
+            self.source_dir, 'portableserver', 'resources')
+        self.server_dir = os.path.join(self.package_dir, 'server')
+        self.tar_package_name = 'portableglobe-{}'.format(self.version_string)
+
+    def build(self):
+        """Builds and packages Portable server."""
+
+        shutil.rmtree(self.build_dir, ignore_errors=True)
+        ensure_directory(self.build_dir)
+        ensure_directory(self.package_dir)
+        ensure_directory(self.server_dir)
+        self.obtain_server_resources()
+        self.build_fileunpacker()
+        self.obtain_sample_globes()
+        self.tar_and_compress()
+
+    def clean(self):
+        """Deletes build files and directories."""
+
+        shutil.rmtree(self.build_dir, ignore_errors=True)
+
+    def obtain_server_resources(self):
+        """Builds <server/>."""
+
+        # Copy from <fusion/portableglobe/servers/>:
+        servers_dir = os.path.join(
+            self.source_dir, 'fusion', 'portableglobe', 'servers')
+
+        exclude_entries = ['linux', 'mac', 'windows', 'fileunpacker']
+        entries = [f
+                   for f in os.listdir(servers_dir)
+                   if f.lower() not in exclude_entries]
+        copy_from_dir_to_dir(servers_dir, self.server_dir, entries)
+        copy_from_dir_to_dir(
+            os.path.join(servers_dir, self.platform), self.server_dir)
+
+        # Copy from <maps/>:
+        copy_from_dir_to_dir(
+            os.path.join(self.source_dir, 'maps'),
+            os.path.join(self.server_dir, 'local', 'maps'),
+            exclude_entries=['SConscript'])
+
+        self.create_version_txt()
+
+        # Copy configuration files:
+        copy_from_dir_to_dir(self.resources_dir, self.server_dir)
+
+    def create_version_txt(self):
+        """Creates <server/local/version.txt>."""
+
+        self.get_version()
+        path = os.path.join(self.server_dir, 'local', 'version.txt')
+        with open(path, 'w') as output_file:
+            output_file.write(self.version_string)
+
+    def get_version(self):
+        """Parses version information, and sets member variables."""
+
+        if self.base_version is None:
+            path = os.path.join(self.source_dir, 'fusion_version.txt')
+            with open(path, 'r') as input_file:
+                while True:
+                    base_version = input_file.readline().strip()
+                    if not base_version.startswith('#'):
+                        break
+            self.base_version = base_version
+
+        if self.build_date is None:
+            self.build_date = datetime.date.today()
+
+        if self.version_string is None:
+            self.version_string = '{}-{}'.format(
+                self.base_version, self.build_date.strftime('%Y%m%d'))
+
+    def build_fileunpacker(self):
+        """Builds `fileunpacker` shared libraries, and copies them to
+        <server/>."""
+
+        # Keep the source directory clean:
+        task_build_dir = os.path.join(self.build_dir, 'fileunpacker-build')
+        shutil.rmtree(task_build_dir, ignore_errors=True)
+        distutils.dir_util.copy_tree(
+            os.path.join(self.source_dir, 'fusion', 'portableglobe', 'servers',
+                         'fileunpacker'),
+            task_build_dir)
+
+        # Execute 'build_and_test.py':
+        os.chdir(task_build_dir)
+        old_path = sys.path
+        sys.path = [task_build_dir] + sys.path
+        import build_and_test
+        sys.path = old_path
+
+        build_and_test.main(['build_and_test.py', self.platform])
+
+        # Copy library to package directory:
+        exclude_files = ['test.py', 'util.py']
+        dist_dir = os.path.join(task_build_dir, 'dist')
+        entries = [
+            f
+            for f in os.listdir(dist_dir)
+            if f.endswith('.so') or f.endswith('.py') \
+                and f not in exclude_files]
+        copy_from_dir_to_dir(dist_dir, self.server_dir, entries)
+
+    def obtain_sample_globes(self):
+        globes_dir = os.path.join(
+            self.source_dir, 'fusion', 'portableglobe', 'globes')
+        distutils.dir_util.copy_tree(
+            globes_dir, os.path.join(self.package_dir, 'data'))
+
+    def tar_and_compress(self):
+        output_path = os.path.join(
+            self.build_dir, self.tar_package_name + '.tgz')
+        with tarfile.open(output_path, 'w:gz') as archive:
+            archive.add(self.package_dir, arcname=self.tar_package_name)
+
+def main(argv):
+    """Parses command-line arguments, detects build environment, builds, and
+    packages Portable server."""
+
+    build_dir = os.path.join(SELF_DIR, 'build')
+    source_dir = os.path.join(SELF_DIR, '..')
+
+    platform = None
+    arg_index = 1
+    while arg_index < len(argv):
+        arg = argv[arg_index]
+        arg_index += 1
+        if arg in ['-p', '--platform']:
+            platform = argv[arg_index].lower()
+            arg_index += 1
+        elif arg.startswith('--platform='):
+            platform = arg[len('--platform='):]
+        elif arg in ['-c', '--clean']:
+            builder = Builder(build_dir, source_dir, platform)
+            builder.clean()
+            return
+        else:
+            print 'Unrecognized command-line argument:', arg
+            return
+
+    if platform is None:
+        platform = sys.platform.lower()
+    if platform.startswith('linux'):
+        platform = 'linux'
+    elif platform.startswith('win'):
+        platform = 'windows'
+    elif platform.startswith('darwin'):
+        platform = 'mac'
+    else:
+        raise ValueError(
+            'Unrecognized platform: {}, please specify "linux", "windows", or "mac" on the command line.'.format(platform))
+    builder = Builder(build_dir, source_dir, platform)
+    builder.build()
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -20,6 +20,7 @@
 Builds Portable server for Linux and Windows.
 """
 
+import argparse
 import datetime
 import distutils.dir_util
 import os
@@ -220,24 +221,13 @@ def main(argv):
     build_dir = os.path.join(SELF_DIR, 'build')
     source_dir = os.path.join(SELF_DIR, '..')
 
-    platform = None
-    arg_index = 1
-    while arg_index < len(argv):
-        arg = argv[arg_index]
-        arg_index += 1
-        if arg in ['-p', '--platform']:
-            platform = argv[arg_index].lower()
-            arg_index += 1
-        elif arg.startswith('--platform='):
-            platform = arg[len('--platform='):]
-        elif arg in ['-c', '--clean']:
-            builder = Builder(build_dir, source_dir, platform)
-            builder.clean()
-            return
-        else:
-            print 'Unrecognized command-line argument:', arg
-            return
+    parser = argparse.ArgumentParser(
+        description=__doc__, prog=os.path.basename(argv[0]))
+    parser.add_argument('--platform', '-p', action='store', default=None)
+    parser.add_argument('--clean', '-c', action='store_true')
+    parse_result = parser.parse_args(argv[1:])
 
+    platform = parse_result.platform
     if platform is None:
         platform = sys.platform.lower()
     if platform.startswith('linux'):
@@ -249,8 +239,12 @@ def main(argv):
     else:
         raise ValueError(
             'Unrecognized platform: {}, please specify "linux", "windows", or "mac" on the command line.'.format(platform))
+
     builder = Builder(build_dir, source_dir, platform)
-    builder.build()
+    if parse_result.clean:
+        builder.clean()
+    else:
+        builder.build()
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -17,7 +17,7 @@
 #
 
 """
-Builds Portable server for the Linux platform.
+Builds Portable server for Linux and Windows.
 """
 
 import datetime

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -198,9 +198,10 @@ class Builder(object):
         """Archives and compresses the install directory."""
 
         shutil.make_archive(
-            os.path.join(self.build_dir, self.tar_package_name),
+            os.path.join(self.build_dir, self.zip_package_name),
             'gztar',
-            self.package_dir)
+            os.path.dirname(self.package_dir),
+            os.path.basename(self.package_dir))
 
     def create_zip_package(self):
         """Archives and compresses the install directory."""
@@ -208,7 +209,8 @@ class Builder(object):
         shutil.make_archive(
             os.path.join(self.build_dir, self.zip_package_name),
             'zip',
-            self.package_dir)
+            os.path.dirname(self.package_dir),
+            os.path.basename(self.package_dir))
 
 
 def main(argv):

--- a/earth_enterprise/src/portableserver/resources/portable.cfg
+++ b/earth_enterprise/src/portableserver/resources/portable.cfg
@@ -1,0 +1,10 @@
+port 9335
+globes_directory ../data
+search_services_directory search_services
+ext_service_directory ext_service
+database file
+local_override True
+fill_missing_map_tiles True
+max_missing_map_tile_ancestor 24
+globe_name tutorial_sf.glb
+use_plugin True

--- a/earth_enterprise/src/portableserver/resources/remote.cfg
+++ b/earth_enterprise/src/portableserver/resources/remote.cfg
@@ -1,0 +1,2 @@
+port 9335
+portable_server __portable_server_ip__:9335


### PR DESCRIPTION
This is no longer a work-in-progress pull request.

* FileUnpacker builds on Linux and Windows now.

* Fixed `fileunpacker` build commands for Windows.
  * Added `sys.prefix` and `sys.exec_prefix` as variables that can be expanded in build commands.
  * Fixed compile commands for MinGW. (Spaces seemed not to work for me.)
* Fixed `util.ExecuteCmd` to show complete standard output and standard error on Windows before returning.