### PR TITLE
Set python version in mod_wsgi-ge.conf

### DIFF
--- a/earth_enterprise/src/.gitignore
+++ b/earth_enterprise/src/.gitignore
@@ -8,3 +8,4 @@ NATIVE-REL-x86_64/
 *.pyc
 .sconf_temp
 config.log
+third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf

--- a/earth_enterprise/src/.gitignore
+++ b/earth_enterprise/src/.gitignore
@@ -8,4 +8,3 @@ NATIVE-REL-x86_64/
 *.pyc
 .sconf_temp
 config.log
-third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf

--- a/earth_enterprise/src/third_party/mod_wsgi/SConscript
+++ b/earth_enterprise/src/third_party/mod_wsgi/SConscript
@@ -115,7 +115,7 @@ mod_wsgi_install = mod_wsgi_env.Command(
         'cp -pr README.rst LICENSE %s' % install_root_doc,
         'mkdir -p %s/gehttpd/conf.d' % install_root_opt,
         'install -m755 %s %s' % (source_conf, target_conf),
-        "sed -i -e 's/@PYTHON_VERSION@/%s/' %s" % (mod_wsgi_env['python_version'], target_conf),
+        "sed -i -e 's/@PYTHON_VERSION@/%s/' -e 's/@PYTHON_MAJOR_VERSION@/%s/' %s" % (mod_wsgi_env['python_version'], mod_wsgi_env['python_major_version'], target_conf),
         'touch %s' % mod_wsgi_target]))])
 
 # [5] Install these into various directories as required for build

--- a/earth_enterprise/src/third_party/mod_wsgi/SConscript
+++ b/earth_enterprise/src/third_party/mod_wsgi/SConscript
@@ -125,6 +125,12 @@ mod_wsgi_env.ExecuteOnClean('rm -rf %s' % current_dir)
 
 if 'install' in COMMAND_LINE_TARGETS:
   server_root = mod_wsgi_env.installdirs['server_root']
+
+  # Configure mod_wsgi-ge.conf with the correct python version
+  mod_wsgi_conf = 'conf.d/mod_wsgi-ge.conf'
+  mod_wsgi_env.Command(mod_wsgi_conf, mod_wsgi_conf + '.in',
+      "sed 's/@PYTHON_VERSION@/%s/' < $SOURCE > $TARGET" % mod_wsgi_env['python_version'])
+
   mod_wsgi_env.install('httpdconf', ['conf.d/mod_wsgi-ge.conf'])
   mod_wsgi_env.InstallFileOrDir(
       '%s/opt/' % install_root,

--- a/earth_enterprise/src/third_party/mod_wsgi/SConscript
+++ b/earth_enterprise/src/third_party/mod_wsgi/SConscript
@@ -100,6 +100,10 @@ install_root_doc = '%s/opt/google/share/doc/packages/%s' % (
     install_root, mod_wsgi_ge_version)
 
 mod_wsgi_target = '%s/.install' % current_dir
+mod_wsgi_conf_dir = Dir('#third_party/mod_wsgi/conf.d').abspath
+mod_wsgi_conf = 'mod_wsgi-ge.conf'
+source_conf = '%s/%s.in' % (mod_wsgi_conf_dir, mod_wsgi_conf)
+target_conf = '%s/gehttpd/conf.d/%s' % (install_root_opt, mod_wsgi_conf)
 mod_wsgi_install = mod_wsgi_env.Command(
     mod_wsgi_target, mod_wsgi_build,
     [mod_wsgi_env.MultiCommand('\n'.join([
@@ -109,6 +113,9 @@ mod_wsgi_install = mod_wsgi_env.Command(
         'cp src/server/.libs/mod_wsgi.so %s/gehttpd/modules/mod_wsgi.so' % install_root_opt,
         'mkdir -p %s' % install_root_doc,
         'cp -pr README.rst LICENSE %s' % install_root_doc,
+        'mkdir -p %s/gehttpd/conf.d' % install_root_opt,
+        'install -m755 %s %s' % (source_conf, target_conf),
+        "sed -i -e 's/@PYTHON_VERSION@/%s/' %s" % (mod_wsgi_env['python_version'], target_conf),
         'touch %s' % mod_wsgi_target]))])
 
 # [5] Install these into various directories as required for build
@@ -125,13 +132,6 @@ mod_wsgi_env.ExecuteOnClean('rm -rf %s' % current_dir)
 
 if 'install' in COMMAND_LINE_TARGETS:
   server_root = mod_wsgi_env.installdirs['server_root']
-
-  # Configure mod_wsgi-ge.conf with the correct python version
-  mod_wsgi_conf = 'conf.d/mod_wsgi-ge.conf'
-  mod_wsgi_env.Command(mod_wsgi_conf, mod_wsgi_conf + '.in',
-      "sed 's/@PYTHON_VERSION@/%s/' < $SOURCE > $TARGET" % mod_wsgi_env['python_version'])
-
-  mod_wsgi_env.install('httpdconf', ['conf.d/mod_wsgi-ge.conf'])
   mod_wsgi_env.InstallFileOrDir(
       '%s/opt/' % install_root,
       '%s/opt/' % server_root,

--- a/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
+++ b/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
@@ -1,9 +1,21 @@
-# Copyright 2013 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 LoadModule wsgi_module modules/mod_wsgi.so
 
 <IfModule wsgi_module>
     WSGIRestrictEmbedded On
-    # TODO: use python version from config.
     WSGIPythonHome /usr
 
     # Handles Fusion requests.

--- a/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
+++ b/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
@@ -17,18 +17,18 @@ LoadModule wsgi_module modules/mod_wsgi.so
 
     # Handles publishing requests.
     # Note: Publish service will be initialized on starting httpd server.
-    WSGIDaemonProcess ge_publish_serve threads=5 display-name=%{GROUP} python-path=/opt/google/gepython/Python-2.7.6/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_publish_serve threads=5 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python@PYTHON_MAJOR_VERSION@/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     WSGIScriptAlias /geserve/Publish /opt/google/gehttpd/wsgi-bin/serve/publish/publish_app.wsgi process-group=ge_publish_serve application-group=%{GLOBAL}
 
     # Handles reguest managing of auxiliary publish data.
-    WSGIDaemonProcess ge_publish_aux_serve threads=5 display-name=%{GROUP} python-path=/opt/google/gepython/Python-2.7.6/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_publish_aux_serve threads=5 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python@PYTHON_MAJOR_VERSION@/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     # --Handles Search Definitions managing requests.
     WSGIScriptAlias /geserve/SearchPublish /opt/google/gehttpd/wsgi-bin/serve/publish/search/search_publish_app.wsgi process-group=ge_publish_aux_serve
     # --Handles Snippets profile managing requests.
     WSGIScriptAlias /geserve/Snippets /opt/google/gehttpd/wsgi-bin/serve/snippets/snippets_app.wsgi process-group=ge_publish_aux_serve
 
     # Handles search requests.
-    WSGIDaemonProcess ge_search_serve processes=10 threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-2.7.6/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_search_serve processes=10 threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python@PYTHON_MAJOR_VERSION@/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     # --Handles Places search requests.
     WSGIScriptAlias /gesearch/PlacesSearch /opt/google/gehttpd/wsgi-bin/search/plugin/geplaces_search_app.py process-group=ge_search_serve
     # --Handles Coordinate search requests.
@@ -47,7 +47,7 @@ LoadModule wsgi_module modules/mod_wsgi.so
     WSGIScriptAlias /gesearch/SearchGoogle /opt/google/gehttpd/wsgi-bin/search/plugin/search_google_app.py process-group=ge_search_serve
 
     # Handles WMS serving requests.
-    WSGIDaemonProcess ge_wms_serve processes=10 threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-2.7.6/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_wms_serve processes=10 threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python@PYTHON_MAJOR_VERSION@/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     WSGIScriptAlias /wms /opt/google/gehttpd/wsgi-bin/wms/ogc/service/wms_request_app.wsgi process-group=ge_wms_serve
 </IfModule>
 

--- a/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
+++ b/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
@@ -7,7 +7,7 @@ LoadModule wsgi_module modules/mod_wsgi.so
     WSGIPythonHome /usr
 
     # Handles Fusion requests.
-    WSGIDaemonProcess ge_fusion_serve threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_fusion_serve threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python@PYTHON_MAJOR_VERSION@/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     # --Handles stream data pushing requests.
     WSGIScriptAlias /geserve/StreamPush /opt/google/gehttpd/wsgi-bin/serve/push/stream/stream_push_app.wsgi process-group=ge_fusion_serve
     # --Handles search data pushing requests.

--- a/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
+++ b/earth_enterprise/src/third_party/mod_wsgi/conf.d/mod_wsgi-ge.conf.in
@@ -7,7 +7,7 @@ LoadModule wsgi_module modules/mod_wsgi.so
     WSGIPythonHome /usr
 
     # Handles Fusion requests.
-    WSGIDaemonProcess ge_fusion_serve threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-2.7.6/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
+    WSGIDaemonProcess ge_fusion_serve threads=15 display-name=%{GROUP} python-path=/opt/google/gepython/Python-@PYTHON_VERSION@/lib/python2.7/site-packages:/opt/google/gehttpd/wsgi-bin home=/tmp
     # --Handles stream data pushing requests.
     WSGIScriptAlias /geserve/StreamPush /opt/google/gehttpd/wsgi-bin/serve/push/stream/stream_push_app.wsgi process-group=ge_fusion_serve
     # --Handles search data pushing requests.


### PR DESCRIPTION
fixes #17

mod_wsgi-ge.conf includes the path to the Python site-packages
file, and the path includes the Python version.  This commit
ensures that the Python version, and thus the path, is correct
in mod_wsgi-ge.conf.