### PR TITLE
Ignore build directory for portableserver.

### DIFF
--- a/earth_enterprise/src/.gitignore
+++ b/earth_enterprise/src/.gitignore
@@ -8,6 +8,7 @@ NATIVE-REL-x86_64/
 *.pyc
 .sconf_temp
 config.log
+portableserver/build
 
 # Eclipse project files
 .cproject


### PR DESCRIPTION
Followup to https://github.com/google/earthenterprise/issues/19