### PR TITLE
Vector resource build fails unless source files have write access  #16

### DIFF
--- a/earth_enterprise/src/fusion/gst/gstOGRFormat.cpp
+++ b/earth_enterprise/src/fusion/gst/gstOGRFormat.cpp
@@ -71,7 +71,7 @@ gstStatus gstOGRFormat::OpenFile() {
   notify(NFY_DEBUG, "OGR Loader opening file %s", name());
 
   data_source_ = (GDALDataset *) GDALOpenEx(name(),
-                                            GDAL_OF_VECTOR || GDAL_OF_READONLY,
+                                            GDAL_OF_VECTOR | GDAL_OF_READONLY,
                                             NULL, NULL, NULL);
 
   if (data_source_ == NULL)


### PR DESCRIPTION
resolves #16 

The issue is that instead of bitwise or logical OR was used. this sure got introduced while last update of GDAL and happens only for shape(.shp) files.