### PR TITLE
Ignore Eclipse project files in entire repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 earth_enterprise/.sconsign.dblite
 earth_enterprise/tutorial/.sconsign.dblite
 earth_enterprise/tutorial/FusionTutorial-Full.tar.gz
+
+# Eclipse project files
+.cproject
+.project
+.pydevproject
+.settings

--- a/earth_enterprise/src/.gitignore
+++ b/earth_enterprise/src/.gitignore
@@ -9,8 +9,3 @@ NATIVE-REL-x86_64/
 .sconf_temp
 config.log
 portableserver/build
-
-# Eclipse project files
-.cproject
-.project
-.pydevproject


### PR DESCRIPTION
This moves the ignore statements for Eclipse project files higher in the directory structure so that they will be ignored anywhere in the repo.