### PR TITLE
(#47) GEServer Installer

### DIFF
--- a/earth_enterprise/geplaces/geplaces
+++ b/earth_enterprise/geplaces/geplaces
@@ -51,11 +51,9 @@ then
 
   create_view_cmd="$BINDIR/psql -U geuser -t -c \"$create_view_query\" geplaces"
   view_exists=`eval $create_view_cmd`
-  if [ $view_exists -eq 1 ] ; then
+  if [ "$view_exists" != "CREATE VIEW" ] ; then
     echo GEPLACES cities_utf8 view already exists.
   fi
-
-
 else
   if [ $1 == "delete" ]
   then

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -98,10 +98,12 @@ determine_os()
 }
 
 run_as_user() {
-    use_su="su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0"
+    local use_su=`su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0`
     if [ "$use_su" -eq 1 ] ; then
+        >&2 echo "cd / ;su $1 -c \"$2\""
         ( cd / ;su $1 -c "$2" )
     else
+        >&2 echo "cd / ;sudo -u $1 $2"
         ( cd / ;sudo -u $1 $2 )
     fi
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -25,12 +25,19 @@ HOSTNAME_A="$(hostname -a | $NEWLINECLEANER)"
 
 NUM_CPUS="$(grep processor /proc/cpuinfo | wc -l | $NEWLINECLEANER)"
 
+SUPPORTED_OS_LIST=("Ubuntu", "Red Hat Enterprise Linux (RHEL)")
+UBUNTUKEY="ubuntu"
+REDHATKEY="rhel"
+CENTOSKEY="centos"
+OS_RELEASE1="/etc/os-release"
+OS_RELEASE2="/etc/system-release"
+
 software_check()
 {
-	local software_check_retval=0
-	
-	# args: $1: ubuntu package
-	# args: $: rhel package
+    local software_check_retval=0
+    
+    # args: $1: ubuntu package
+    # args: $: rhel package
 
     if [ "$MACHINE_OS" == "$UBUNTUKEY" ]; then
         if [[ -z "$(dpkg --get-selections | sed s:install:: | sed -e 's:\s::g' | grep ^$1\$)" ]]; then
@@ -42,13 +49,13 @@ software_check()
             echo -e "Install $2 and restart the $GEEF $LONG_VERSION uninstaller."
             software_check_retval=1
         fi
-	else 
-		echo -e "\nThe installer could not determine your machine's operating system."
+    else 
+        echo -e "\nThe installer could not determine your machine's operating system."
             echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
             software_check_retval=1
     fi
 
-	return $software_check_retval
+    return $software_check_retval
 }
 
 determine_os()
@@ -57,17 +64,24 @@ determine_os()
     local test_os=""
     local test_versionid=""
 
-    if [ -f "$OS_RELEASE" ]; then
-        test_os="$(cat $OS_RELEASE | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
-        test_versionid="$(cat $OS_RELEASE | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
+    if [ -f "$OS_RELEASE1" ] || [ -f "$OS_RELEASE2" ]; then
+        if [ -f "$OS_RELEASE1" ]; then
+                test_os="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
+                test_versionid="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
+        else
+            test_os="$(cat $OS_RELEASE2 | sed 's:[0-9\.] *::g')"
+            test_versionid="$(cat $OS_RELEASE2 | sed 's:[^0-9\.]*::g')"
+        fi
 
-		MACHINE_OS_FRIENDLY="$test_os $test_versionid"
-        MACHINE_OS_VERSION=$test_versionid
+        MACHINE_OS_FRIENDLY="$test_os $test_versionid"
+            MACHINE_OS_VERSION=$test_versionid
 
-        if [[ "${test_os,,}" == "ubuntu"* ]]; then
-            MACHINE_OS=$UBUNTUKEY
-        elif [ "${test_os,,}" == "red hat"* ]; then
-            MACHINE_OS=$REDHATKEY
+            if [[ "${test_os,,}" == "ubuntu"* ]]; then
+                    MACHINE_OS=$UBUNTUKEY
+            elif [[ "${test_os,,}" == "red hat"* ]]; then
+                    MACHINE_OS=$REDHATKEY
+        elif [[ "${test_os,,}" == "centos"* ]]; then
+            MACHINE_OS=$CENTOSKEY
         else
             MACHINE_OS=""
             echo -e "\nThe installer could not determine your machine's operating system."
@@ -76,7 +90,7 @@ determine_os()
         fi
     else
         echo -e "\nThe installer could not determine your machine's operating system."
-        echo -e "Missing file: $OS_RELEASE\n"
+        echo -e "Missing file: $OS_RELEASE1 or $OS_RELEASE2\n"
         retval=1
     fi
 
@@ -94,50 +108,50 @@ run_as_user() {
 
 show_no_tmp_dir_message()
 {
-	echo -e "\nThe temp install directory specified [$1] does not exist."
-	echo -e "Please specify the path of the extracted install files or first run"
+    echo -e "\nThe temp install directory specified [$1] does not exist."
+    echo -e "Please specify the path of the extracted install files or first run"
     echo -e "scons release=1 installdir=$1 install\n"
 }
 
 check_bad_hostname() {
     if [ -z "$HOSTNAME" ] || [[ " ${BADHOSTNAMELIST[*]} " == *"${HOSTNAME,,} "* ]]; then
-		show_badhostname
+        show_badhostname
 
-		if [ $BADHOSTNAMEOVERRIDE == true ]; then
-			echo -e "Continuing the installation process...\n"
-			return 1
-		else
-			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnf 'Hostname Override' flag.\n"
-			return 0
-		fi
-	fi
+        if [ $BADHOSTNAMEOVERRIDE == true ]; then
+            echo -e "Continuing the installation process...\n"
+            return 1
+        else
+            echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnf 'Hostname Override' flag.\n"
+            return 0
+        fi
+    fi
 }
 
 show_badhostname()
 {
-	echo -e "\nYour server [$HOSTNAME] contains an invalid hostname value which typically"
-	echo -e "indicates an automatically generated hostname that might change over time."
+    echo -e "\nYour server [$HOSTNAME] contains an invalid hostname value which typically"
+    echo -e "indicates an automatically generated hostname that might change over time."
     echo -e "A subsequent hostname change would cause configuration issues for the "
     echo -e "$SOFTWARE_NAME software.  Invalid values: ${BADHOSTNAMELIST[*]}."
 }
 
 check_mismatched_hostname() {
     if [ $HOSTNAME != $HOSTNAME_F ]; then
-		show_mismatchedhostname
+        show_mismatchedhostname
 
-		if [ $MISMATCHHOSTNAMEOVERRIDE == true ]; then
-			echo -e "Continuing the installation process...\n"
-		else
-			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
-			exit 1
-		fi		
-	fi
+        if [ $MISMATCHHOSTNAMEOVERRIDE == true ]; then
+            echo -e "Continuing the installation process...\n"
+        else
+            echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
+            exit 1
+        fi        
+    fi
 }
 
 show_mismatchedhostname()
 {
-	echo -e "\nThe hostname of this machine does not match the fully-qualified hostname."
-	echo -e "$SOFTWARE_NAME requires that they match for local publishing to function properly."
+    echo -e "\nThe hostname of this machine does not match the fully-qualified hostname."
+    echo -e "$SOFTWARE_NAME requires that they match for local publishing to function properly."
     # Chris: I took out the message about updating the hostname because this script doesn't actually do it.
     # TODO Add some instructions on how to update hostname
 }
@@ -146,42 +160,42 @@ check_group() {
   GROUP_EXISTS=$(getent group $GROUPNAME)
 
   # add group if it does not exist
-	if [ -z "$GROUP_EXISTS" ]; then
-		groupadd -r $GROUPNAME &> /dev/null 
+    if [ -z "$GROUP_EXISTS" ]; then
+        groupadd -r $GROUPNAME &> /dev/null 
         NEW_GEGROUP=true 
-	fi
+    fi
 }
 
 check_username() {
   USERNAME_EXISTS=$(getent passwd $1)
 
   # add user if it does not exist
-	if [ -z "$USERNAME_EXISTS" ]; then
+    if [ -z "$USERNAME_EXISTS" ]; then
     mkdir -p $BASEINSTALLDIR_OPT/.users/$1
-		useradd -d $BASEINSTALLDIR_OPT/.users/$1 -g gegroup $1
+        useradd -d $BASEINSTALLDIR_OPT/.users/$1 -g gegroup $1
     NEW_GEFUSIONUSER=true
   else
     echo "User $1 exists"
     # user already exists -- update primary group
     usermod -g $GROUPNAME $1
-	fi
+    fi
 }
 
 create_links()
 {
-	printf "Setting up system links..."
+    printf "Setting up system links..."
 
-	if [ ! -L "$BASEINSTALLDIR_OPT/etc" ]; then
-		ln -s $BASEINSTALLDIR_ETC $BASEINSTALLDIR_OPT/etc
-	fi 
+    if [ ! -L "$BASEINSTALLDIR_OPT/etc" ]; then
+        ln -s $BASEINSTALLDIR_ETC $BASEINSTALLDIR_OPT/etc
+    fi 
 
-	if [ ! -L "$BASEINSTALLDIR_OPT/log" ]; then
-		ln -s $BASEINSTALLDIR_VAR/log $BASEINSTALLDIR_OPT/log
-	fi
+    if [ ! -L "$BASEINSTALLDIR_OPT/log" ]; then
+        ln -s $BASEINSTALLDIR_VAR/log $BASEINSTALLDIR_OPT/log
+    fi
 
-	if [ ! -L "$BASEINSTALLDIR_OPT/run" ]; then
-		ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
-	fi
+    if [ ! -L "$BASEINSTALLDIR_OPT/run" ]; then
+        ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
+    fi
 
-	printf "DONE\n"	
+    printf "DONE\n"    
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -35,7 +35,7 @@ OS_RELEASE2="/etc/system-release"
 software_check()
 {
     local software_check_retval=0
-    
+
     # args: $1: ubuntu package
     # args: $: rhel package
 
@@ -51,8 +51,8 @@ software_check()
         fi
     else 
         echo -e "\nThe installer could not determine your machine's operating system."
-            echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
-            software_check_retval=1
+        echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
+        software_check_retval=1
     fi
 
     return $software_check_retval
@@ -66,20 +66,20 @@ determine_os()
 
     if [ -f "$OS_RELEASE1" ] || [ -f "$OS_RELEASE2" ]; then
         if [ -f "$OS_RELEASE1" ]; then
-                test_os="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
-                test_versionid="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
+            test_os="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
+            test_versionid="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
         else
             test_os="$(cat $OS_RELEASE2 | sed 's:[0-9\.] *::g')"
             test_versionid="$(cat $OS_RELEASE2 | sed 's:[^0-9\.]*::g')"
         fi
 
         MACHINE_OS_FRIENDLY="$test_os $test_versionid"
-            MACHINE_OS_VERSION=$test_versionid
+        MACHINE_OS_VERSION=$test_versionid
 
-            if [[ "${test_os,,}" == "ubuntu"* ]]; then
-                    MACHINE_OS=$UBUNTUKEY
-            elif [[ "${test_os,,}" == "red hat"* ]]; then
-                    MACHINE_OS=$REDHATKEY
+        if [[ "${test_os,,}" == "ubuntu"* ]]; then
+            MACHINE_OS=$UBUNTUKEY
+        elif [[ "${test_os,,}" == "red hat"* ]]; then
+            MACHINE_OS=$REDHATKEY
         elif [[ "${test_os,,}" == "centos"* ]]; then
             MACHINE_OS=$CENTOSKEY
         else
@@ -98,12 +98,12 @@ determine_os()
 }
 
 run_as_user() {
- use_su="su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0"
- if [ "$use_su" -eq 1 ] ; then
-    ( cd / ;su $1 -c "$2" )
- else
-    ( cd / ;sudo -u $1 $2 )
- fi
+    use_su="su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0"
+    if [ "$use_su" -eq 1 ] ; then
+        ( cd / ;su $1 -c "$2" )
+    else
+        ( cd / ;sudo -u $1 $2 )
+    fi
 }
 
 show_no_tmp_dir_message()
@@ -144,7 +144,7 @@ check_mismatched_hostname() {
         else
             echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
             exit 1
-        fi        
+        fi
     fi
 }
 
@@ -157,9 +157,9 @@ show_mismatchedhostname()
 }
 
 check_group() {
-  GROUP_EXISTS=$(getent group $GROUPNAME)
+    GROUP_EXISTS=$(getent group $GROUPNAME)
 
-  # add group if it does not exist
+    # add group if it does not exist
     if [ -z "$GROUP_EXISTS" ]; then
         groupadd -r $GROUPNAME &> /dev/null 
         NEW_GEGROUP=true 
@@ -167,17 +167,17 @@ check_group() {
 }
 
 check_username() {
-  USERNAME_EXISTS=$(getent passwd $1)
+    USERNAME_EXISTS=$(getent passwd $1)
 
-  # add user if it does not exist
+    # add user if it does not exist
     if [ -z "$USERNAME_EXISTS" ]; then
-    mkdir -p $BASEINSTALLDIR_OPT/.users/$1
+        mkdir -p $BASEINSTALLDIR_OPT/.users/$1
         useradd -d $BASEINSTALLDIR_OPT/.users/$1 -g gegroup $1
-    NEW_GEFUSIONUSER=true
-  else
-    echo "User $1 exists"
-    # user already exists -- update primary group
-    usermod -g $GROUPNAME $1
+        NEW_GEFUSIONUSER=true
+    else
+        echo "User $1 exists"
+        # user already exists -- update primary group
+        usermod -g $GROUPNAME $1
     fi
 }
 
@@ -197,5 +197,5 @@ create_links()
         ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
     fi
 
-    printf "DONE\n"    
+    printf "DONE\n"
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BADHOSTNAMELIST=(empty linux localhost dhcp bootp)
+
+# Get system info values
+NEWLINECLEANER="sed -e s:\\n::g"
+HOSTNAME="$(hostname -f | tr [A-Z] [a-z] | $NEWLINECLEANER)"
+HOSTNAME_F="$(hostname -f | $NEWLINECLEANER)"
+HOSTNAME_S="$(hostname -s | $NEWLINECLEANER)"
+HOSTNAME_A="$(hostname -a | $NEWLINECLEANER)"
+
+NUM_CPUS="$(grep processor /proc/cpuinfo | wc -l | $NEWLINECLEANER)"
+
+software_check()
+{
+	local software_check_retval=0
+	
+	# args: $1: ubuntu package
+	# args: $: rhel package
+
+    if [ "$MACHINE_OS" == "$UBUNTUKEY" ]; then
+        if [[ -z "$(dpkg --get-selections | sed s:install:: | sed -e 's:\s::g' | grep ^$1\$)" ]]; then
+            echo -e "Install $1 and restart the $GEEF $LONG_VERSION uninstaller."
+            software_check_retval=1
+        fi
+    elif [ "$MACHINE_OS" == "$REDHATKEY" ]; then
+        if [[ -z "$(rpm -qa | grep ^$2\$)" ]]; then
+            echo -e "Install $2 and restart the $GEEF $LONG_VERSION uninstaller."
+            software_check_retval=1
+        fi
+	else 
+		echo -e "\nThe installer could not determine your machine's operating system."
+            echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
+            software_check_retval=1
+    fi
+
+	return $software_check_retval
+}
+
+determine_os()
+{
+    local retval=0
+    local test_os=""
+    local test_versionid=""
+
+    if [ -f "$OS_RELEASE" ]; then
+        test_os="$(cat $OS_RELEASE | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
+        test_versionid="$(cat $OS_RELEASE | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
+
+		MACHINE_OS_FRIENDLY="$test_os $test_versionid"
+        MACHINE_OS_VERSION=$test_versionid
+
+        if [[ "${test_os,,}" == "ubuntu"* ]]; then
+            MACHINE_OS=$UBUNTUKEY
+        elif [ "${test_os,,}" == "red hat"* ]; then
+            MACHINE_OS=$REDHATKEY
+        else
+            MACHINE_OS=""
+            echo -e "\nThe installer could not determine your machine's operating system."
+            echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
+            retval=1
+        fi
+    else
+        echo -e "\nThe installer could not determine your machine's operating system."
+        echo -e "Missing file: $OS_RELEASE\n"
+        retval=1
+    fi
+
+    return $retval
+}
+
+run_as_user() {
+ use_su="su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0"
+ if [ "$use_su" -eq 1 ] ; then
+    ( cd / ;su $1 -c "$2" )
+ else
+    ( cd / ;sudo -u $1 $2 )
+ fi
+}
+
+show_no_tmp_dir_message()
+{
+	echo -e "\nThe temp install directory specified [$1] does not exist."
+	echo -e "Please specify the path of the extracted install files or first run"
+    echo -e "scons release=1 installdir=$1 install\n"
+}
+
+check_bad_hostname() {
+    if [ -z "$HOSTNAME" ] || [[ " ${BADHOSTNAMELIST[*]} " == *"${HOSTNAME,,} "* ]]; then
+		show_badhostname
+
+		if [ $BADHOSTNAMEOVERRIDE == true ]; then
+			echo -e "Continuing the installation process...\n"
+			return 1
+		else
+			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnf 'Hostname Override' flag.\n"
+			return 0
+		fi
+	fi
+}
+
+show_badhostname()
+{
+	echo -e "\nYour server [$HOSTNAME] contains an invalid hostname value which typically"
+	echo -e "indicates an automatically generated hostname that might change over time."
+    echo -e "A subsequent hostname change would cause configuration issues for the "
+    echo -e "$SOFTWARE_NAME software.  Invalid values: ${BADHOSTNAMELIST[*]}."
+}
+
+check_mismatched_hostname() {
+    if [ $HOSTNAME != $HOSTNAME_F ]; then
+		show_mismatchedhostname
+
+		if [ $MISMATCHHOSTNAMEOVERRIDE == true ]; then
+			echo -e "Continuing the installation process...\n"
+		else
+			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
+			exit 1
+		fi		
+	fi
+}
+
+show_mismatchedhostname()
+{
+	echo -e "\nThe hostname of this machine does not match the fully-qualified hostname."
+	echo -e "$SOFTWARE_NAME requires that they match for local publishing to function properly."
+    # Chris: I took out the message about updating the hostname because this script doesn't actually do it.
+    # TODO Add some instructions on how to update hostname
+}
+
+check_group() {
+  GROUP_EXISTS=$(getent group $GROUPNAME)
+
+  # add group if it does not exist
+	if [ -z "$GROUP_EXISTS" ]; then
+		groupadd -r $GROUPNAME &> /dev/null 
+        NEW_GEGROUP=true 
+	fi
+}
+
+check_username() {
+  USERNAME_EXISTS=$(getent passwd $1)
+
+  # add user if it does not exist
+	if [ -z "$USERNAME_EXISTS" ]; then
+    mkdir -p $BASEINSTALLDIR_OPT/.users/$1
+		useradd -d $BASEINSTALLDIR_OPT/.users/$1 -g gegroup $1
+    NEW_GEFUSIONUSER=true
+  else
+    echo "User $1 exists"
+    # user already exists -- update primary group
+    usermod -g $GROUPNAME $1
+	fi
+}
+
+create_links()
+{
+	printf "Setting up system links..."
+
+	if [ ! -L "$BASEINSTALLDIR_OPT/etc" ]; then
+		ln -s $BASEINSTALLDIR_ETC $BASEINSTALLDIR_OPT/etc
+	fi 
+
+	if [ ! -L "$BASEINSTALLDIR_OPT/log" ]; then
+		ln -s $BASEINSTALLDIR_VAR/log $BASEINSTALLDIR_OPT/log
+	fi
+
+	if [ ! -L "$BASEINSTALLDIR_OPT/run" ]; then
+		ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
+	fi
+
+	printf "DONE\n"	
+}

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -119,10 +119,12 @@ check_bad_hostname() {
 
         if [ $BADHOSTNAMEOVERRIDE == true ]; then
             echo -e "Continuing the installation process...\n"
-            return 1
+            # 0 = true (in bash)
+            return 0
         else
             echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnf 'Hostname Override' flag.\n"
-            return 0
+            # 1 = false
+            return 1
         fi
     fi
 }
@@ -141,9 +143,12 @@ check_mismatched_hostname() {
 
         if [ $MISMATCHHOSTNAMEOVERRIDE == true ]; then
             echo -e "Continuing the installation process...\n"
+            # 0 = true (in bash)
+            return 0
         else
             echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
-            exit 1
+            # 1 = false
+            return 1
         fi
     fi
 }

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -18,6 +18,8 @@
 
 set +x
 
+. common.sh
+
 # config values
 ASSET_ROOT="/gevol/assets"
 SOURCE_VOLUME="/gevol/src"
@@ -39,7 +41,6 @@ OS_RELEASE1="/etc/os-release"
 OS_RELEASE2="/etc/system-release"
 
 # script arguments
-BADHOSTNAMELIST=(empty linux localhost dhcp bootp)
 BACKUPFUSION=true
 BADHOSTNAMEOVERRIDE=false
 MISMATCHHOSTNAMEOVERRIDE=false
@@ -59,9 +60,9 @@ TOPSOURCEDIR_EE=$(dirname $SOURCECODEDIR)
 
 # additional variables
 GEEF="Google Earth Enterprise Fusion"
+SOFTWARE_NAME="$GEEF"
 LONG_VERSION="5.1.3"
 IS_NEWINSTALL=false
-NEWLINECLEANER="sed -e s:\\n::g"
 PUBLISH_ROOT_VOLUME=""
 IS_64BIT_OS=false
 ROOT_USERNAME="root"
@@ -79,9 +80,10 @@ HOSTNAME_S="$(hostname -s | $NEWLINECLEANER)"
 HOSTNAME_A="$(hostname -a | $NEWLINECLEANER)"
 NUM_CPUS="$(grep processor /proc/cpuinfo | wc -l | $NEWLINECLEANER)"
 
+ASSET_ROOT_VOLUME_SIZE=0
 SOURCE_VOLUME_PREEXISTING=false
 ASSET_ROOT_PREEXISTING=false
-ASSET_ROOT_VOLUME_SIZE=0
+
 MIN_ASSET_ROOT_VOLUME_SIZE_IN_KB=1048576
 EXISTING_HOST=""
 IS_SLAVE=false
@@ -142,27 +144,13 @@ main_preinstall()
 		show_invalid_assetroot_name $INVALID_ASSETROOT_NAMES
 		exit 1
 	fi
-    
-	if [ -z "$HOSTNAME" ] || [[ " ${BADHOSTNAMELIST[*]} " == *"${HOSTNAME,,} "* ]]; then
-		show_badhostname
 
-		if [ $BADHOSTNAMEOVERRIDE == true ]; then
-			echo -e "Continuing the installation process...\n"
-		else
-			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnf 'Hostname Override' flag.\n"
-			exit 1
-		fi
+	if ! check_bad_hostname; then
+		exit 1
 	fi
-
-	if [ $HOSTNAME != $HOSTNAME_F ]; then
-		show_mismatchedhostname
-
-		if [ $MISMATCHHOSTNAMEOVERRIDE == true ]; then
-			echo -e "Continuing the installation process...\n"
-		else
-			echo -e "Exiting the installer.  If you wish to continue, re-run this command with the -hnmf 'Hostname Mismatch Override' flag.\n"
-			exit 1
-		fi		
+    
+	if ! check_mismatched_hostname; then
+		exit 1
 	fi
 
 	# 64 bit check
@@ -421,21 +409,6 @@ show_X11()
 	echo -e "The installer must exit."
 }
 
-show_badhostname()
-{
-	echo -e "\nYour server [$HOSTNAME] contains an invalid hostname value which typically indicates an automatically generated"
-	echo -e "hostname that might change over time.  A subsequent hostname change would cause configuration issues for the "
-	echo -e "$GEEF software.  Invalid values: ${BADHOSTNAMELIST[*]}."
-}
-
-show_mismatchedhostname()
-{
-	echo -e "\nThe hostname of this machine does not match the fully-qualified hostname."
-	echo -e "$GEEF requires that they match for local publishing to function properly."
-	echo -e "To continue, the installer will update the hostname to match "
-	echo -e "the fully-qualified hostname."
-}
-
 is_valid_custom_directory()
 {
 	# Standard function that tests a string to see if it passes the "valid" alphanumeric for asset root/source volume.
@@ -461,12 +434,6 @@ is_valid_alphanumeric()
 	else
 		return 1
 	fi
-}
-
-show_no_tmp_dir_message()
-{
-	echo -e "\nThe temp install directory specified [$1] does not exist."
-	echo -e "Please specify the path of the extracted install files.\n"
 }
 
 parse_arguments()
@@ -773,6 +740,7 @@ copy_files_to_target()
 	fi
 }
 
+<<<<<<< Updated upstream
 create_links()
 {
 	printf "Setting up system links..."
@@ -792,6 +760,8 @@ create_links()
 	printf "Done\n"	
 }
 
+=======
+>>>>>>> Stashed changes
 #-----------------------------------------------------------------
 # Post-install Functions
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -812,7 +812,7 @@ compare_asset_root_publishvolume()
                 echo -e "can be quickly accomplished with hard/soft links without taking the additional space "
                 echo -e "needed for a full copy."
                 echo ""
-        
+
                 if ! prompt_to_quit "X (Exit) the installer and change the asset root location - C (Continue) to use the asset root that you have specified."; then
                     compare_assetroot_publishvolume_retval=1
                 fi                

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -37,8 +37,6 @@ BASEINSTALLDIR_VAR="/var/opt/google"
 TMPINSTALLDIR="/tmp/fusion_os_install"
 INITSCRIPTUPDATE="/usr/sbin/update-rc.d"
 CHKCONFIG="/sbin/chkconfig"
-OS_RELEASE1="/etc/os-release"
-OS_RELEASE2="/etc/system-release"
 
 # script arguments
 BACKUPFUSION=true
@@ -66,10 +64,7 @@ IS_NEWINSTALL=false
 PUBLISH_ROOT_VOLUME=""
 IS_64BIT_OS=false
 ROOT_USERNAME="root"
-SUPPORTED_OS_LIST=("Ubuntu", "Red Hat Enterprise Linux (RHEL)")
-UBUNTUKEY="ubuntu"
-REDHATKEY="rhel"
-CENTOSKEY="centos"
+
 MACHINE_OS=""
 MACHINE_OS_VERSION=""
 MACHINE_OS_FRIENDLY=""
@@ -277,45 +272,6 @@ load_systemrc_config()
 		GEFUSIONUSER_NAME=$(xmllint --xpath '//Systemrc/fusionUsername/text()' $SYSTEMRC)
 		GROUPNAME=$(xmllint --xpath '//Systemrc/userGroupname/text()' $SYSTEMRC)		
 	fi
-}
-
-determine_os()
-{
-    local retval=0
-    local test_os=""
-    local test_versionid=""
-
-    if [ -f "$OS_RELEASE1" ] || [ -f "$OS_RELEASE2" ]; then
-	if [ -f "$OS_RELEASE1" ]; then
-	        test_os="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^NAME= | sed 's:name=::gI')"
-    		test_versionid="$(cat $OS_RELEASE1 | sed -e 's:\"::g' | grep ^VERSION_ID= | sed 's:version_id=::gI')"
-	else
-		test_os="$(cat $OS_RELEASE2 | sed 's:[0-9\.] *::g')"
-		test_versionid="$(cat $OS_RELEASE2 | sed 's:[^0-9\.]*::g')"
-	fi
-
-	MACHINE_OS_FRIENDLY="$test_os $test_versionid"
-    	MACHINE_OS_VERSION=$test_versionid
-
-        if [[ "${test_os,,}" == "ubuntu"* ]]; then
-            	MACHINE_OS=$UBUNTUKEY
-        elif [[ "${test_os,,}" == "red hat"* ]]; then
-            	MACHINE_OS=$REDHATKEY
-	elif [[ "${test_os,,}" == "centos"* ]]; then
-		MACHINE_OS=$CENTOSKEY
-        else
-            MACHINE_OS=""
-            echo -e "\nThe installer could not determine your machine's operating system."
-            echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
-            retval=1
-        fi
-    else
-		echo -e "\nThe installer could not determine your machine's operating system."
-        echo -e "Missing file: $OS_RELEASE\n"
-        retval=1		
-	fi
-
-    return $retval
 }
 
 software_check()
@@ -740,28 +696,6 @@ copy_files_to_target()
 	fi
 }
 
-<<<<<<< Updated upstream
-create_links()
-{
-	printf "Setting up system links..."
-
-	if [ ! -L "$BASEINSTALLDIR_OPT/etc" ]; then
-		ln -s $BASEINSTALLDIR_ETC $BASEINSTALLDIR_OPT/etc
-	fi 
-
-	if [ ! -L "$BASEINSTALLDIR_OPT/log" ]; then
-		ln -s $BASEINSTALLDIR_VAR/log $BASEINSTALLDIR_OPT/log
-	fi
-
-	if [ ! -L "$BASEINSTALLDIR_OPT/run" ]; then
-		ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
-	fi
-
-	printf "Done\n"	
-}
-
-=======
->>>>>>> Stashed changes
 #-----------------------------------------------------------------
 # Post-install Functions
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -18,7 +18,10 @@
 
 set +x
 
-. common.sh
+# get script directory
+SCRIPTDIR=`dirname $0`
+
+. $SCRIPTDIR/common.sh
 
 # config values
 ASSET_ROOT="/gevol/assets"

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -234,19 +234,19 @@ show_intro()
 # TODO: Update for GEE Server
 show_help()
 {
-  echo -e "\nUsage: \tsudo ./install_fusion.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
+  echo -e "\nUsage: \tsudo ./install_server.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
   echo -e "\t\t-g gegroup -nobk -nop -hnf -nostart]\n"
 
   echo -e "-h \t\tHelp - display this help screen"
   echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
   echo -e "-u \t\tFusion User Name - the user name to use for Fusion. Default is [$GEFUSIONUSER_NAME]. \n\t\tNote: this is only used for new installations."
   echo -e "-g \t\tUser Group Name - the group name to use for the Fusion user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
-  echo -e "-ar \t\tAsset Root Mame - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
+  echo -e "-ar \t\tAsset Root Name - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
   echo -e "-sv \t\tSource Volume Name - the name of the source volume.  Default is [$SOURCE_VOLUME]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
-  echo -e "-nobk \t\tNo Backup - do not backup the current fusion setup. Default is to backup \n\t\tthe setup before installing."
+  echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tthe setup before installing."
   echo -e "-nop \t\tNo Purge - do not delete the temporary install directory upon successful run of the installer."
   echo -e "\t\tDefault is to delete the directory after successful installation."
-  echo -e "-nostart \tDo Not Start Fusion - after install, do not start the Fusion daemon.  Default is to start the daemon."
+  echo -e "-nostart \tDo Not Start Server - after install, do not start the server daemon.  Default is to start the daemon."
   echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
   echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
 }
@@ -286,12 +286,8 @@ parse_arguments()
   local parse_arguments_retval=0
   local show_user_group_recommendation=false
 
-  # TODO: Remove debug
-  echo Num args: $#
-
   while [ $# -gt 0 ]
   do
-    echo Parsing: "${1,,}"
     case "${1,,}" in
       -h|-help|--help)
         show_help
@@ -471,7 +467,7 @@ copy_files_to_target()
 {
   printf "\nCopying files from source to target directories..."
 
-  kdir -p $BASEINSTALLDIR_OPT/share/doc
+  mkdir -p $BASEINSTALLDIR_OPT/share/doc
   mkdir -p $BASEINSTALLDIR_OPT/gehttpd/conf
   mkdir -p $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images
   mkdir -p $BASEINSTALLDIR_OPT/search
@@ -570,11 +566,11 @@ setup_geserver_daemon()
 {
   # setup geserver daemon
   # For Ubuntu
-   echo "Setting up the geserver daemon...\n"
-   test -f $CHKCONFIG && $CHKCONFIG --add geserver
-   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE -f geserver remove
-   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE geserver start 90 2 3 4 5 . stop 10 0 1 6 .
-   printf "GEE Server daemon setup ... DONE\n"
+  printf "Setting up the geserver daemon...\n"
+  test -f $CHKCONFIG && $CHKCONFIG --add geserver
+  test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE -f geserver remove
+  test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE geserver start 90 2 3 4 5 . stop 10 0 1 6 .
+  printf "GEE Server daemon setup ... DONE\n"
 }
 
 # 6) Install the GEPlaces and SearchExample Databases

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -87,68 +87,68 @@ main_preinstall()
   # 3) Introduction
   show_intro
 
-	# 2) Root/Sudo check
-	if [ "$EUID" != "0" ]; then 
-		show_need_root
-		exit 1
-	fi
+  # 2) Root/Sudo check
+  if [ "$EUID" != "0" ]; then
+    show_need_root
+    exit 1
+  fi
 
   # 5a) Check previous installation
   if [ -f "$SERVERBININSTALL" ]; then
-		IS_NEWINSTALL=false
-	else
-		IS_NEWINSTALL=true
-	fi
+    IS_NEWINSTALL=false
+  else
+    IS_NEWINSTALL=true
+  fi
 
   # Argument check
-	if ! parse_arguments "$@"; then		
-		exit 1
-	fi
-
-	if ! determine_os; then
+  if ! parse_arguments "$@"; then
     exit 1
   fi
-  
+
+  if ! determine_os; then
+    exit 1
+  fi
+
   # 7) Check prerequisite software
   if ! check_prereq_software; then
-		exit 1
-	fi
+    exit 1
+  fi
 
   # check to see if GE Server processes are running
   services_running = check_server_processes_running
-  
-	if [ $services_running -ne 0 ]; then
-		show_server_running_message
-		exit 1
-	fi
+
+  if [ $services_running -ne 0 ]; then
+    show_server_running_message
+    exit 1
+  fi
 
   # tmp dir check
-	if [ ! -d "$TMPINSTALLDIR" ]; then
-		show_no_tmp_dir_message $TMPINSTALLDIR
-		exit 1
-	fi
+  if [ ! -d "$TMPINSTALLDIR" ]; then
+    show_no_tmp_dir_message $TMPINSTALLDIR
+    exit 1
+  fi
 
   # 5b) Perform backup
   if [ $BACKUPSERVER == true ]; then
-		# Backing up current Server Install...
-		backup_server
-	fi
+    # Backing up current Server Install...
+    backup_server
+  fi
 
   # 6) Check valid host properties
- 	if ! check_bad_hostname; then
-		exit 1
-	fi
+   if ! check_bad_hostname; then
+    exit 1
+  fi
 
   if ! check_mismatched_hostname; then
-		exit 1
-	fi
+    exit 1
+  fi
 
   # 64 bit check
-	if [[ "$(uname -i)" == "x86_64" ]]; then 
-        IS_64BIT_OS=true 
-	else
-		echo -e "\n$GEEF $LONG_VERSION can only be installed on a 64 bit operating system."
-		exit 1
+  if [[ "$(uname -i)" == "x86_64" ]]; then
+        IS_64BIT_OS=true
+  else
+    echo -e "\n$GEEF $LONG_VERSION can only be installed on a 64 bit operating system."
+    exit 1
   fi
 
   # 8) Check if group and users exist
@@ -163,24 +163,24 @@ main_preinstall()
 
 check_prereq_software()
 {
-	local check_prereq_software_retval=0
+  local check_prereq_software_retval=0
 
-	if ! software_check "libxml2-utils" "libxml2.*x86_64"; then
-		check_prereq_software_retval=1
-	fi
+  if ! software_check "libxml2-utils" "libxml2.*x86_64"; then
+    check_prereq_software_retval=1
+  fi
 
-	if ! software_check "python2.7" "python-2.7.*"; then
-		check_prereq_software_retval=1
-	fi
+  if ! software_check "python2.7" "python-2.7.*"; then
+    check_prereq_software_retval=1
+  fi
 
 
-	return $check_prereq_software_retval
+  return $check_prereq_software_retval
 }
 
 main_install()
 {
-	copy_files_to_target
-	create_links
+  copy_files_to_target
+  create_links
 }
 
 main_postinstall()
@@ -190,7 +190,7 @@ main_postinstall()
 
   # 2) Set Permissions Before Server Start/Stop
   fix_postinstall_filepermissions
-  
+
   # 3) PostGres DB config
   postgres_db_config
 
@@ -209,16 +209,16 @@ main_postinstall()
 
   # 8) Set permissions after geserver Start/Stop.
   fix_postinstall_filepermissions
-  
+
   # TODO - verify
   # 9) Run geecheck config script
   # If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
   if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
-     cd $BASEINSTALLDIR_OPT/gehttpd/cgi-bin
-     python ./set_geecheck_config.py
+    cd $BASEINSTALLDIR_OPT/gehttpd/cgi-bin
+    python ./set_geecheck_config.py
   fi
 
-  # 10) 
+  # 10)
   show_final_success_message
 }
 
@@ -227,41 +227,41 @@ main_postinstall()
 #-----------------------------------------------------------------
 
 show_intro()
-{	
-	echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
+{
+  echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
 }
 
 # TODO: Update for GEE Server
 show_help()
 {
-	echo -e "\nUsage: \tsudo ./install_fusion.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
-	echo -e "\t\t-g gegroup -nobk -nop -hnf -nostart]\n"
+  echo -e "\nUsage: \tsudo ./install_fusion.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
+  echo -e "\t\t-g gegroup -nobk -nop -hnf -nostart]\n"
 
-	echo -e "-h \t\tHelp - display this help screen"
-	echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."	
-	echo -e "-u \t\tFusion User Name - the user name to use for Fusion. Default is [$GEFUSIONUSER_NAME]. \n\t\tNote: this is only used for new installations."
-	echo -e "-g \t\tUser Group Name - the group name to use for the Fusion user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
-	echo -e "-ar \t\tAsset Root Mame - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
-	echo -e "-sv \t\tSource Volume Name - the name of the source volume.  Default is [$SOURCE_VOLUME]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
-	echo -e "-nobk \t\tNo Backup - do not backup the current fusion setup. Default is to backup \n\t\tthe setup before installing."
-	echo -e "-nop \t\tNo Purge - do not delete the temporary install directory upon successful run of the installer."
-	echo -e "\t\tDefault is to delete the directory after successful installation."
-	echo -e "-nostart \tDo Not Start Fusion - after install, do not start the Fusion daemon.  Default is to start the daemon."
-	echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
-	echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n" 	
+  echo -e "-h \t\tHelp - display this help screen"
+  echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
+  echo -e "-u \t\tFusion User Name - the user name to use for Fusion. Default is [$GEFUSIONUSER_NAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-g \t\tUser Group Name - the group name to use for the Fusion user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-ar \t\tAsset Root Mame - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
+  echo -e "-sv \t\tSource Volume Name - the name of the source volume.  Default is [$SOURCE_VOLUME]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
+  echo -e "-nobk \t\tNo Backup - do not backup the current fusion setup. Default is to backup \n\t\tthe setup before installing."
+  echo -e "-nop \t\tNo Purge - do not delete the temporary install directory upon successful run of the installer."
+  echo -e "\t\tDefault is to delete the directory after successful installation."
+  echo -e "-nostart \tDo Not Start Fusion - after install, do not start the Fusion daemon.  Default is to start the daemon."
+  echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
+  echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
 }
 
 # TODO convert to common function
 show_need_root()
 {
-	echo -e "\nYou must have root privileges to install $GEES.\n"
-	echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
-	echo -e "The installer must exit."
+  echo -e "\nYou must have root privileges to install $GEES.\n"
+  echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
+  echo -e "The installer must exit."
 }
 
 backup_server()
 {
-	export BACKUP_DIR=$BACKUP_DIR
+  export BACKUP_DIR=$BACKUP_DIR
 
   if [ ! -d $BACKUP_DIR ]; then
     mkdir -p $BACKUP_DIR
@@ -283,147 +283,147 @@ backup_server()
 # TODO update for server
 parse_arguments()
 {
-	local parse_arguments_retval=0
-    local show_user_group_recommendation=false
+  local parse_arguments_retval=0
+  local show_user_group_recommendation=false
 
   # TODO: Remove debug
   echo Num args: $#
 
-	while [ $# -gt 0 ]
-	do
+  while [ $# -gt 0 ]
+  do
     echo Parsing: "${1,,}"
-		case "${1,,}" in
-			-h|-help|--help)
-				show_help
-				parse_arguments_retval=1
-				break
-				;;
-			-nobk)
-				BACKUPFUSION=false				
-				;;
-			-hnf)
-				BADHOSTNAMEOVERRIDE=true;
-				;;			
-			-hnmf)
-				MISMATCHHOSTNAMEOVERRIDE=true
-				;;
-            -nostart)
-                START_FUSION_DAEMON=false
-                ;;
-			-nop)
-				PURGE_TMP_DIR=false
-				;;
-			-dir)
-				shift
-					if [ -d "$1" ]; then
-						TMPINSTALLDIR="$1"
-					else
-						show_no_tmp_dir_message $1
-						parse_arguments_retval=-1
-						break		
-					fi
-					;;
-			-ar)
-				if [ $IS_NEWINSTALL == false ]; then
-					echo -e "\nYou cannot modify the asset root using the installer because Fusion is already installed on this server."
-					parse_arguments_retval=1
-					break
-				else
-					shift
+    case "${1,,}" in
+      -h|-help|--help)
+        show_help
+        parse_arguments_retval=1
+        break
+        ;;
+      -nobk)
+        BACKUPFUSION=false
+        ;;
+      -hnf)
+        BADHOSTNAMEOVERRIDE=true;
+        ;;
+      -hnmf)
+        MISMATCHHOSTNAMEOVERRIDE=true
+        ;;
+      -nostart)
+        START_FUSION_DAEMON=false
+        ;;
+      -nop)
+        PURGE_TMP_DIR=false
+        ;;
+      -dir)
+        shift
+        if [ -d "$1" ]; then
+          TMPINSTALLDIR="$1"
+        else
+          show_no_tmp_dir_message $1
+          parse_arguments_retval=-1
+          break
+        fi
+        ;;
+      -ar)
+        if [ $IS_NEWINSTALL == false ]; then
+          echo -e "\nYou cannot modify the asset root using the installer because Fusion is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          shift
 
-					if is_valid_custom_directory ${1// }; then
-						ASSET_ROOT=${1// }
-					else
-						echo -e "\nThe asset root you specified does not appear to be a syntactically valid directory. Please"
-						echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
-						echo -e "letters, numbers and the underscore characters for the asset root name. The asset root cannot"
-						echo -e "start with a number or underscore."
-						parse_arguments_retval=1
-						break		
-					fi
-				fi
-				;;
-            -sv)
-                
-                if [ $IS_NEWINSTALL == false ]; then
-					echo -e "\nYou cannot modify the source volume using the installer because Fusion is already installed on this server."
-					parse_arguments_retval=1
-					break
-				else
-					shift
+          if is_valid_custom_directory ${1// }; then
+            ASSET_ROOT=${1// }
+          else
+            echo -e "\nThe asset root you specified does not appear to be a syntactically valid directory. Please"
+            echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
+            echo -e "letters, numbers and the underscore characters for the asset root name. The asset root cannot"
+            echo -e "start with a number or underscore."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+        ;;
+      -sv)
 
-					if is_valid_directory ${1// }; then
-						SOURCE_VOLUME=${1// }
-					else
-						echo -e "\nThe source volume you specified does not appear to be a syntactically valid directory. Please"
-						echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
-						echo -e "letters, numbers and the underscore characters for the source volume name. The source volume cannot"
-						echo -e "start with a number or underscore."
-						parse_arguments_retval=1
-						break		
-					fi
-				fi
-                ;;
-			-u)
-                show_user_group_recommendation=true
+        if [ $IS_NEWINSTALL == false ]; then
+          echo -e "\nYou cannot modify the source volume using the installer because Fusion is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          shift
 
-				if [ $IS_NEWINSTALL == false ]; then
-					echo -e "\nYou cannot modify the fusion user name using the installer because Fusion is already installed on this server."
-					parse_arguments_retval=1
-					break
-				else
-					shift
-				
-					if is_valid_alphanumeric ${1// }; then
-						GEFUSIONUSER_NAME=${1// }
-					else
-						echo -e "\nThe fusion user name you specified is not valid. Valid characters are upper/lowercase letters, "
-						echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
-						parse_arguments_retval=1					
-						break
-					fi
-				fi
-				;;
-			-g)
-                show_user_group_recommendation=true
+          if is_valid_directory ${1// }; then
+            SOURCE_VOLUME=${1// }
+          else
+            echo -e "\nThe source volume you specified does not appear to be a syntactically valid directory. Please"
+            echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
+            echo -e "letters, numbers and the underscore characters for the source volume name. The source volume cannot"
+            echo -e "start with a number or underscore."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+        ;;
+      -u)
+        show_user_group_recommendation=true
 
-				if [ $IS_NEWINSTALL == false ]; then
-					echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
-					parse_arguments_retval=1
-					break
-				else
-					shift
-				
-					if is_valid_alphanumeric ${1// }; then
-						GROUPNAME=${1// }
-					else
-						echo -e "\nThe fusion group name you specified is not valid. Valid characters are upper/lowercase letters, "
-						echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
-						parse_arguments_retval=1
-						break			
-					fi
-				fi
-				;;
-			*)
-				echo -e "\nArgument Error: $1 is not a valid argument."
-				show_help
-				parse_arguments_retval=1
-				break
-				;;
-		esac
-	
-		if [ $# -gt 0 ]
-		then
-		    shift
-		fi
-	done	
-	
-	return $parse_arguments_retval;
+        if [ $IS_NEWINSTALL == false ]; then
+          echo -e "\nYou cannot modify the fusion user name using the installer because Fusion is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          shift
+
+          if is_valid_alphanumeric ${1// }; then
+            GEFUSIONUSER_NAME=${1// }
+          else
+            echo -e "\nThe fusion user name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+        ;;
+      -g)
+        show_user_group_recommendation=true
+
+        if [ $IS_NEWINSTALL == false ]; then
+          echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          shift
+
+          if is_valid_alphanumeric ${1// }; then
+            GROUPNAME=${1// }
+          else
+            echo -e "\nThe fusion group name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+        ;;
+      *)
+        echo -e "\nArgument Error: $1 is not a valid argument."
+        show_help
+        parse_arguments_retval=1
+        break
+        ;;
+    esac
+
+    if [ $# -gt 0 ]
+    then
+      shift
+    fi
+  done
+
+  return $parse_arguments_retval;
 }
 
 check_server_processes_running()
 {
-	local retval=0
+  local retval=0
 
   # i) Check postgres is running .Store o/p in post_master_running
   local post_master_running=$( ps -ef | grep asd | grep -v grep )
@@ -433,26 +433,26 @@ check_server_processes_running()
   local gehttpd_running=$( ps -ef | grep gehttpd | grep -v grep )
   gehttpd_running_str="false"
 
-	if [ -n "$post_master_running" ]; then 
+  if [ -n "$post_master_running" ]; then
     retval = $((retval + 1))
     post_master_running_str="true"
   fi
   echo "postgres service: $post_master_running_str"
 
   if [ -n "$gehttpd_running" ]; then
-		retval = $((retval + 1))
+    retval = $((retval + 1))
     gehttpd_running_str = "true"
-	fi
+  fi
   echo "gehttpd service: $gehttpd_running_str"
   echo "$retval"
 
-	return $retval
+  return $retval
 }
 
 show_server_running_message()
 {
-	echo -e "\n$GEES has active running processes."
-	echo -e "To use this installer to upgrade, you must stop all geserver services.\n"	
+  echo -e "\n$GEES has active running processes."
+  echo -e "To use this installer to upgrade, you must stop all geserver services.\n"
 }
 
 configure_publish_root()
@@ -469,17 +469,17 @@ configure_publish_root()
 #-----------------------------------------------------------------
 copy_files_to_target()
 {
-	printf "\nCopying files from source to target directories..."
+  printf "\nCopying files from source to target directories..."
 
-	kdir -p $BASEINSTALLDIR_OPT/share/doc
-	mkdir -p $BASEINSTALLDIR_OPT/gehttpd/conf
+  kdir -p $BASEINSTALLDIR_OPT/share/doc
+  mkdir -p $BASEINSTALLDIR_OPT/gehttpd/conf
   mkdir -p $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images
   mkdir -p $BASEINSTALLDIR_OPT/search
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/private
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/misc
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/certs
-	mkdir -p $BASEINSTALLDIR_ETC/openldap
-	mkdir -p $BASEINSTALLDIR_VAR/pgsql
+  mkdir -p $BASEINSTALLDIR_VAR/openssl/private
+  mkdir -p $BASEINSTALLDIR_VAR/openssl/misc
+  mkdir -p $BASEINSTALLDIR_VAR/openssl/certs
+  mkdir -p $BASEINSTALLDIR_ETC/openldap
+  mkdir -p $BASEINSTALLDIR_VAR/pgsql
 
   cp -rf $TMPINSTALLDIR/common/opt/google/bin $BASEINSTALLDIR_OPT
   cp -rf $TMPINSTALLDIR/common/opt/google/share $BASEINSTALLDIR_OPT
@@ -499,35 +499,35 @@ copy_files_to_target()
   cp -rf $TMPINSTALLDIR/server/etc/init.d/geserver $BININSTALLROOTDIR
   cp -rf $TMPINSTALLDIR/server/etc/profile.d/ge-server.sh $BININSTALLPROFILEDIR
   cp -rf $TMPINSTALLDIR/server/etc/profile.d/ge-server.csh $BININSTALLPROFILEDIR
-  
+
   cp -rf $TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd $BASEINSTALLLOGROTATEDIR
   cp -rf $TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/ $BASEINSTALLDIR_VAR/pgsql
   cp -rf $TMPINSTALLDIR/manual/opt/google/share/doc/manual $BASEINSTALLDIR_OPT/share/doc
   cp -rf $TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf $BASEINSTALLDIR_OPT/gehttpd/conf
   cp -rf $TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images
 
-	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+  TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
 
-	cp -f $TMPOPENSSLPATH/openssl.cnf $BASEINSTALLDIR_VAR/openssl
-	cp -rf $TMPOPENSSLPATH/private $BASEINSTALLDIR_VAR/openssl
-	cp -f $TMPOPENSSLPATH/misc/CA.sh $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/tsget $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/c_name $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/CA.pl $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/c_issuer $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/c_info $BASEINSTALLDIR_VAR/openssl/misc
-	cp -f $TMPOPENSSLPATH/misc/c_hash $BASEINSTALLDIR_VAR/openssl/misc
-	cp -rf $TMPOPENSSLPATH/certs $BASEINSTALLDIR_VAR/openssl
+  cp -f $TMPOPENSSLPATH/openssl.cnf $BASEINSTALLDIR_VAR/openssl
+  cp -rf $TMPOPENSSLPATH/private $BASEINSTALLDIR_VAR/openssl
+  cp -f $TMPOPENSSLPATH/misc/CA.sh $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/tsget $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/c_name $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/CA.pl $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/c_issuer $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/c_info $BASEINSTALLDIR_VAR/openssl/misc
+  cp -f $TMPOPENSSLPATH/misc/c_hash $BASEINSTALLDIR_VAR/openssl/misc
+  cp -rf $TMPOPENSSLPATH/certs $BASEINSTALLDIR_VAR/openssl
 
-	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
+  TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
 
-	cp -f $TMPOPENLDAPPATH/ldap.conf $BASEINSTALLDIR_ETC/openldap
-	cp -f $TMPOPENLDAPPATH/ldap.conf.default $BASEINSTALLDIR_ETC/openldap
+  cp -f $TMPOPENLDAPPATH/ldap.conf $BASEINSTALLDIR_ETC/openldap
+  cp -f $TMPOPENLDAPPATH/ldap.conf.default $BASEINSTALLDIR_ETC/openldap
 
-	# TODO: final step: copy uninstall script
-	# cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
+  # TODO: final step: copy uninstall script
+  # cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
 
-	printf "DONE\n"
+  printf "DONE\n"
 }
 
 #-----------------------------------------------------------------
@@ -548,7 +548,7 @@ reset_pgdb()
   # a) Always do an upgrade of the psql db
   echo 2 | run_as_user $GEPGUSER_NAME "/opt/google/bin/geresetpgdb upgrade"
   echo -e "upgrade done"
-  
+
   # b) Check for Success of PostGresDb
   #  If file ‘/var/opt/google/pgsql/data’ doesn’t exist:
 
@@ -560,9 +560,9 @@ reset_pgdb()
   else
     # postgress reset/install failed.
     echo -e "Failed to create PostGresDb."
-    echo -e "The PostgreSQL component of the installation failed 
+    echo -e "The PostgreSQL component of the installation failed
          to install."
-  fi 
+  fi
 }
 
 # 4) Creating Daemon thread for geserver
@@ -576,7 +576,7 @@ setup_geserver_daemon()
    test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE geserver start 90 2 3 4 5 . stop 10 0 1 6 .
    printf "GEE Server daemon setup ... DONE\n"
 }
-  
+
 # 6) Install the GEPlaces and SearchExample Databases
 install_search_databases()
 {
@@ -678,7 +678,7 @@ fix_postinstall_filepermissions()
   # Tutorial and Share
   find /opt/google/share -type d -exec chmod 755 {} \;
   find /opt/google/share -type f -exec chmod 644 {} \;
-  chmod ugo+x /opt/google/share/searchexample/searchexample 
+  chmod ugo+x /opt/google/share/searchexample/searchexample
   chmod ugo+x /opt/google/share/geplaces/geplaces
   chmod ugo+x /opt/google/share/support/geecheck/geecheck.pl
   chmod ugo+x /opt/google/share/support/geecheck/convert_to_kml.pl
@@ -735,17 +735,17 @@ show_final_success_message(){
           /opt/google \n
           Start Google Earth Enterprise Server with the following command:
           $BININSTALLROOTDIR/geserver start"
-  
+
 }
 
 check_server_running()
 {
   # Check that server is setup properly
-  
+
   if ! check_server_processes_running; then
-    echo -e "$GEES service is not running properly. Check the logs in 
-             /opt/google/gehttpd/logs \n 
-             /var/opt/google/pgsql/logs \n 
+    echo -e "$GEES service is not running properly. Check the logs in
+             /opt/google/gehttpd/logs \n
+             /var/opt/google/pgsql/logs \n
              for more details. "
   fi
 }

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -138,7 +138,7 @@ main_preinstall()
   fi
 
   # 6) Check valid host properties
-   if ! check_bad_hostname; then
+  if ! check_bad_hostname; then
     exit 1
   fi
 
@@ -234,22 +234,13 @@ show_intro()
   echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
 }
 
-# TODO: Update for GEE Server
+# TODO: Add additional parameters for GEE Server
 show_help()
 {
-  echo -e "\nUsage: \tsudo ./install_server.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
-  echo -e "\t\t-g gegroup -nobk -nop -hnf -nostart]\n"
+  echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf]\n"
 
-  echo -e "-h \t\tHelp - display this help screen"
+  echo -e "-h --help \tHelp - display this help screen"
   echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
-  echo -e "-u \t\tFusion User Name - the user name to use for Fusion. Default is [$GEFUSIONUSER_NAME]. \n\t\tNote: this is only used for new installations."
-  echo -e "-g \t\tUser Group Name - the group name to use for the Fusion user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
-  echo -e "-ar \t\tAsset Root Name - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
-  echo -e "-sv \t\tSource Volume Name - the name of the source volume.  Default is [$SOURCE_VOLUME]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
-  echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tthe setup before installing."
-  echo -e "-nop \t\tNo Purge - do not delete the temporary install directory upon successful run of the installer."
-  echo -e "\t\tDefault is to delete the directory after successful installation."
-  echo -e "-nostart \tDo Not Start Server - after install, do not start the server daemon.  Default is to start the daemon."
   echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
   echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
 }
@@ -283,7 +274,7 @@ backup_server()
   chown -R root:root $BACKUP_DIR
 }
 
-# TODO update for server
+# TODO Add additional parameters for server
 parse_arguments()
 {
   local parse_arguments_retval=0
@@ -297,20 +288,11 @@ parse_arguments()
         parse_arguments_retval=1
         break
         ;;
-      -nobk)
-        BACKUPFUSION=false
-        ;;
       -hnf)
         BADHOSTNAMEOVERRIDE=true;
         ;;
       -hnmf)
         MISMATCHHOSTNAMEOVERRIDE=true
-        ;;
-      -nostart)
-        START_FUSION_DAEMON=false
-        ;;
-      -nop)
-        PURGE_TMP_DIR=false
         ;;
       -dir)
         shift
@@ -320,87 +302,6 @@ parse_arguments()
           show_no_tmp_dir_message $1
           parse_arguments_retval=-1
           break
-        fi
-        ;;
-      -ar)
-        if [ $IS_NEWINSTALL == false ]; then
-          echo -e "\nYou cannot modify the asset root using the installer because Fusion is already installed on this server."
-          parse_arguments_retval=1
-          break
-        else
-          shift
-
-          if is_valid_custom_directory ${1// }; then
-            ASSET_ROOT=${1// }
-          else
-            echo -e "\nThe asset root you specified does not appear to be a syntactically valid directory. Please"
-            echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
-            echo -e "letters, numbers and the underscore characters for the asset root name. The asset root cannot"
-            echo -e "start with a number or underscore."
-            parse_arguments_retval=1
-            break
-          fi
-        fi
-        ;;
-      -sv)
-
-        if [ $IS_NEWINSTALL == false ]; then
-          echo -e "\nYou cannot modify the source volume using the installer because Fusion is already installed on this server."
-          parse_arguments_retval=1
-          break
-        else
-          shift
-
-          if is_valid_directory ${1// }; then
-            SOURCE_VOLUME=${1// }
-          else
-            echo -e "\nThe source volume you specified does not appear to be a syntactically valid directory. Please"
-            echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
-            echo -e "letters, numbers and the underscore characters for the source volume name. The source volume cannot"
-            echo -e "start with a number or underscore."
-            parse_arguments_retval=1
-            break
-          fi
-        fi
-        ;;
-      -u)
-        show_user_group_recommendation=true
-
-        if [ $IS_NEWINSTALL == false ]; then
-          echo -e "\nYou cannot modify the fusion user name using the installer because Fusion is already installed on this server."
-          parse_arguments_retval=1
-          break
-        else
-          shift
-
-          if is_valid_alphanumeric ${1// }; then
-            GEFUSIONUSER_NAME=${1// }
-          else
-            echo -e "\nThe fusion user name you specified is not valid. Valid characters are upper/lowercase letters, "
-            echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
-            parse_arguments_retval=1
-            break
-          fi
-        fi
-        ;;
-      -g)
-        show_user_group_recommendation=true
-
-        if [ $IS_NEWINSTALL == false ]; then
-          echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
-          parse_arguments_retval=1
-          break
-        else
-          shift
-
-          if is_valid_alphanumeric ${1// }; then
-            GROUPNAME=${1// }
-          else
-            echo -e "\nThe fusion group name you specified is not valid. Valid characters are upper/lowercase letters, "
-            echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
-            parse_arguments_retval=1
-            break
-          fi
         fi
         ;;
       *)

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -18,7 +18,10 @@
 
 set +x
 
-. common.sh
+# get script directory
+SCRIPTDIR=`dirname $0`
+
+. $SCRIPTDIR/common.sh
 
 # config values
 PUBLISHER_ROOT="/gevol/published_dbs"

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -38,7 +38,6 @@ TMPINSTALLDIR="/tmp/fusion_os_install"
 KH_SYSTEMRC="/usr/keyhole/etc/systemrc"
 INITSCRIPTUPDATE="/usr/sbin/update-rc.d"
 CHKCONFIG="/sbin/chkconfig"
-OS_RELEASE="/etc/os-release"
 
 # script arguments
 BACKUPSERVER=true
@@ -203,7 +202,7 @@ main_postinstall()
   test -f $CHKCONFIG && $CHKCONFIG --add geserver
 
   # 6) Register publish root
-  $BASEINSTALLDIR_OPT/bin/geconfigurepublishroot --noprompt --path=$PUBLISHER_ROOT$
+  $BASEINSTALLDIR_OPT/bin/geconfigurepublishroot --noprompt --path=$PUBLISHER_ROOT
 
   # 7) Install the GEPlaces and SearchExample Databases
   install_search_databases
@@ -456,15 +455,12 @@ show_server_running_message()
 	echo -e "To use this installer to upgrade, you must stop all geserver services.\n"	
 }
 
-# TODO update for proper operation See 
 configure_publish_root()
 {
+  # Update PUBLISHER_ROOT if geserver already installed
   local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
-  echo $STREAM_SPACE
   if [ -e $STREAM_SPACE ]; then
-    echo "Found stream_space!"
-  else 
-    echo "Couldn't find stream_space!"
+    PUBLISHER_ROOT=`cat $STREAM_SPACE |cut -d" " -f3 |sed 's/.\{13\}$//'`
   fi
 }
 

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -18,19 +18,19 @@
 
 set +x
 
-# script arguments
+. common.sh
 
 # config values
-PUBLISHER_ROOT="/usr/local/google/gevol/publish_dbs"
-#SOURCE_VOLUME="/usr/local/google/gevol/src"
-DEFAULTGEFUSIONUSER_NAME="gefusionuser"
+PUBLISHER_ROOT="/gevol/published_dbs"
 DEFAULTGROUPNAME="gegroup"
-GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
 GROUPNAME=$DEFAULTGROUPNAME
+DEFAULTGEFUSIONUSER_NAME="gefusionuser"
+GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
 
 # directory locations
 BININSTALLROOTDIR="/etc/init.d"
 BININSTALLPROFILEDIR="/etc/profile.d"
+BASEINSTALLLOGROTATEDIR="/etc/logrotate.d"
 BASEINSTALLDIR_OPT="/opt/google"
 BASEINSTALLDIR_ETC="/etc/opt/google"
 BASEINSTALLDIR_VAR="/var/opt/google"
@@ -40,19 +40,28 @@ INITSCRIPTUPDATE="/usr/sbin/update-rc.d"
 CHKCONFIG="/sbin/chkconfig"
 OS_RELEASE="/etc/os-release"
 
+# script arguments
+BACKUPSERVER=true
+BADHOSTNAMEOVERRIDE=false
+MISMATCHHOSTNAMEOVERRIDE=false
+
 # derived directories
 BASEINSTALLGDALSHAREDIR="$BASEINSTALLDIR_OPT/share/gdal"
 PATH_TO_LOGS="$BASEINSTALLDIR_VAR/log"
 SYSTEMRC="$BASEINSTALLDIR_ETC/systemrc"
+BACKUP_DIR="$BASEINSTALLDIR_VAR/server-backups/$(date +%Y_%m_%d.%H%M%S)"
 OLD_SYSTEMRC=$SYSTEMRC
 SOURCECODEDIR=$(dirname $(dirname $(readlink -f "$0")))
 TOPSOURCEDIR_EE=$(dirname $SOURCECODEDIR)
-GESERVERBININSTALL="$BININSTALLROOTDIR/gesever"
+GESERVERBININSTALL="$BININSTALLROOTDIR/geserver"
 INSTALL_LOG_DIR="$BASEINSTALLDIR_OPT/install"
 INSTALL_LOG="$INSTALL_LOG_DIR/geserver_install_$(date +%Y_%m_%d.%H%M%S).log"
+GEHTTPD="$BASEINSTALLDIR_OPT/gehttpd"
+GEHTTPD_CONF="$GEHTTPD/conf.d"
 
 # versions and user names
 GEES="Google Earth Enterprise Server"
+SOFTWARE_NAME="$GEES"
 SHORT_VERSION="5.1"
 LONG_VERSION="5.1.3"
 GRPNAME="gegroup"
@@ -74,6 +83,107 @@ PROMPT_FOR_START="n"
 #-----------------------------------------------------------------
 # Main Functions
 #-----------------------------------------------------------------
+main_preinstall()
+{
+  # 3) Introduction
+  show_intro
+
+	# 2) Root/Sudo check
+	if [ "$EUID" != "0" ]; then 
+		show_need_root
+		exit 1
+	fi
+
+  # 5a) Check previous installation
+  if [ -f "$SERVERBININSTALL" ]; then
+		IS_NEWINSTALL=false
+	else
+		IS_NEWINSTALL=true
+	fi
+
+  # Argument check
+	if ! parse_arguments "$@"; then		
+		exit 1
+	fi
+
+	if ! determine_os; then
+    exit 1
+  fi
+  
+  # 7) Check prerequisite software
+  if ! check_prereq_software; then
+		exit 1
+	fi
+
+  # check to see if GE Server processes are running
+  services_running = check_server_processes_running
+  
+	if [ $services_running -ne 0 ]; then
+		show_server_running_message
+		exit 1
+	fi
+
+  # tmp dir check
+	if [ ! -d "$TMPINSTALLDIR" ]; then
+		show_no_tmp_dir_message $TMPINSTALLDIR
+		exit 1
+	fi
+
+  # 5b) Perform backup
+  if [ $BACKUPSERVER == true ]; then
+		# Backing up current Server Install...
+		backup_server
+	fi
+
+  # 6) Check valid host properties
+ 	if ! check_bad_hostname; then
+		exit 1
+	fi
+
+  if ! check_mismatched_hostname; then
+		exit 1
+	fi
+
+  # 64 bit check
+	if [[ "$(uname -i)" == "x86_64" ]]; then 
+        IS_64BIT_OS=true 
+	else
+		echo -e "\n$GEEF $LONG_VERSION can only be installed on a 64 bit operating system."
+		exit 1
+  fi
+
+  # 8) Check if group and users exist
+  check_group
+
+  check_username $GEAPACHEUSER_NAME
+  check_username $GEPGUSER_NAME
+
+  # 10) Configure Publish Root
+  configure_publish_root
+}
+
+check_prereq_software()
+{
+	local check_prereq_software_retval=0
+
+	if ! software_check "libxml2-utils" "libxml2.*x86_64"; then
+		check_prereq_software_retval=1
+	fi
+
+	if ! software_check "python2.7" "python-2.7.*"; then
+		check_prereq_software_retval=1
+	fi
+
+
+	return $check_prereq_software_retval
+}
+
+main_install()
+{
+	copy_files_to_target
+	create_links
+}
+
 main_postinstall()
 {
   # 1) Modify files
@@ -109,9 +219,324 @@ main_postinstall()
      python ./set_geecheck_config.py
   fi
 
-  # 10)
+  # 10) 
   show_final_success_message
 }
+
+#-----------------------------------------------------------------
+# Pre-install Functions
+#-----------------------------------------------------------------
+
+show_intro()
+{	
+	echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
+}
+
+# TODO: Update for GEE Server
+show_help()
+{
+	echo -e "\nUsage: \tsudo ./install_fusion.sh [-dir /tmp/fusion_os_install -ar /gevol/assets -sv /gevol/src -u fusionuser"
+	echo -e "\t\t-g gegroup -nobk -nop -hnf -nostart]\n"
+
+	echo -e "-h \t\tHelp - display this help screen"
+	echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."	
+	echo -e "-u \t\tFusion User Name - the user name to use for Fusion. Default is [$GEFUSIONUSER_NAME]. \n\t\tNote: this is only used for new installations."
+	echo -e "-g \t\tUser Group Name - the group name to use for the Fusion user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
+	echo -e "-ar \t\tAsset Root Mame - the name of the asset root volume.  Default is [$ASSET_ROOT]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
+	echo -e "-sv \t\tSource Volume Name - the name of the source volume.  Default is [$SOURCE_VOLUME]. \n\t\tNote: this is only used for new installations. Specify absolute paths only."
+	echo -e "-nobk \t\tNo Backup - do not backup the current fusion setup. Default is to backup \n\t\tthe setup before installing."
+	echo -e "-nop \t\tNo Purge - do not delete the temporary install directory upon successful run of the installer."
+	echo -e "\t\tDefault is to delete the directory after successful installation."
+	echo -e "-nostart \tDo Not Start Fusion - after install, do not start the Fusion daemon.  Default is to start the daemon."
+	echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
+	echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n" 	
+}
+
+# TODO convert to common function
+show_need_root()
+{
+	echo -e "\nYou must have root privileges to install $GEES.\n"
+	echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
+	echo -e "The installer must exit."
+}
+
+backup_server()
+{
+	export BACKUP_DIR=$BACKUP_DIR
+
+  if [ ! -d $BACKUP_DIR ]; then
+    mkdir -p $BACKUP_DIR
+  fi
+
+  # Copy gehttpd directory.
+  # Do not back up folder /opt/google/gehttpd/htdocs/cutter/globes.
+  # Do not back up folders /opt/google/gehttpd/{bin, lib, manual, modules}
+  rsync -rltpu $INSTALL_DIR/gehttpd $BACKUP_DIR --exclude bin --exclude lib --exclude manual --exclude modules --exclude htdocs/cutter/globes
+
+  # Copy other files.
+  cp -f /etc/init.d/gevars.sh $BACKUP_DIR
+  cp -rf /etc/opt/google/openldap $BACKUP_DIR
+
+  # Change the ownership of the backup folder.
+  chown -R root:root $BACKUP_DIR
+}
+
+# TODO update for server
+parse_arguments()
+{
+	local parse_arguments_retval=0
+    local show_user_group_recommendation=false
+
+  # TODO: Remove debug
+  echo Num args: $#
+
+	while [ $# -gt 0 ]
+	do
+    echo Parsing: "${1,,}"
+		case "${1,,}" in
+			-h|-help|--help)
+				show_help
+				parse_arguments_retval=1
+				break
+				;;
+			-nobk)
+				BACKUPFUSION=false				
+				;;
+			-hnf)
+				BADHOSTNAMEOVERRIDE=true;
+				;;			
+			-hnmf)
+				MISMATCHHOSTNAMEOVERRIDE=true
+				;;
+            -nostart)
+                START_FUSION_DAEMON=false
+                ;;
+			-nop)
+				PURGE_TMP_DIR=false
+				;;
+			-dir)
+				shift
+					if [ -d "$1" ]; then
+						TMPINSTALLDIR="$1"
+					else
+						show_no_tmp_dir_message $1
+						parse_arguments_retval=-1
+						break		
+					fi
+					;;
+			-ar)
+				if [ $IS_NEWINSTALL == false ]; then
+					echo -e "\nYou cannot modify the asset root using the installer because Fusion is already installed on this server."
+					parse_arguments_retval=1
+					break
+				else
+					shift
+
+					if is_valid_custom_directory ${1// }; then
+						ASSET_ROOT=${1// }
+					else
+						echo -e "\nThe asset root you specified does not appear to be a syntactically valid directory. Please"
+						echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
+						echo -e "letters, numbers and the underscore characters for the asset root name. The asset root cannot"
+						echo -e "start with a number or underscore."
+						parse_arguments_retval=1
+						break		
+					fi
+				fi
+				;;
+            -sv)
+                
+                if [ $IS_NEWINSTALL == false ]; then
+					echo -e "\nYou cannot modify the source volume using the installer because Fusion is already installed on this server."
+					parse_arguments_retval=1
+					break
+				else
+					shift
+
+					if is_valid_directory ${1// }; then
+						SOURCE_VOLUME=${1// }
+					else
+						echo -e "\nThe source volume you specified does not appear to be a syntactically valid directory. Please"
+						echo -e "specify the absolute path of a valid directory location. Valid characters are upper/lowercase"
+						echo -e "letters, numbers and the underscore characters for the source volume name. The source volume cannot"
+						echo -e "start with a number or underscore."
+						parse_arguments_retval=1
+						break		
+					fi
+				fi
+                ;;
+			-u)
+                show_user_group_recommendation=true
+
+				if [ $IS_NEWINSTALL == false ]; then
+					echo -e "\nYou cannot modify the fusion user name using the installer because Fusion is already installed on this server."
+					parse_arguments_retval=1
+					break
+				else
+					shift
+				
+					if is_valid_alphanumeric ${1// }; then
+						GEFUSIONUSER_NAME=${1// }
+					else
+						echo -e "\nThe fusion user name you specified is not valid. Valid characters are upper/lowercase letters, "
+						echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
+						parse_arguments_retval=1					
+						break
+					fi
+				fi
+				;;
+			-g)
+                show_user_group_recommendation=true
+
+				if [ $IS_NEWINSTALL == false ]; then
+					echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
+					parse_arguments_retval=1
+					break
+				else
+					shift
+				
+					if is_valid_alphanumeric ${1// }; then
+						GROUPNAME=${1// }
+					else
+						echo -e "\nThe fusion group name you specified is not valid. Valid characters are upper/lowercase letters, "
+						echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
+						parse_arguments_retval=1
+						break			
+					fi
+				fi
+				;;
+			*)
+				echo -e "\nArgument Error: $1 is not a valid argument."
+				show_help
+				parse_arguments_retval=1
+				break
+				;;
+		esac
+	
+		if [ $# -gt 0 ]
+		then
+		    shift
+		fi
+	done	
+	
+	return $parse_arguments_retval;
+}
+
+check_server_processes_running()
+{
+	local retval=0
+
+  # i) Check postgres is running .Store o/p in post_master_running
+  local post_master_running=$( ps -ef | grep asd | grep -v grep )
+  post_master_running_str="false"
+
+  # ii) Check gehttpd is running  .Store the o/p in gehttpd_running
+  local gehttpd_running=$( ps -ef | grep gehttpd | grep -v grep )
+  gehttpd_running_str="false"
+
+	if [ -n "$post_master_running" ]; then 
+    retval = $((retval + 1))
+    post_master_running_str="true"
+  fi
+  echo "postgres service: $post_master_running_str"
+
+  if [ -n "$gehttpd_running" ]; then
+		retval = $((retval + 1))
+    gehttpd_running_str = "true"
+	fi
+  echo "gehttpd service: $gehttpd_running_str"
+  echo "$retval"
+
+	return $retval
+}
+
+show_server_running_message()
+{
+	echo -e "\n$GEES has active running processes."
+	echo -e "To use this installer to upgrade, you must stop all geserver services.\n"	
+}
+
+# TODO update for proper operation See 
+configure_publish_root()
+{
+  local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
+  echo $STREAM_SPACE
+  if [ -e $STREAM_SPACE ]; then
+    echo "Found stream_space!"
+  else 
+    echo "Couldn't find stream_space!"
+  fi
+}
+
+#-----------------------------------------------------------------
+# Install Functions
+#-----------------------------------------------------------------
+copy_files_to_target()
+{
+	printf "\nCopying files from source to target directories..."
+
+	kdir -p $BASEINSTALLDIR_OPT/share/doc
+	mkdir -p $BASEINSTALLDIR_OPT/gehttpd/conf
+  mkdir -p $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images
+  mkdir -p $BASEINSTALLDIR_OPT/search
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/private
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/misc
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/certs
+	mkdir -p $BASEINSTALLDIR_ETC/openldap
+	mkdir -p $BASEINSTALLDIR_VAR/pgsql
+
+  cp -rf $TMPINSTALLDIR/common/opt/google/bin $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/common/opt/google/share $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/common/opt/google/qt $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/common/opt/google/qt/lib $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/common/opt/google/lib $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/common/opt/google/gepython $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/opt/google/share $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/opt/google/bin $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/opt/google/lib $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/opt/google/gehttpd $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/opt/google/search $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/searchexample/opt/google/share $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/geplaces/opt/google/share $BASEINSTALLDIR_OPT
+  cp -rf $TMPINSTALLDIR/server/AppacheSupport/opt/google/gehttpd $BASEINSTALLDIR_OPT
+
+  cp -rf $TMPINSTALLDIR/server/etc/init.d/geserver $BININSTALLROOTDIR
+  cp -rf $TMPINSTALLDIR/server/etc/profile.d/ge-server.sh $BININSTALLPROFILEDIR
+  cp -rf $TMPINSTALLDIR/server/etc/profile.d/ge-server.csh $BININSTALLPROFILEDIR
+  
+  cp -rf $TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd $BASEINSTALLLOGROTATEDIR
+  cp -rf $TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/ $BASEINSTALLDIR_VAR/pgsql
+  cp -rf $TMPINSTALLDIR/manual/opt/google/share/doc/manual $BASEINSTALLDIR_OPT/share/doc
+  cp -rf $TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf $BASEINSTALLDIR_OPT/gehttpd/conf
+  cp -rf $TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images
+
+	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+
+	cp -f $TMPOPENSSLPATH/openssl.cnf $BASEINSTALLDIR_VAR/openssl
+	cp -rf $TMPOPENSSLPATH/private $BASEINSTALLDIR_VAR/openssl
+	cp -f $TMPOPENSSLPATH/misc/CA.sh $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/tsget $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/c_name $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/CA.pl $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/c_issuer $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/c_info $BASEINSTALLDIR_VAR/openssl/misc
+	cp -f $TMPOPENSSLPATH/misc/c_hash $BASEINSTALLDIR_VAR/openssl/misc
+	cp -rf $TMPOPENSSLPATH/certs $BASEINSTALLDIR_VAR/openssl
+
+	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
+
+	cp -f $TMPOPENLDAPPATH/ldap.conf $BASEINSTALLDIR_ETC/openldap
+	cp -f $TMPOPENLDAPPATH/ldap.conf.default $BASEINSTALLDIR_ETC/openldap
+
+	# TODO: final step: copy uninstall script
+	# cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
+
+	printf "DONE\n"
+}
+
+#-----------------------------------------------------------------
+# Post-install Functions
+#-----------------------------------------------------------------
 
 postgres_db_config()
 {
@@ -119,15 +544,6 @@ postgres_db_config()
   chmod -R 700 /var/opt/google/pgsql/
   chown -R $GEPGUSER_NAME:$GRPNAME /var/opt/google/pgsql/
   reset_pgdb
-}
-
-run_as_user() {
- use_su="su $1 -c 'echo -n 1' 2> /dev/null  || echo -n 0"
- if [ "$use_su" -eq 1 ] ; then
-    ( cd / ;su $1 -c "$2" )
- else
-    ( cd / ;sudo -u $1 $2 )
- fi
 }
 
 reset_pgdb()
@@ -159,10 +575,10 @@ setup_geserver_daemon()
   # setup geserver daemon
   # For Ubuntu
    echo "Setting up the geserver daemon...\n"
-   test -f $CHKCONFIG && $CHKCONFIG --add gefusion
-   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE -f gefusion remove
-   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE gefusion start 90 2 3 4 5 . stop 10 0 1 6 .
-   printf "Fusion daemon setup ... DONE\n"
+   test -f $CHKCONFIG && $CHKCONFIG --add geserver
+   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE -f geserver remove
+   test -f $INITSCRIPTUPDATE && $INITSCRIPTUPDATE geserver start 90 2 3 4 5 . stop 10 0 1 6 .
+   printf "GEE Server daemon setup ... DONE\n"
 }
   
 # 6) Install the GEPlaces and SearchExample Databases
@@ -192,22 +608,20 @@ modify_files()
   # if there are non-OSS installs in the system, it might help cleanup those.
 
   # a) Search and replace the below variables in /etc/init.d/geserver.
-  sed -i 's/IA_GEAPACHE_USER/GEAPACHEUSER_NAME/' $BININSTALLROOTDIR/geserver
-  sed -i 's/IA_GEPGUSER/GEPGUSER_NAME/' $BININSTALLROOTDIR/geserver
+  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" $BININSTALLROOTDIR/geserver
+  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" $BININSTALLROOTDIR/geserver
 
   # b) Search and replace the file ‘/opt/google/gehttpd/conf/gehttpd.conf’
-  sed -i 's/IA_GEAPACHE_USER/GEAPACHEUSER_NAME/' /opt/google/gehttpd/conf/gehttpd.conf
-  sed -i 's/IA_GEPGUSER/GEPGUSER_NAME/' /opt/google/gehttpd/conf/gehttpd.conf
+  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+  sed -i "s/IA_GEGROUP/$GRPNAME/" /opt/google/gehttpd/conf/gehttpd.conf
 
   # c) Create a new file ‘/etc/opt/google/fusion_Server_version’ and
   # add the below text to it.
   echo $LONG_VERSION > /etc/opt/google/fusion_Server_version
 
   # d) Create a new file ‘/etc/init.d/gevars.sh’ and prepend the below lines.
-  echo -e 'GEAPACHEUSER=GEAPACHEUSER_NAME \n 
-        GEPGUSER=GEPGUSER_NAME \n
-        GEFUSIONUSER=GEFUSIONUSER_NAME \n
-        GEGROUP=GRPNAME' > $BININSTALLROOTDIR/gevars.sh
+  echo -e "GEAPACHEUSER=$GEAPACHEUSER_NAME\nGEPGUSER=$GEPGUSER_NAME\nGEFUSIONUSER=$GEFUSIONUSER_NAME\nGEGROUP=$GRPNAME" > $BININSTALLROOTDIR/gevars.sh
 }
 
 fix_postinstall_filepermissions()
@@ -224,6 +638,7 @@ fix_postinstall_filepermissions()
   chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/
   chmod -R 700 $BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/
   chown $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess
+  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/logs
 
   # Publish Root
   chmod 775 $PUBLISHER_ROOT/stream_space
@@ -330,11 +745,8 @@ show_final_success_message(){
 check_server_running()
 {
   # Check that server is setup properly
-  # i) Check postgres is running .Store o/p in CHECK_POST_MASTER
-  CHECK_POST_MASTER=$( ps -e | grep postgres)
-  # ii) Check gehttpd is running  .Store the o/p in CHECK_GEHTTPD
-  CHECK_GEHTTPD=$( ps -e| grep gehttpd )
-  if [ -z "$CHECK_POST_MASTER" ] || [ -z "$CHECK_GEHTTPD" ]; then
+  
+  if ! check_server_processes_running; then
     echo -e "$GEES service is not running properly. Check the logs in 
              /opt/google/gehttpd/logs \n 
              /var/opt/google/pgsql/logs \n 
@@ -343,9 +755,19 @@ check_server_running()
 }
 
 #-----------------------------------------------------------------
-# Post-Install Main
+# Pre-Install Main
 #-----------------------------------------------------------------
 mkdir -p $INSTALL_LOG_DIR
 exec 2> $INSTALL_LOG
 
+main_preinstall "$@"
+
+#-----------------------------------------------------------------
+# Install Main
+#-----------------------------------------------------------------
+main_install
+
+#-----------------------------------------------------------------
+# Post-Install Main
+#-----------------------------------------------------------------
 main_postinstall


### PR DESCRIPTION
Fixes https://github.com/google/earthenterprise/issues/47

This is the initial cut of the GE Server installer. There are a few things missing:

1. PUBLISH_ROOT_VOLUME size checking
1. ASSET_ROOT and PUBLISH_ROOT volume checking
1. Script parameter parsing and updated help

I figured I would go ahead and push this up so everyone can start testing with the defaults. The above two checks are also fairly complex and really don't add much value at this stage. I'd rather for users and developers to go ahead and have a basic installer. 

This also modifies install_fusion.sh to move several of the functions to a common.sh script so that both install_server.sh and install_fusion.sh can use them. So, we also need to run some regression testing on install_fusion.sh.