### PR TITLE
Ensure unit tests can find test data (#15).

### DIFF
--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -22,7 +22,7 @@ use File::Basename;
 # gdal_rasterize,...) used in tests.
 $ENV{'PATH'} = join ":", "$Bin/..", $ENV{'PATH'};
 
-my @tests = glob("$Bin/*");
+my @tests = glob("$Bin/*test*");
 
 my $longest = 0;
 foreach my $test (@tests) {

--- a/earth_enterprise/src/common/tests/SConscript
+++ b/earth_enterprise/src/common/tests/SConscript
@@ -16,6 +16,7 @@
 
 Import('env')
 import os
+import shutil
 
 env.Append(LIBPATH = ['/usr/lib/', '/usr/lib64'])
 
@@ -50,8 +51,12 @@ map(lambda test: env.test(test, [test + '.cc'],
     ['etencoder_tests',
      ])
 
+testdir = os.path.join(env.exportdirs['bin'],'tests')
+env.copyfile(testdir, 'RunAllTests.pl')
 
-env.copyfile(os.path.join(env.exportdirs['bin'],'tests'),
-             'RunAllTests.pl')
+# Drop in the test data
+fusiontestdir = os.path.join(testdir, 'fusion')
+shutil.rmtree(fusiontestdir, ignore_errors=True)
+shutil.copytree('../../fusion', fusiontestdir)
 
 env.sharedLib('getests', ['qtpathgen.cpp'])


### PR DESCRIPTION
I considered adding a symlink, but since the tests create files in the test data directory, a copy seemed safer.