### PR TITLE
Remove gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Earth Enterprise [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-ff69b4.svg)](http://slack.opengee.org) [![Join the chat at https://gitter.im/earthenterprise/Lobby](https://badges.gitter.im/earthenterprise/Lobby.svg)](https://gitter.im/earthenterprise/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# Earth Enterprise [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-ff69b4.svg)](http://slack.opengee.org)
 
 Earth Enterprise is the open source release of Google Earth Enterprise, a geospatial application which provides the ability to build and host custom 3D globes and 2D maps.  Earth Enterprise does not provide a private version of Google imagery that's currently available in Google Maps or Earth.
 


### PR DESCRIPTION
The gitter chat is not commonly used, so this change removes the
gitter badge to avoid confusion.