### PR TITLE
GE Server Installer fails to create link to manual under htdocs

### DIFF
--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -250,7 +250,7 @@ create_links()
         ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
     fi
 
-    if [ ! -L "$BASEINSTALLDIR_OPT/share/doc" ]; then
+    if [ ! -L "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/docs" ]; then
         sudo ln -s $BASEINSTALLDIR_OPT/share/doc $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/docs
     fi
 

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -250,6 +250,10 @@ create_links()
         ln -s $BASEINSTALLDIR_VAR/run $BASEINSTALLDIR_OPT/run
     fi
 
+    if [ ! -L "$BASEINSTALLDIR_OPT/share/doc" ]; then
+        sudo ln -s $BASEINSTALLDIR_OPT/share/doc $BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/docs
+    fi
+
     printf "DONE\n"
 }
 

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -491,9 +491,8 @@ fix_postinstall_filepermissions()
   mkdir -p $BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime
   chmod -R 755 $BASEINSTALLDIR_OPT/gehttpd
   chmod -R 775 $BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/
-  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/
-  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/
-  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/
+  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/
+  chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/
   chmod -R 700 $BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/
   chown $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess
   chown -R $GEAPACHEUSER_NAME:$GRPNAME $BASEINSTALLDIR_OPT/gehttpd/logs
@@ -520,7 +519,7 @@ fix_postinstall_filepermissions()
   chown root:$GRPNAME $BASEINSTALLDIR_VAR/run/
 
   # Logs
-  chmod 775 /var/$BASEINSTALLDIR_OPT/log/
+  chmod 775 $BASEINSTALLDIR_VAR/log/
   chmod 775 $BASEINSTALLDIR_OPT/log/
   chown root:$GRPNAME $BASEINSTALLDIR_VAR/log
   chown root:$GRPNAME $BASEINSTALLDIR_OPT/log


### PR DESCRIPTION
fix for  #188
permission changes from other requests. 
duplicate code lines removed
cutter permission issue seen in the log, so modified it to the parent.