### PR TITLE
cachedreadaccessor_unittest fails on free() call on Ubuntu 16.04 #239

### DIFF
--- a/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
+++ b/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
@@ -65,7 +65,7 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     if (!keep_temp_bundle_) {
       khPruneDir(path_base_);
     }
-    delete test_buffer_;
+    delete [] test_buffer_;
   }
 
   // Maintain Test bundle info for all the tests.

--- a/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
+++ b/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
@@ -64,6 +64,7 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
   ~CachedReadAccessorUnitTest() {
     if (!keep_temp_bundle_) {
       khPruneDir(path_base_);
+      delete test_buffer_;
     }
   }
 
@@ -72,7 +73,6 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
   uint32 segment_size_;
   std::string path_base_;
   std::string bundle_name_;
-  std::string buffer_;
   char* test_buffer_;
   std::vector<std::string> segment_names_;
   std::string header_path_;
@@ -158,8 +158,10 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                    uint32 max_blocks,
                    uint32 block_size,
                    std::string prefix) {
-    buffer_.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer_.data());
+    std::string buffer;
+    buffer.reserve(block_size);
+    buffer.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer.data());
 
     // Test Read uncached of entire filebundle
     CachedReadAccessor accessor(max_blocks < 2 ? 2 : max_blocks, block_size);
@@ -223,9 +225,10 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                                     segment_names_[segment_id],
                                     segment_names_[segment_id],
                                     segment_id);
-
-    buffer_.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer_.data());
+    std::string buffer;
+    buffer.reserve(block_size);
+    buffer.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer.data());
 
     // Test read within a single block
     // uncached block
@@ -238,6 +241,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     // same block cached read
     offset *= 2;
     request_count -= offset;
+    buffer.resize(request_count);
+    
     accessor.Pread(segment, out_buffer, request_count, offset);
     expected = test_buffer_ + offset;
     if (!TestBuffer(out_buffer, expected, request_count,
@@ -248,6 +253,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     // uncached 2nd block
     offset = block_size / 3;
     request_count = block_size;
+    buffer.resize(request_count);
+    
     accessor.Pread(segment, out_buffer, request_count, offset);
     expected = test_buffer_ + offset;
     if (!TestBuffer(out_buffer, expected, request_count,
@@ -257,6 +264,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     // same 2 blocks cached read
     offset *= 2;
     request_count -= offset;
+    buffer.resize(request_count);
+    
     accessor.Pread(segment, out_buffer, request_count, offset);
     expected = test_buffer_ + offset;
     if (!TestBuffer(out_buffer, expected, request_count,
@@ -395,8 +404,10 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                                     segment_names_[segment_id],
                                     segment_names_[segment_id],
                                     segment_id);
-    buffer_.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer_.data());
+    std::string buffer;
+    buffer.reserve(block_size);
+    buffer.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer.data());
 
     // Test read within non-cached (uninitialized) block
     uint64 stats_bytes_read = 0;
@@ -416,6 +427,7 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     // Test read from the NOW cached block within the segment.
     offset = 23;
     request_count /= 3;
+    buffer.resize(request_count);
     read_count =
       block1.Read(segment, out_buffer, request_count, offset, access_tick++,
                   stats_bytes_read, stats_disk_accesses);
@@ -432,6 +444,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     // create a new CacheBlock to start with an empty cache.
     block1 = CachedReadAccessor::CacheBlock(address1, block_size);
     request_count = 200;
+    buffer.resize(request_count);
+
     uint32 expected_read_count = 133;
     offset = block_size - expected_read_count;
     // Read from a non-cached block

--- a/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
+++ b/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
@@ -71,8 +71,9 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
   uint32 file_bundle_size_;
   uint32 segment_size_;
   std::string path_base_;
-  char* test_buffer_;
   std::string bundle_name_;
+  std::string buffer_;
+  char* test_buffer_;
   std::vector<std::string> segment_names_;
   std::string header_path_;
   geFilePool file_pool_;
@@ -157,9 +158,9 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                    uint32 max_blocks,
                    uint32 block_size,
                    std::string prefix) {
-    std::string buffer;
-    buffer.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer.data());
+    buffer_.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer_.data());
+
     // Test Read uncached of entire filebundle
     CachedReadAccessor accessor(max_blocks < 2 ? 2 : max_blocks, block_size);
     khTimer_t begin = khTimer::tick();
@@ -212,7 +213,6 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
     uint32 offset = 13;
     uint32 segment_id = 0;
     uint32 block_size = file_bundle_size_ / 4;
-
     CachedReadAccessor accessor(2, block_size);
 
     // Test Read
@@ -223,9 +223,9 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                                     segment_names_[segment_id],
                                     segment_names_[segment_id],
                                     segment_id);
-    std::string buffer;
-    buffer.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer.data());
+
+    buffer_.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer_.data());
 
     // Test read within a single block
     // uncached block
@@ -395,9 +395,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
                                     segment_names_[segment_id],
                                     segment_names_[segment_id],
                                     segment_id);
-    std::string buffer;
-    buffer.resize(request_count);
-    char* out_buffer = const_cast<char*>(buffer.data());
+    buffer_.resize(request_count);
+    char* out_buffer = const_cast<char*>(buffer_.data());
 
     // Test read within non-cached (uninitialized) block
     uint64 stats_bytes_read = 0;

--- a/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
+++ b/earth_enterprise/src/common/filebundle/cachedreadaccessor_unittest.cpp
@@ -64,8 +64,8 @@ class CachedReadAccessorUnitTest : public UnitTest<CachedReadAccessorUnitTest> {
   ~CachedReadAccessorUnitTest() {
     if (!keep_temp_bundle_) {
       khPruneDir(path_base_);
-      delete test_buffer_;
     }
+    delete test_buffer_;
   }
 
   // Maintain Test bundle info for all the tests.


### PR DESCRIPTION
resolves #239 ,
root cause:
The issue is that sometimes request_count is too big and by the time end of function reaches that memory is already taken by some other culprit or overwritten, so at the end when is comes to free() up the string buffer it runs in SEGFAULT.
TestCacheBlock and Pread agravates the problem with multiple long reads

Resolution:
Made string a global member in tests.

