### PR TITLE
Specifying a volume in the fusion installer fails

### DIFF
--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -398,7 +398,7 @@ parse_arguments()
 				else
 					shift
 
-					if is_valid_directory ${1// }; then
+					if is_valid_custom_directory ${1// }; then
 						SOURCE_VOLUME=${1// }
 					else
 						echo -e "\nThe source volume you specified does not appear to be a syntactically valid directory. Please"


### PR DESCRIPTION
resolves #125 

basically correcting the function name and using the same one that we use for the custom asset root folder check.