### PR TITLE
Pass correct data type to curl library

### DIFF
--- a/earth_enterprise/src/fusion/gepublish/CurlRequest.cpp
+++ b/earth_enterprise/src/fusion/gepublish/CurlRequest.cpp
@@ -267,9 +267,10 @@ int GetRequest::Start(const std::string& args) {
 
   if (code != CURLE_OK) {
     long result_code = 0;
-    curl_easy_getinfo(curl_easy_handle_, CURLINFO_RESPONSE_CODE, &result_code);
+    CURLcode getinfoCode =
+        curl_easy_getinfo(curl_easy_handle_, CURLINFO_RESPONSE_CODE, &result_code);
     // Authentication required.
-    if (result_code == AUTH_REQD)
+    if (getinfoCode == CURLE_OK && result_code == AUTH_REQD)
       return result_code;
     // Ignore the GOT_NOTHING error code. This happens sometimes when
     // tomcat restarts apache and for some reason apache sends out an

--- a/earth_enterprise/src/fusion/gepublish/CurlRequest.cpp
+++ b/earth_enterprise/src/fusion/gepublish/CurlRequest.cpp
@@ -266,7 +266,7 @@ int GetRequest::Start(const std::string& args) {
   CURLcode code = curl_easy_perform(curl_easy_handle_);
 
   if (code != CURLE_OK) {
-    int result_code = 0;
+    long result_code = 0;
     curl_easy_getinfo(curl_easy_handle_, CURLINFO_RESPONSE_CODE, &result_code);
     // Authentication required.
     if (result_code == AUTH_REQD)


### PR DESCRIPTION
Fixes #26.

We were passing an int to a libcurl function that expected a long.  Because of this, the library overwrote the int, which caused a corrupted pointer in the LoggingManager class, leading to a segfault.  To verify this fix, run the reproduction steps listed in the issue.