### PR TITLE
Adds links for downloading fusion source files

### DIFF
--- a/geedocs/answer/4412441.html
+++ b/geedocs/answer/4412441.html
@@ -27,7 +27,11 @@
 <p><img src="../art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Fusion tutorial</h1>
 <h2>Setting Up the Tutorial</h2>
-<p>The Google Earth Enterprise Fusion tutorial data is provided on the Google Earth Enterprise Fusion installation DVD and should have been installed in <code>/opt/google/share/tutorials/fusion/</code> on your workstation or network. In addition, your system administrator should have configured a tutorial environment for you to work on the tutorial lessons, keeping your practice data separate from your live production data.</p>
+<p>
+  In Google Earth Enterprise Open Source, the fusion tutorial data is not included in the installation packages.
+  Refer to <a href="../answer/6028272.html">Configure tutorial workspace</a> for download and installation instructions.
+</p>
+<p>In older versions, the Google Earth Enterprise Fusion tutorial data is provided on the Google Earth Enterprise Fusion installation DVD and should have been installed in <code>/opt/google/share/tutorials/fusion/</code> on your workstation or network. In addition, your system administrator should have configured a tutorial environment for you to work on the tutorial lessons, keeping your practice data separate from your live production data.</p>
 <p>If Google Earth Enterprise Fusion or the tutorial files are not installed or you encounter an error message that tells you that a tutorial source file is not readable or you cannot save a resource, contact your system administrator or refer to <a href="../answer/6028272.html">Configure tutorial workspace</a> to install the files and configure the tutorial environment before saving any practice data.</p>
 <p>As you follow the steps in this tutorial, you'll begin to learn how to create 2D and 3D databases, as well as becoming familiar with the Google Earth Enterprise Fusion user interface.</p>
 <ul>

--- a/geedocs/answer/6028272.html
+++ b/geedocs/answer/6028272.html
@@ -32,10 +32,42 @@
 <p>This article describes how to configure the tutorial work space and how to switch back and forth between the tutorial asset root and the production asset root. You also learn how to clean up the tutorial files when they are no longer needed.
 </p>
 <ul>
+<li><a href="#download_tutorial_source">Download the Tutorial Source Files</a></li>
 <li><a href="#configure_tutorial_asset_root">Configure the tutorial asset root and source volume</a></li>
 <li><a href="#select_tutorial_asset_root">Select the tutorial asset root</a></li>
 <li><a href="#cleanup_tutorial_workspace">Clean up the tutorial workspace</a></li>
 </ul>
+<h2><a id="download_tutorial_source"></a>Download the Tutorial Source Files
+</h2>
+<p>
+  The tutorial source files are available in the following archives. It can be downloaded all together, or for
+  convenience it can be downloaded in two parts.
+  <ul>
+    <li>
+      <a href="http://data.opengee.org/FusionTutorial-Full.tar.gz">FusionTutorial-Full.tar.gz</a>
+      [<a href="http://data.opengee.org/FusionTutorial-Full.tar.gz.md5">md5</a>]
+      - Contains all the source data needed to complete the tutorial - 600 MB
+    </li>
+    <li>
+      <a href="http://data.opengee.org/FusionTutorial-NoMosaicImagery.tar.gz">FusionTutorial-NoMosaicImagery.tar.gz</a>
+      [<a href="http://data.opengee.org/FusionTutorial-NoMosaicImagery.tar.gz.md5">md5</a>]
+      - Contains all the source data needed to complete the tutorial, except for the Mosaic section - 282 MB
+    </li>
+    <li>
+      <a href="http://data.opengee.org/FusionTutorial-Imagery-mosaic.tar.gz">FusionTutorial-Imagery-mosaic.tar.gz</a>
+      [<a href="http://data.opengee.org/FusionTutorial-Imagery-mosaic.tar.gz.md5">md5</a>]
+      - Contains only the souce data needed to complete the Mosaic section of the tutorial - 318 MB
+    </li>
+  </ul>
+</p>
+<p>
+  Once the source files are downloaded, as root, create the <code>/opt/google/share/tutorials/fusion</code> directory if it doesn't
+  exist. Extract each archive downloaded to that location. Be sure all the files have read permission for all users and directories
+  have read and execute permission for all users.
+</p>
+<p>
+  Note: due to a bug in the current Google Earth Enterprise Open Source version, vector source files also need the write permission.
+</p>
 <h2><a id="configure_tutorial_asset_root"></a>Configuring the tutorial asset root and source volume
 </h2>
 <p>When you install Google Earth Enterprise, you configure a source volume and asset root for your production data. If you accepted the default values, they are <code>/gevol/src</code> and <code>/gevol/assets</code>, respectively.</p>


### PR DESCRIPTION
Fixes https://github.com/google/earthenterprise/issues/40
Added links and instructions for downloading and installing fusion source files

A preview of the changes is available here: https://tst-ccamp.github.io/earthenterprise/geedocs/answer/4412441.html