### PR TITLE
Create build and install targets in top level SConstruct (#131, #123)

### DIFF
--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -154,6 +154,7 @@ stage_tutorial_cmds = {'stage_tutorial': [
 stage_tutorial = env.PhonyTargets(**stage_tutorial_cmds)
 env.Depends(stage_tutorial, stage_data)
 env.Alias('stage_install', 'stage_tutorial')
+env.Alias('install', 'stage_install')
 
 Export('env')
 Export('installdir')

--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -24,23 +24,8 @@ from khEnvironment import khEnvironment
 
 EnsureSConsVersion(0, 96, 92)
 
-# only accept known arguments
-ValidOptions = { 'installdir' : 1,
-               }
-for argkey in ARGUMENTS.keys():
-   if argkey not in ValidOptions:
-      print "Unrecognized option: '" + argkey + "'"
-      Exit(1)
-
 # process commandline arguments
-installdir = ARGUMENTS.get('installdir', 0)
-
-# this fallback really shouldn't be used, whenever you specify the install
-# target you should also specify an install dir.
-# But having a default makes the rest of the SCons code easier
-if (not installdir) and ('install' in COMMAND_LINE_TARGETS):
-   print "installdir=... must be specified with install target"
-   Exit(1)
+installdir = ARGUMENTS.get('installdir', '/tmp/fusion_os_install')
 
 installdir = Dir(installdir)
 def dir_cat(installdir, subdir1, subdir2):
@@ -134,21 +119,54 @@ env = khEnvironment(ENV={'PATH' : '/bin:/bin:/usr/bin'},
                     exportdirs=exportdirs,
                     installdirs=installdirs,
                     JAVA_HOME="/opt/google/java")
-env.Alias('install', installdirs['root'])
+
+def getArgumentVarsAsString():
+  vars=''
+  for var, value in ARGUMENTS.iteritems():
+    if var != 'installdir':
+      vars += var + '=' + str(value) + ' '
+  return vars[:-1]  # Remove the trailing space
+
+arg_vars = getArgumentVarsAsString()
+num_jobs = GetOption('num_jobs')
+
+# Build Fusion and Server
+build_cmds = {'build': [
+    'cd src; scons -j%d %s third_party' % (num_jobs, arg_vars),
+    'cd src; scons -j%d %s' % (num_jobs, arg_vars)
+]}
+run_build = env.PhonyTargets(**build_cmds)
+
+# Copy the binaries to the install staging directory
+stage_bin_cmds = {'stage_bin': [
+    'cd src; scons -j%d installdir=%s %s install' % (num_jobs, installdir, arg_vars)
+]}
+stage_bin = env.PhonyTargets(**stage_bin_cmds)
+
+# Copy the data and docs to the install staging directory
+stage_data = env.Alias('stage_data', installdirs['root'])
+env.Depends(stage_data, stage_bin)
+
+# Copy the tutorial to the install staging directory if it exists.
+stage_tutorial_cmds = {'stage_tutorial': [
+    'cd tutorial; if [ -d FusionTutorial ]; then scons -j%d installdir=%s; else echo "Skipping tutorial; no tutorial files found."; fi' % (num_jobs, installdir)
+]}
+stage_tutorial = env.PhonyTargets(**stage_tutorial_cmds)
+env.Depends(stage_tutorial, stage_data)
+env.Alias('stage_install', 'stage_tutorial')
+
 Export('env')
 Export('installdir')
 
-# Note that "src" is not built from this SConstruct currently.
-# May want to do this eventually. This SConstruct is purely for installer
-# building, not for temp or debug builds.
-# Tutorial is not "installed" at the moment due to the cost involved, the
-# installer simply references those files directly at install time.
 SConscript(dirs=['datasets', 'geplaces', 'searchexample', 'docs'],
            exports=['env', 'installdir'])
 
-# The following target is added to phony_target(or alias_target) 'install'
-# so that it will be executed last while trying to create target install
-this_dict = {'install': ['/bin/bash ./src/installer/scripts/verify_installerdir.sh %s' % installdir]}
+# The following target is added to phony_target(or alias_target) 'stage_install'
+# so that it will be executed last while trying to create target stage_install
+this_dict = {'stage_install': [
+    '/bin/bash ./src/installer/scripts/verify_installerdir.sh %s' % installdir,
+    'echo "Install files copied to %s."' % installdir
+]}
 env.PhonyTargets(**this_dict)
 
 # Clean install dir (note: the current sconscripts leave stuff behind, like

--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -139,7 +139,7 @@ run_build = env.PhonyTargets(**build_cmds)
 
 # Copy the binaries to the install staging directory
 stage_bin_cmds = {'stage_bin': [
-    'cd src; scons -j%d installdir=%s %s install' % (num_jobs, installdir, arg_vars)
+    'cd src; scons -j%d installdir="%s" %s install' % (num_jobs, installdir, arg_vars)
 ]}
 stage_bin = env.PhonyTargets(**stage_bin_cmds)
 
@@ -149,7 +149,7 @@ env.Depends(stage_data, stage_bin)
 
 # Copy the tutorial to the install staging directory if it exists.
 stage_tutorial_cmds = {'stage_tutorial': [
-    'cd tutorial; if [ -d FusionTutorial ]; then scons -j%d installdir=%s; else echo "Skipping tutorial; no tutorial files found."; fi' % (num_jobs, installdir)
+    'cd tutorial; if [ -d FusionTutorial ]; then scons -j%d installdir="%s"; else echo "Skipping tutorial; no tutorial files found."; fi' % (num_jobs, installdir)
 ]}
 stage_tutorial = env.PhonyTargets(**stage_tutorial_cmds)
 env.Depends(stage_tutorial, stage_data)
@@ -164,7 +164,7 @@ SConscript(dirs=['datasets', 'geplaces', 'searchexample', 'docs'],
 # The following target is added to phony_target(or alias_target) 'stage_install'
 # so that it will be executed last while trying to create target stage_install
 this_dict = {'stage_install': [
-    '/bin/bash ./src/installer/scripts/verify_installerdir.sh %s' % installdir,
+    '/bin/bash ./src/installer/scripts/verify_installerdir.sh "%s"' % installdir,
     'echo "Install files copied to %s."' % installdir
 ]}
 env.PhonyTargets(**this_dict)


### PR DESCRIPTION
This change allows the user to run a complete build and to stage install files using a single command for each. The old method of building and installing is still available, but this method is simpler because it requires fewer commands and doesn't require changing directories.  This also sets the default install directory to /tmp/fusion_os_installer.

The new instructions for building and creating install files are as follows:
```
cd earthenterprise/earth_enterprise
scons -j8 optimize=1 build
scons -j8 optimize=1 stage_install
```
Then go to `src/installer` and run the installers.  I will update the wiki with these instructions when this PR is merged.

Tested on Ubuntu 14.04 and RHEL 7.

Fixes #131 
Fixes #123