### PR TITLE
Update date parsing to handle default date string.

### DIFF
--- a/earth_enterprise/src/common/khConstants.cpp
+++ b/earth_enterprise/src/common/khConstants.cpp
@@ -91,6 +91,7 @@ const std::string kEarthClientSearchAdapter = "ECV4Adapter";
 const std::string kMapsSearchAdapter = "MapsAdapter";
 
 const std::string kUnknownDate = "0000-00-00";
+const std::string kUnknownDateTimeUTC = "0000-00-00T00:00:00Z";
 const std::string kDatedImageryChannelsFileName = "dated_imagery_channels";
 
 // TimeMachine specific constants.

--- a/earth_enterprise/src/common/khConstants.h
+++ b/earth_enterprise/src/common/khConstants.h
@@ -164,6 +164,9 @@ extern const std::string kTimeMachineTOCSuffix;
 // Empty date string used for dated imagery dates.
 extern const std::string kUnknownDate;
 
+// Empty date-time string used for dated imagery dates.
+extern const std::string kUnknownDateTimeUTC;
+
 // An empty string that can be returned as a const string result by any method.
 extern const std::string kEmptyString;
 

--- a/earth_enterprise/src/fusion/autoingest/tools/genewimageryresource.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/genewimageryresource.cpp
@@ -229,7 +229,10 @@ main(int argc, char *argv[]) {
       // also accepts old time string such as "YYYY-MM-DD" in order not to
       // break customers' old scripts.
       struct tm ts;
-      if (ParseUTCTime(sourcedate, &ts)) {
+      if (sourcedate == kUnknownDate) {
+        // default input, set to standard metadata value.
+        req.meta.SetValue("sourcedate", kUnknownDateTimeUTC);
+      } else if (ParseUTCTime(sourcedate, &ts)) {
         // Reformat into standard UTC ISO 8601 time string.
         req.meta.SetValue("sourcedate", GetUTCTimeString(ts));
       } else {

--- a/earth_enterprise/src/fusion/autoingest/tools/genewvectorresource.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/genewvectorresource.cpp
@@ -203,7 +203,10 @@ main(int argc, char *argv[]) {
       // also accepts old time string such as "YYYY-MM-DD" in order not to
       // break customers' old scripts.
       struct tm ts;
-      if (ParseUTCTime(sourcedate, &ts)) {
+      if (sourcedate == kUnknownDate) {
+        // default input, set to standard metadata value.
+        req.meta.SetValue("sourcedate", kUnknownDateTimeUTC);
+      } else if (ParseUTCTime(sourcedate, &ts)) {
         // Reformat into standard UTC ISO 8601 time string.
         req.meta.SetValue("sourcedate", GetUTCTimeString(ts));
       } else {


### PR DESCRIPTION
Resolves #92, does not change definition of default (which I had considered, but decided was risky in terms of existing resource / project definition, or against a mismatched server version).