### PR TITLE
Fix error loading the wrong utils module (#351)

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/form_wrap.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/form_wrap.py
@@ -22,8 +22,8 @@ import posixpath
 import re
 import urllib
 
-from common import errors
-from common import utils
+import errors
+import utils
 
 # It is used for debugging.
 # logging.getLogger().setLevel(level=logging.DEBUG)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/portable_globe.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/portable_globe.py
@@ -22,7 +22,7 @@ Adapted from module of same name used in Portable Server.
 import os
 import re
 
-from common import portable_exceptions
+import portable_exceptions
 import glc_unpacker
 
 NON_COMPOSITE_LAYER = 0

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -28,7 +28,7 @@ import xml.sax.saxutils as saxutils
 import distutils.dir_util
 import distutils.errors
 
-from common import errors
+import errors
 
 BYTES_PER_MEGABYTE = 1024.0 * 1024.0
 NAME_TEMPLATE = "%s_%s"

--- a/earth_enterprise/src/server/wsgi/common/batch_sql_manager.py
+++ b/earth_enterprise/src/server/wsgi/common/batch_sql_manager.py
@@ -22,7 +22,7 @@ Class for managing batch sql command processing.
 import logging
 import psycopg2  # No lint.
 
-from common import exceptions
+import exceptions
 
 ERR_BATCH_SQL_MANAGER_CLOSED = ("Server-side Internal Error"
                                 " - BatchSqlManager has already been closed.")

--- a/earth_enterprise/src/server/wsgi/common/exceptions.py
+++ b/earth_enterprise/src/server/wsgi/common/exceptions.py
@@ -18,8 +18,7 @@
 
 import cgitb
 
-from common import utils
-
+import utils
 
 def FormatException(exc_info):
   """Gets information from exception info tuple.

--- a/earth_enterprise/src/server/wsgi/common/postgres_properties.py
+++ b/earth_enterprise/src/server/wsgi/common/postgres_properties.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """Postgres database properties loader."""
-from common import utils
+import utils
 
 
 class PostgresProperties(object):


### PR DESCRIPTION
Fixes #351 

This issue likely corresponds to an update to python which changes the way that imports resolve module paths. If you want to load a module from the same directory, then you should not specify the from clause. 