### PR TITLE
Fusion Pro support for JPEG 2000 (#53)

### DIFF
--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -28,6 +28,7 @@
 Import('third_party_env')
 
 gdal_version = 'gdal-2.1.2'
+openjpeg_version = 'openjpeg-v2.1.2-linux-x86_64'
 # kakadu_version = 'v5_2_6-00418C'
 # geoexpress_version = 'MrSID_DSDK-8.5.0.3422'
 make_cmd_cpu = 'make -j%d' % GetOption('num_jobs')
@@ -38,6 +39,11 @@ current_dir = Dir('.').abspath
 build_root = '%s/%s' % (current_dir, gdal_version)
 gdal_source = File('#/../../earth_enterprise/third_party/gdal/%s.tar.gz'
                    % gdal_version).abspath
+
+
+## Specify path to openjpeg library here:
+openjpeg_source = File('#/../../earth_enterprise/third_party/openjpeg/%s.tar.gz'
+                      % openjpeg_version).abspath
 
 # Specify path to kakadu library here:
 # kakadu_source = File('#/../../earth_enterprise/third_party/kakadu/%s.zip'
@@ -74,7 +80,18 @@ gdal_extract = gdal_env.Command(
         'tar xzf %s\n'
         'touch %s'% (current_dir, current_dir, gdal_source, gdal_target))])
 
-# [2] Extract Kakadu
+
+# [2] Extract openjpeg
+gdal_target = '%s/.extract_openjpeg' % current_dir
+openjpeg_extract = gdal_env.Command(
+    gdal_target, [openjpeg_source, gdal_extract],
+    [gdal_env.MultiCommand(
+        'cd %s\n'
+        'tar xzf %s\n'
+        'touch %s' % (build_root, openjpeg_source, gdal_target))])
+
+
+# [3] Extract Kakadu
 # gdal_target = '%s/.extract_kakadu' % current_dir
 # kakadu_extract = gdal_env.Command(
 #     gdal_target, [kakadu_source, gdal_extract],
@@ -84,7 +101,7 @@ gdal_extract = gdal_env.Command(
 #         'touch %s' % (build_root, kakadu_source, gdal_target))])
 
 # kakadu 5.2
-# [3] Patch Kakadu
+# [4] Patch Kakadu
 # gdal_target = '%s/.patch_kakadu' % current_dir
 # kakadu_patch = gdal_env.Command(
 #     gdal_target, kakadu_extract +
@@ -98,7 +115,7 @@ gdal_extract = gdal_env.Command(
 #                     kakadu_patches[i], gdal_env.GetBuildPath(i)),
 #                 kakadu_patches.keys())), gdal_target))])
 
-# [4] Extract Geoexpress (Mrsid)
+# [5] Extract Geoexpress (Mrsid)
 # gdal_target = '%s/.extract_geoexpress' % current_dir
 # geoexpress_extract = gdal_env.Command(
 #    gdal_target, [geoexpress_source, gdal_extract],
@@ -107,7 +124,7 @@ gdal_extract = gdal_env.Command(
 #         'tar xzf %s\n'
 #         'touch %s' % (build_root, geoexpress_source, gdal_target))])
 
-# [5] Build kakadu
+# [6] Build kakadu
 # Note: kakadu build uses -DKDU_PENTIUM_GCC which don't work well with anything
 # later than gcc 4.1.1 ; Removing this flag and using gcc 4.4.0 gives good
 # image but with image regressions. So to keep things unchanged use gcc 4.1.1
@@ -128,7 +145,7 @@ gdal_extract = gdal_env.Command(
 #             kakadu_version, kakadu_version, kakadu_version, gdal_target))])
 
 
-# [6] Configure Gdal
+# [7] Configure Gdal
 gdal_target = '%s/.configure_gdal' % current_dir
 
 if gdal_env['bundle_3rd_libs']:
@@ -139,6 +156,7 @@ if gdal_env['bundle_3rd_libs']:
       '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
       '--with-geotiff=internal --with-xerces=%s --with-geos=%s/bin/geos-config '
 #      '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
+      '--with-openjpeg=%s/%s '
       '--with-python=%s '
       '--with-xml2=%s/bin '
       '--without-pg --without-jasper --with-odbc=no --without-mysql '
@@ -150,10 +168,12 @@ if gdal_env['bundle_3rd_libs']:
            root_dir, root_dir,
            root_dir, root_dir,
 #           build_root, kakadu_version, build_root, geoexpress_version,
+           build_root, openjpeg_version,
            gdal_env['python_bin'],
            root_dir,
            root_dir,
            gdal_target))
+
 else:
   configure_cmd = (
         'cd %s\n'
@@ -162,6 +182,7 @@ else:
         '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
         '--with-geotiff=internal --with-xerces --with-geos '
 #        '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
+        '--with-openjpeg=%s/%s '
         '--with-python=%s '
         '--with-xml2 '
         '--without-pg --without-jasper --with-odbc=no --without-mysql '
@@ -171,16 +192,17 @@ else:
             build_root,
             gdal_env['ENV']['mod_env'], optdir,
 #            build_root, kakadu_version, build_root, geoexpress_version,
+            build_root, openjpeg_version,
             gdal_env['python_bin'],
             gdal_target))
 
 
 gdal_configure = gdal_env.Command(
 #    gdal_target, [geoexpress_extract, gdal_kakadu_build],
-    gdal_target, gdal_extract,
+    gdal_target, [gdal_extract, openjpeg_extract],
     [gdal_env.MultiCommand(configure_cmd)])
 
-# [7] Build Gdal
+# [8] Build Gdal
 if third_party_env['is_hardy'] and not third_party_env['native_cc']:
   ld = '%s -shared' % gdal_env['ENV']['CXX']
 else:
@@ -196,7 +218,7 @@ gdal_build = gdal_env.Command(
         'touch %s' % (build_root, gdal_env['ENV']['mod_env'], make_cmd,
                       gdal_target))])
 
-# [8] Create Gdal master installer
+# [9] Create Gdal master installer
 make_cmd = 'make LD_SHARED="%s"' % (ld)
 install_root = '%s/install' % current_dir
 other_dir = '%s/share/doc/packages/%s' % (install_root, ge_version)
@@ -214,7 +236,7 @@ gdal_install = gdal_env.Command(
             other_dir, other_dir, install_root,
             gdal_target))])
 
-# [9] Copy Geoexpress libraries (Gdal master installer)
+# [10] Copy Geoexpress libraries (Gdal master installer)
 # gdal_target = '%s/.geoxpress_install' % current_dir
 # geoexpress_install = gdal_env.Command(
 #    gdal_target, gdal_install,
@@ -224,11 +246,23 @@ gdal_install = gdal_env.Command(
 #        'touch %s' % (
 #        build_root, geoexpress_version, install_root, gdal_target))])
 
-# [10] Install these into various directories as required for build
+
+# [10] Copy Openjpeg libraries (Gdal master installer)
+gdal_target = '%s/.openjpeg_install' % current_dir
+openjpeg_install = gdal_env.Command(
+    gdal_target, gdal_install,
+    [gdal_env.MultiCommand(
+         'cd %s\n'
+         'cp -d  %s/lib/*.so* %s/lib\n'
+        'touch %s' % (
+        build_root, openjpeg_version, install_root, gdal_target))])
+
+
+# [11] Install these into various directories as required for build
 gdal_target = '%s/.install_for_build' % current_dir
 gdal_install_build = gdal_env.Command(
 #    gdal_target, [gdal_install, geoexpress_install],
-    gdal_target, gdal_install,
+    gdal_target, [gdal_install, openjpeg_install],
     [gdal_env.rsync_cmd % (
         '%s/bin/' % install_root,
         '%s/' % Dir(gdal_env.exportdirs['bin']).abspath),

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -145,7 +145,7 @@ openjpeg_extract = gdal_env.Command(
 #             kakadu_version, kakadu_version, kakadu_version, gdal_target))])
 
 
-# [7] Configure Gdal
+# [7] Configure gdal
 gdal_target = '%s/.configure_gdal' % current_dir
 
 if gdal_env['bundle_3rd_libs']:
@@ -202,7 +202,7 @@ gdal_configure = gdal_env.Command(
     gdal_target, [gdal_extract, openjpeg_extract],
     [gdal_env.MultiCommand(configure_cmd)])
 
-# [8] Build Gdal
+# [8] Build gdal
 if third_party_env['is_hardy'] and not third_party_env['native_cc']:
   ld = '%s -shared' % gdal_env['ENV']['CXX']
 else:
@@ -218,7 +218,7 @@ gdal_build = gdal_env.Command(
         'touch %s' % (build_root, gdal_env['ENV']['mod_env'], make_cmd,
                       gdal_target))])
 
-# [9] Create Gdal master installer
+# [9] Create gdal master installer
 make_cmd = 'make LD_SHARED="%s"' % (ld)
 install_root = '%s/install' % current_dir
 other_dir = '%s/share/doc/packages/%s' % (install_root, ge_version)
@@ -236,7 +236,7 @@ gdal_install = gdal_env.Command(
             other_dir, other_dir, install_root,
             gdal_target))])
 
-# [10] Copy Geoexpress libraries (Gdal master installer)
+# [10] Copy Geoexpress libraries (gdal master installer)
 # gdal_target = '%s/.geoxpress_install' % current_dir
 # geoexpress_install = gdal_env.Command(
 #    gdal_target, gdal_install,
@@ -247,15 +247,15 @@ gdal_install = gdal_env.Command(
 #        build_root, geoexpress_version, install_root, gdal_target))])
 
 
-# [10] Copy Openjpeg libraries (Gdal master installer)
+# [10] Copy Openjpeg libraries (gdal master installer)
 gdal_target = '%s/.openjpeg_install' % current_dir
 openjpeg_install = gdal_env.Command(
     gdal_target, gdal_install,
     [gdal_env.MultiCommand(
-         'cd %s\n'
-         'cp -d  %s/lib/*.so* %s/lib\n'
+        'cd %s\n'
+        'cp -d  %s/lib/*.so* %s/lib\n'
         'touch %s' % (
-        build_root, openjpeg_version, install_root, gdal_target))])
+            build_root, openjpeg_version, install_root, gdal_target))])
 
 
 # [11] Install these into various directories as required for build
@@ -276,7 +276,7 @@ gdal_install_build = gdal_env.Command(
 Default(gdal_install_build)
 
 if 'install' in COMMAND_LINE_TARGETS:
-  # Copies GDAL python bindings from ../install/lib/python2.7/site-packages
+  # Copies gdal python bindings from ../install/lib/python2.7/site-packages
   # to ../opt/google/gepython/../site-packages/ folder.
   gdal_env.InstallFileOrDir(
       '%s/lib/python%s/site-packages/' % (install_root,
@@ -286,8 +286,7 @@ if 'install' in COMMAND_LINE_TARGETS:
           gdal_env['python_major_version']),
       gdal_install_build, 'install')
 
-  # Copies GDAL py_tools to /opt/google/bin folder.
-
+  # Copies gdal py_tools to /opt/google/bin folder.
   gdal_env.InstallFileOrDir(
       '%s/bin/' % install_root,
       '%s/opt/google/bin' % gdal_env.installdirs['common_root'],

--- a/earth_enterprise/src/third_party/gdal/gdal-ge.spec
+++ b/earth_enterprise/src/third_party/gdal/gdal-ge.spec
@@ -2,6 +2,7 @@
 %define PACKAGE_VERSION 2.1.2
 %define KAKADU_SOURCEDIR v5_2_6-00418C
 %define KAKADU_ZIPFILE %KAKADU_SOURCEDIR.zip
+%define OPENJPEG_VERSION 20100
 
 %define MRSID_VERSION 8.5.0.3422
 %define MRSID_PLATFORM %(eval "%_topdir/SOURCES/GDALMrSIDConfig.pl platform")
@@ -55,7 +56,7 @@ AutoReqProv: no
 BuildRequires: gcc-ge >= 4.1.1
 Requires: gcc-ge-runtime >= 4.1.1
 
-# Stupid GDAL doesn't compile clean if another version is already installed
+# GDAL doesn't compile clean if another version is already installed
 BuildConflicts: gdal-ge
 BuildConflicts: gdal-ge-devel
 

--- a/earth_enterprise/third_party/openjpeg/openjpeg-v2.1.2-linux-x86_64.tar.gz
+++ b/earth_enterprise/third_party/openjpeg/openjpeg-v2.1.2-linux-x86_64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6738a90a50cd580cb4940e2ad04b58ded2e15ba7cfbbe99cbd56e048115eb31
+size 1553746


### PR DESCRIPTION
resolves #53 
This implementation uses gdal's implementation of openjpeg.

ref:
https://wiki.orfeo-toolbox.org/index.php/JPEG2000_with_GDAL_OpenJpeg_plugin

openjpeg downloaded from:
https://github.com/uclouvain/openjpeg/releases/tag/v2.1.2
