### PR TITLE
I139: Add 'Supported images' Default File Filter to Fusion UI

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
+++ b/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
@@ -163,6 +163,7 @@ QFileDialog* RasterAssetWidget::FileDialog() {
     file_dialog_ = new QFileDialog(this);
     file_dialog_->setMode(QFileDialog::ExistingFiles);
     file_dialog_->setCaption(tr("Open Source"));
+    bool add_dem_file_filter = false;
 
     if (AssetType() == AssetDefs::Imagery) {
       if (khDirExists(Preferences::DefaultImageryPath().latin1())) {
@@ -184,8 +185,10 @@ QFileDialog* RasterAssetWidget::FileDialog() {
                    "Please update your preferences."),
                 tr("OK"), 0, 0, 0);
       }
-      file_dialog_->addFilter("USGS ASCII DEM ( *.dem *.DEM )");
+      add_dem_file_filter = true;
     }
+    // For JPEG2000 and MrSID, check if GDAL is built
+    // with specific format support.
     bool is_jpeg_found = false;
     bool is_mrsid_found = false;
     for (int iDr = 0; iDr < GDALGetDriverCount(); iDr++) {
@@ -216,8 +219,19 @@ QFileDialog* RasterAssetWidget::FileDialog() {
         }
       }
     }
-    // For JPEG2000 and MrSID, check if GDAL is built
-    // with specific format support.
+    // Add file filters:
+    QString supported_files_filter = "Supported images (";
+    if (add_dem_file_filter)
+      supported_files_filter += " *.dem *.DEM";
+    if (is_jpeg_found)
+      supported_files_filter += " *.jp2 *.JP2";
+    if (is_mrsid_found)
+      supported_files_filter += " *.sid *.SID";
+    supported_files_filter += " *.img *.IMG *.tif *.TIF )";
+    file_dialog_->addFilter(supported_files_filter);
+
+    if (add_dem_file_filter)
+      file_dialog_->addFilter("USGS ASCII DEM ( *.dem *.DEM )");
     if (is_jpeg_found)
       file_dialog_->addFilter("JPEG2000 ( *.jp2 *.JP2 )");
     if (is_mrsid_found)
@@ -226,7 +240,7 @@ QFileDialog* RasterAssetWidget::FileDialog() {
     file_dialog_->addFilter("Tiff/GeoTiff ( *.tif *.TIF )");
 
     // make the first filter current, which is the default "All Files (*)"
-    file_dialog_->setSelectedFilter(0);
+    file_dialog_->setSelectedFilter(1);
   }
   return file_dialog_;
 }

--- a/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
+++ b/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
@@ -237,9 +237,10 @@ QFileDialog* RasterAssetWidget::FileDialog() {
     if (is_mrsid_found)
       file_dialog_->addFilter("MrSID ( *.sid *.SID )");
     file_dialog_->addFilter("Erdas Imagine ( *.img *.IMG )");
-    file_dialog_->addFilter("Tiff/GeoTiff ( *.tif *.TIF )");
+    file_dialog_->addFilter("TIFF/GeoTIFF ( *.tif *.TIF )");
 
-    // make the first filter current, which is the default "All Files (*)"
+    // Make the second filter current, which is the "Supported images" one.
+    // The first one is the default "All Files (*)".
     file_dialog_->setSelectedFilter(1);
   }
   return file_dialog_;

--- a/earth_enterprise/src/fusion/fusionui/VectorAssetWidget.cpp
+++ b/earth_enterprise/src/fusion/fusionui/VectorAssetWidget.cpp
@@ -192,6 +192,9 @@ QFileDialog* VectorAssetWidget::FileDialog() {
           tr("OK"), 0, 0, 0);
     }
 
+    file_dialog_->addFilter(
+      "Supported files ( *.rt1 *.RT1 *.gml *.GML *.txt *.csv *.TXT *.CSV *.dgn"
+        " *.DGN *.tab *.TAB *.shp *.SHP *.kml *.KML *.kmz *.KMZ )");
     file_dialog_->addFilter("US Census Tiger Line Files ( *.rt1 *.RT1 )");
     file_dialog_->addFilter("OpenGIS GML ( *.gml *.GML )");
     file_dialog_->addFilter("Generic Text ( *.txt *.csv *.TXT *.CSV )");
@@ -201,8 +204,9 @@ QFileDialog* VectorAssetWidget::FileDialog() {
     file_dialog_->addFilter(
         "Keyhole Markup Language ( *.kml *.KML *.kmz *.KMZ )");
 
-    // make the first filter current, which is the default "All Files (*)"
-    file_dialog_->setSelectedFilter(0);
+    // Make the second filter current, which is the 'Support files' one.
+    // The first filter is the default "All Files (*)".
+    file_dialog_->setSelectedFilter(1);
   }
 
   return file_dialog_;


### PR DESCRIPTION
* Added a 'Supported images' file filter to the _Asset Manager -> Imagery Resource -> Add_ dialog.