### PR TITLE
Release notes for 5.2.0

### DIFF
--- a/docs/geedocs/answer/3424202.html
+++ b/docs/geedocs/answer/3424202.html
@@ -10,6 +10,7 @@
 <!-- 3424202.html -->
 <div class="container">
 <div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
   <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
   <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
   <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/4556704.html
+++ b/docs/geedocs/answer/4556704.html
@@ -4,6 +4,7 @@
 <!-- 4556704.html -->
 <div class="container">
   <div class="sidebar1">
+<p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
 <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
 <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
 <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/6053170.html
+++ b/docs/geedocs/answer/6053170.html
@@ -4,6 +4,7 @@
 <!-- 6053170.html -->
 <div class="container">
   <div class="sidebar1">
+<p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
 <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
 <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
 <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/6078762.html
+++ b/docs/geedocs/answer/6078762.html
@@ -10,6 +10,7 @@
 <!-- 6078762.html -->
 <div class="container">
 <div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
   <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
   <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
   <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/6159443.html
+++ b/docs/geedocs/answer/6159443.html
@@ -10,6 +10,7 @@
 <!-- 6159443.html -->
 <div class="container">
 <div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
   <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
   <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
   <p class="sidebar-toc"><a href="../answer/6159443.html" class="current-file">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/6259403.html
+++ b/docs/geedocs/answer/6259403.html
@@ -10,6 +10,7 @@
 <!-- 6259403.html -->
 <div class="container">
 <div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
   <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
   <p class="sidebar-toc"><a href="../answer/6259403.html" class="current-file">GEE 5.1.2</a></p>
   <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>

--- a/docs/geedocs/answer/7159245.html
+++ b/docs/geedocs/answer/7159245.html
@@ -10,7 +10,14 @@
 <!-- 7159245.html -->
 <div class="container">
 <div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html">Open GEE 5.2.0</a></p>
   <p class="sidebar-toc"><a href="../answer/7159245.html" class="current-file">GEE 5.1.3</a></p>
+  <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
+  <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>
+  <p class="sidebar-toc"><a href="../answer/6078762.html">GEE 5.1.0</a></p>
+  <p class="sidebar-toc"><a href="../answer/6053170.html">GEE 5.0.2</a></p>
+  <p class="sidebar-toc"><a href="../answer/4556704.html">GEE 5.0.1</a></p>
+  <p class="sidebar-toc"><a href="../answer/3424202.html">GEE 5.0</a></p>
 </div>
 <div class="content"> <a name="top_of_file"></a>
   <p><img src="../art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -43,7 +43,7 @@ current asset root without stopping Fusion.</p>
   </h5>
   <p>The Open GEE 5.2.0 release is supported on 64-bit versions of the following operating systems:</p>
     <ul>
-      <li>Red Hat Enterprise Linux versions 7.x, including the most recent security patches</li>
+      <li>Red Hat Enterprise Linux version 7.x, including the most recent security patches</li>
       <li>CentOS 7.x</li>
       <li>Ubuntu 14.04 LTS and 16.04 LTS</li>
     </ul>
@@ -113,6 +113,16 @@ current asset root without stopping Fusion.</p>
           <td>Ensure that <code>/home</code> and <code>/tmp</code> are on the same file system or download the tutorial files to <code>/opt/google/share/tutorials/fusion/</code> after installing Fusion.</td>
         </tr>
         <tr>
+          <td>202</td>
+          <td>Icons are not displayed on vector layers in the Enterprise Client</td>
+          <td>No current work around.  It is not clear if this is an error in GEE or in the Enterprise Client.</td>
+        </tr>
+        <tr>
+          <td>203</td>
+          <td>Some vector layer options are not saved</td>
+          <td>No current work around</td>
+        </tr>
+        <tr>
           <td>254</td>
           <td>Automasking fails for images stored with UTM projection</td>
           <td>Use GDAL to convert the images to a different projection before ingesting them into Fusion.</td>
@@ -140,7 +150,7 @@ current asset root without stopping Fusion.</p>
         <tr>
           <td>342</td>
           <td>Fusion crashes when opening an unsupported file type</td>
-          <td>Do not open unsupported file types.</td>
+          <td>Re-open fusion and avoid opening unsupported file types.</td>
         </tr>
       </tbody>
     </table>
@@ -168,7 +178,7 @@ current asset root without stopping Fusion.</p>
         <tr>
           <td>26</td>
           <td>Fusion segmentation faults when trying to push and the server is not available</td>
-          <td>Pass the correct data type to cURL function</td>
+          <td>Passed the correct data type to cURL function</td>
         </tr>
         <tr>
           <td>167</td>
@@ -181,6 +191,11 @@ current asset root without stopping Fusion.</p>
           <td>Added code to handle default dates in Fusion tools</td>
         </tr>
         <tr>
+          <td>196</td>
+          <td>Simplify SSL settings and enable TLS 1.2 by default</td>
+          <td>Consolidated SSL settings and updated the defaults to include TLS 1.2</td>
+        </tr>
+        <tr>
           <td>239</td>
           <td><code>cachedreadaccessor_unittest</code> fails on <code>free()</code> call on Ubuntu 16.04</td>
           <td>Increased the size of a buffer that was overflowing</td>
@@ -190,6 +205,11 @@ current asset root without stopping Fusion.</p>
           <td>Fix broken line in cutter script</td>
           <td>Fixed the relevant line</td>
         </tr>
+        <tr>
+          <td>351</td>
+          <td>Portable Globe Cutter fails with a Python error</td>
+          <td>Fixed import errors in the cutter scripts</td>
+        </tr>
       </tbody>
     </table>
   <div class="footer">
@@ -197,7 +217,7 @@ current asset root without stopping Fusion.</p>
     
     <hr />
     </p>
-    <p class="copyright">&copy;2015 Google</p>
+    <p class="copyright">&copy;2017 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -28,22 +28,6 @@
 Open GEE 5.2.0 includes a number of code and library changes to support the open source effort.</p>
 <!-- TODO: talk about changes between 5.1.3 and 5.2.0 -->
 <!--
-Changes:
--tif versions of tutorial files
--separate tutorial files from main repo
--unbundle third party libraries: python, cython, PIL, setuptools, numpy, lots of others
--remove old installers, create new installers
--rewrite all copyrights in source files, remove Google EULA
--update documentation to take out Google links
--query GDAL for MrSID and JPEG2000 support
--open gee website
--lots of documentation updates
--remove obsolete and experimental code
--updates for building on supported platforms
--download tutorial files separately
--new portable build process
--Add "--listvolumes" flag to geconfigureassetroot utility 
-
 Issues fixed:
 Fix fusing a mosaic with GDAL 2.x: implements IReadBlock() API for khVRRasterBand.
 Shapefiles cannot be read unless they have write access
@@ -81,6 +65,13 @@ gefusion crash when opening non supported type of file #342
   </h5>
     <p><strong>Open Sourcing</strong>. Open GEE 5.2.0 includes a number of changes that were necessary for the open sourcing effort.  This includes a number of library replacements, library unbundling,
 removal of obsolete code and libraries, changes to support new compilers, updates to support git and Github, and several documentation changes.</p>
+    <p><strong>New Installers</strong>. Previous GEE installers used proprietary tools that are not appropriate for open source projects.  Open GEE 5.2.0 includes new installers that run as bash
+scripts.  There are also new build and install scripts for the Portable Server.</p>
+    <p><strong>New Tutorial Files</strong>. Images used in the Fusion tutorial are now provided in both tif and jp2 format.  In addition, the tutorial files are stored and downloaded separately
+from the rest of the Open GEE code.</p>
+    <p><strong>OpenGEE.org Web Site</strong>. The Open GEE repository now includes the source code for the Open GEE website, which can be viewed at <a href="http://www.opengee.org">http://www.opengee.org</a>.</p>
+    <p><strong>New --listvolumes Flag in geconfigureassetroot</strong>. The geconfigureassetroot utility now supports a --listvolumes flag that allows users to display the configured volumes for the
+current asset root without stopping Fusion.</p>
   <h5>
     <p id="supported_5.2.0">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -26,30 +26,6 @@
 <h2>Release notes: Open GEE 5.2.0</h2>
 <p>Open GEE 5.2.0 the first open source release of Google Earth Enterprise.  It is designed to be compatible with GEE 5.1.3 with the exception of MrSID support.
 Open GEE 5.2.0 includes a number of code and library changes to support the open source effort.</p>
-<!-- TODO: talk about changes between 5.1.3 and 5.2.0 -->
-<!--
-Known issues:
-333 portable on MacOS
-Incorrect versions of libraries loaded #326
-167, 335 Form errors creating resources
-Errors in install_fusion.sh script #308
-Documentation to clean up
-The Portable Server Page at <http://localhost:9335/local/setup.html> Uses Obsolete REST Calls #320
-Mercator maps published with Google basemap fail to load #267
-Automasking fails for images stored with UTM projection #254
-Google Earth Server fails to load Admin console when there is an invalid link to a published portable file #252
-Default Imagery and Terrain file filters ignore files with the ".tiff" extension #247
-Geserver raises error executing apache_logs.pyc #237
-Some vector layer options are not saved #203
-Icons are not displayed on lines in vector projects #202
-Some tiles are displayed incorrectly in the enterprise client when terrain is enabled #201
-stage_install fails on the tutorial files when /home and /tmp are on different file systems #200
-Improve FileUnpacker Handling of Invalid Files #9
-Bug in Portable UI when canceling #6
-Google basemap fails to load in 2D Mercator Maps #4
-Geserver Error : New version of same DB publish to existing target name #341
-gefusion crash when opening non supported type of file #342
--->
   <h5>
     <p id="overview_5">New Features</p>
   </h5>
@@ -118,8 +94,53 @@ current asset root without stopping Fusion.</p>
         </tr>
         <tr>
           <td>2</td>
-          <td>MrSID imagery is not supported.</td>
+          <td>MrSID imagery is not supported</td>
           <td>MrSID support can be added by purchasing a proprietary GDAL plugin that supports MrSID and modifying the build process to include the plugin.</td>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td>Google basemap fails to load in 2D Mercator Maps</td>
+          <td>Obtain a valid Google Maps API key and include it in <code>/opt/google/gehttpd/htdocs/maps/maps_google.html</code>.</td>
+        </tr>
+        <tr>
+          <td>6</td>
+          <td>The Portable UI reports an error any time a cut is canceled, even if the cancel was successful</td>
+          <td>Ignore the misleading error message.</td>
+        </tr>
+        <tr>
+          <td>200</td>
+          <td>stage_install fails on the tutorial files when <code>/home</code> and <code>/tmp</code> are on different file systems</td>
+          <td>Ensure that <code>/home</code> and <code>/tmp</code> are on the same file system or download the tutorial files to <code>/opt/google/share/tutorials/fusion/</code> after installing Fusion.</td>
+        </tr>
+        <tr>
+          <td>254</td>
+          <td>Automasking fails for images stored with UTM projection</td>
+          <td>Use GDAL to convert the images to a different projection before ingesting them into Fusion.</td>
+        </tr>
+        <tr>
+          <td>320</td>
+          <td>The Portable Server web page uses obsolete REST calls</td>
+          <td>Do not use the buttons on the Portable Server web interface for adding remote servers or broadcasting to remote servers as these features are no longer supported.</td>
+        </tr>
+        <tr>
+          <td>326</td>
+          <td>Libraries may be loaded from the wrong directory</td>
+          <td>Delete any library versions that should not be loaded or use LD_LIBRARY_PATH to load libraries from <code>/opt/google/lib</code>.</td>
+        </tr>
+        <tr>
+          <td>333</td>
+          <td>Portable Server is not supported on MacOS</td>
+          <td>Building and running Portable Server on MacOS should be possible with minimal changes.</td>
+        </tr>
+        <tr>
+          <td>335, 359</td>
+          <td>If there is an error while saving a resource, the resource cannot be saved again even if the error is resolved</td>
+          <td>Close the resource form and open it again to make the save option available again.</td>
+        </tr>
+        <tr>
+          <td>342</td>
+          <td>Fusion crashes when opening an unsupported file type</td>
+          <td>Do not open unsupported file types.</td>
         </tr>
       </tbody>
     </table>
@@ -137,7 +158,7 @@ current asset root without stopping Fusion.</p>
         <tr>
           <td>(none)</td>
           <td>Error when fusing a mosaic in GDAL 2.x</td>
-          <td>Implement IReadBlock() API for khVRRasterBand</td>
+          <td>Implemented <code>IReadBlock()</code> API for <code>khVRRasterBand</code></td>
         </tr>
         <tr>
           <td>16</td>
@@ -161,7 +182,7 @@ current asset root without stopping Fusion.</p>
         </tr>
         <tr>
           <td>239</td>
-          <td>cachedreadaccessor_unittest fails on free() call on Ubuntu 16.04</td>
+          <td><code>cachedreadaccessor_unittest</code> fails on <code>free()</code> call on Ubuntu 16.04</td>
           <td>Increased the size of a buffer that was overflowing</td>
         </tr>
         <tr>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -28,16 +28,6 @@
 Open GEE 5.2.0 includes a number of code and library changes to support the open source effort.</p>
 <!-- TODO: talk about changes between 5.1.3 and 5.2.0 -->
 <!--
-Issues fixed:
-Fix fusing a mosaic with GDAL 2.x: implements IReadBlock() API for khVRRasterBand.
-Shapefiles cannot be read unless they have write access
-Fusion UI and geserveradmin get segmentation fault if they cannot contact Publish module #26 - pass correct data type to cURL library
-cachedreadaccessor_unittest fails on free() call on Ubuntu 16.04 #239 (buffer was too small)
-Portable Globe Cutter fails with a Python error #351 - fix paths
-Once failed to save a new resource, the resource cannot be saved again #317 - partial fixes
-Fix broken line in cutter script. #243
-Update date parsing to handle default date string. #179
-
 Known issues:
 333 portable on MacOS
 Incorrect versions of libraries loaded #326
@@ -143,6 +133,41 @@ current asset root without stopping Fusion.</p>
           <th>Number</th>
           <th class="narrow">Description</th>
           <th>Resolution</th>
+        </tr>
+        <tr>
+          <td>(none)</td>
+          <td>Error when fusing a mosaic in GDAL 2.x</td>
+          <td>Implement IReadBlock() API for khVRRasterBand</td>
+        </tr>
+        <tr>
+          <td>16</td>
+          <td>gefusionuser must have write access to vector files</td>
+          <td>Removed the requirement for write access</td>
+        </tr>
+        <tr>
+          <td>26</td>
+          <td>Fusion segmentation faults when trying to push and the server is not available</td>
+          <td>Pass the correct data type to cURL function</td>
+        </tr>
+        <tr>
+          <td>167</td>
+          <td>If save fails because the Fusion server is not running, the user cannot save again even if the problem is fixed</td>
+          <td>Updated state management in resource creation form</td>
+        </tr>
+        <tr>
+          <td>179</td>
+          <td>Update date parsing to fix default date handling</td>
+          <td>Added code to handle default dates in Fusion tools</td>
+        </tr>
+        <tr>
+          <td>239</td>
+          <td>cachedreadaccessor_unittest fails on free() call on Ubuntu 16.04</td>
+          <td>Increased the size of a buffer that was overflowing</td>
+        </tr>
+        <tr>
+          <td>243</td>
+          <td>Fix broken line in cutter script</td>
+          <td>Fixed the relevant line</td>
         </tr>
       </tbody>
     </table>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -29,7 +29,7 @@ Open GEE 5.2.0 includes a number of code and library changes to support the open
   <h5>
     <p id="overview_5">New Features</p>
   </h5>
-    <p><strong>Open Sourcing</strong>. Open GEE 5.2.0 includes a number of changes that were necessary for the open sourcing effort.  This includes a number of library replacements, library unbundling,
+    <p><strong>Open Sourcing</strong>. Open GEE 5.2.0 includes a number of changes that were necessary for the open sourcing effort.  This includes several library replacements, library unbundling,
 removal of obsolete code and libraries, changes to support new compilers, updates to support git and Github, and several documentation changes.</p>
     <p><strong>New Installers</strong>. Previous GEE installers used proprietary tools that are not appropriate for open source projects.  Open GEE 5.2.0 includes new installers that run as bash
 scripts.  There are also new build and install scripts for the Portable Server.</p>

--- a/docs/geedocs/answer/7160000.html
+++ b/docs/geedocs/answer/7160000.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8"/>
+<title>Release notes: Open GEE 5.2.0</title>
+<link rel="stylesheet" href="../css/styles.css" type="text/css" media="all" />
+<link rel="stylesheet" href="../css/containers.css" type="text/css" media="all" />
+</head>
+<body>
+<!-- 7160000.html -->
+<div class="container">
+<div class="sidebar1">
+  <p class="sidebar-toc"><a href="../answer/7160000.html" class="current-file">Open GEE 5.2.0</a></p>
+  <p class="sidebar-toc"><a href="../answer/7159245.html">GEE 5.1.3</a></p>
+  <p class="sidebar-toc"><a href="../answer/6259403.html">GEE 5.1.2</a></p>
+  <p class="sidebar-toc"><a href="../answer/6159443.html">GEE 5.1.1</a></p>
+  <p class="sidebar-toc"><a href="../answer/6078762.html">GEE 5.1.0</a></p>
+  <p class="sidebar-toc"><a href="../answer/6053170.html">GEE 5.0.2</a></p>
+  <p class="sidebar-toc"><a href="../answer/4556704.html">GEE 5.0.1</a></p>
+  <p class="sidebar-toc"><a href="../answer/3424202.html">GEE 5.0</a></p>
+</div>
+<div class="content">
+<a name="top_of_file"></a>
+<p><img src="../art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>
+<h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
+<h2>Release notes: Open GEE 5.2.0</h2>
+<p>Open GEE 5.2.0 the first open source release of Google Earth Enterprise.  It is designed to be compatible with GEE 5.1.3 with the exception of MrSID support.
+Open GEE 5.2.0 includes a number of code and library changes to support the open source effort.</p>
+<!-- TODO: talk about changes between 5.1.3 and 5.2.0 -->
+<!--
+Changes:
+-tif versions of tutorial files
+-separate tutorial files from main repo
+-unbundle third party libraries: python, cython, PIL, setuptools, numpy, lots of others
+-remove old installers, create new installers
+-rewrite all copyrights in source files, remove Google EULA
+-update documentation to take out Google links
+-query GDAL for MrSID and JPEG2000 support
+-open gee website
+-lots of documentation updates
+-remove obsolete and experimental code
+-updates for building on supported platforms
+-download tutorial files separately
+-new portable build process
+-Add "--listvolumes" flag to geconfigureassetroot utility 
+
+Issues fixed:
+Fix fusing a mosaic with GDAL 2.x: implements IReadBlock() API for khVRRasterBand.
+Shapefiles cannot be read unless they have write access
+Fusion UI and geserveradmin get segmentation fault if they cannot contact Publish module #26 - pass correct data type to cURL library
+cachedreadaccessor_unittest fails on free() call on Ubuntu 16.04 #239 (buffer was too small)
+Portable Globe Cutter fails with a Python error #351 - fix paths
+Once failed to save a new resource, the resource cannot be saved again #317 - partial fixes
+Fix broken line in cutter script. #243
+Update date parsing to handle default date string. #179
+
+Known issues:
+333 portable on MacOS
+Incorrect versions of libraries loaded #326
+167, 335 Form errors creating resources
+Errors in install_fusion.sh script #308
+Documentation to clean up
+The Portable Server Page at <http://localhost:9335/local/setup.html> Uses Obsolete REST Calls #320
+Mercator maps published with Google basemap fail to load #267
+Automasking fails for images stored with UTM projection #254
+Google Earth Server fails to load Admin console when there is an invalid link to a published portable file #252
+Default Imagery and Terrain file filters ignore files with the ".tiff" extension #247
+Geserver raises error executing apache_logs.pyc #237
+Some vector layer options are not saved #203
+Icons are not displayed on lines in vector projects #202
+Some tiles are displayed incorrectly in the enterprise client when terrain is enabled #201
+stage_install fails on the tutorial files when /home and /tmp are on different file systems #200
+Improve FileUnpacker Handling of Invalid Files #9
+Bug in Portable UI when canceling #6
+Google basemap fails to load in 2D Mercator Maps #4
+Geserver Error : New version of same DB publish to existing target name #341
+gefusion crash when opening non supported type of file #342
+-->
+  <h5>
+    <p id="overview_5">New Features</p>
+  </h5>
+    <p><strong>Open Sourcing</strong>. Open GEE 5.2.0 includes a number of changes that were necessary for the open sourcing effort.  This includes a number of library replacements, library unbundling,
+removal of obsolete code and libraries, changes to support new compilers, updates to support git and Github, and several documentation changes.</p>
+  <h5>
+    <p id="supported_5.2.0">Supported Platforms</p>
+  </h5>
+  <p>The Open GEE 5.2.0 release is supported on 64-bit versions of the following operating systems:</p>
+    <ul>
+      <li>Red Hat Enterprise Linux versions 7.x, including the most recent security patches</li>
+      <li>CentOS 7.x</li>
+      <li>Ubuntu 14.04 LTS and 16.04 LTS</li>
+    </ul>
+    <p>Google Earth Enterprise 5.2.0 is compatible with Google Earth Enterprise Client (EC) version 7.1.5 and above.</p>
+  <h5>
+    <p id="library_updates_5.2.0">New and Updated Libraries</p>
+  </h5>
+    Open GEE 5.2.0 includes extensive library changes.  This list may be incomplete.
+    <table class="nice-table">
+      <tbody>
+        <tr>
+          <th>Library</th>
+          <th>Version</th>
+          <th>New or Updated</th>
+        </tr>
+        <tr>
+          <td>Google Maps API V3</td>
+          <td>3.29</td>
+          <td>Updated</td>
+        </tr>
+        <tr>
+          <td>mod_wsgi</td>
+          <td>4.5.14</td>
+          <td>Updated</td>
+        </tr>
+        <tr>
+          <td>OpenJPEG</td>
+          <td>2.1.2</td>
+          <td>New</td>
+        </tr>
+        <tr>
+          <td>QT</td>
+          <td>3.3.8b-free</td>
+          <td>Updated</td>
+        </tr>
+      </tbody>
+    </table>
+  <h5>
+  <h5>
+    <p id="known_issues_5.2.0">Known Issues</p>
+  </h5>
+    <table class="nice-table">
+      <tbody>
+        <tr>
+          <th>Number</th>
+          <th class="narrow">Description</th>
+          <th>Workaround</th>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>MrSID imagery is not supported.</td>
+          <td>MrSID support can be added by purchasing a proprietary GDAL plugin that supports MrSID and modifying the build process to include the plugin.</td>
+        </tr>
+      </tbody>
+    </table>
+  <h5>
+    <p id="resolved_issues_5.2.0">Resolved Issues</p>
+  </h5>
+  <div>
+    <table class="nice-table">
+      <tbody>
+        <tr>
+          <th>Number</th>
+          <th class="narrow">Description</th>
+          <th>Resolution</th>
+        </tr>
+      </tbody>
+    </table>
+  <div class="footer">
+    <p class="BackToTop"><a href="#top_of_file">Back to top</a>
+    
+    <hr />
+    </p>
+    <p class="copyright">&copy;2015 Google</p>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/geedocs/index.html
+++ b/docs/geedocs/index.html
@@ -27,11 +27,11 @@
     <h4><a href="answer/4580164.html">Portable</a></h4>
     <h4><a href="answer/6014171.html">Developers</a></h4>
     <h4><a href="answer/6121524.html">Troubleshooting and error messages</a></h4>
-    <h4><a href="answer/7159245.html">Release notes</a></h4>
+    <h4><a href="answer/7160000.html">Release notes</a></h4>
   </div>
   <div class="footer">
     <hr />
-    <p class="copyright">&copy;2015 Google</p>
+    <p class="copyright">&copy;2017 Google</p>
   </div>
 </div>
 </body>


### PR DESCRIPTION
This PR includes the proposed release notes for Open GEE 5.2.0. The release notes may also need a last minute update for any bugs we find during testing; those can be handled on a different PR.

This should be merged into the release branch when it is available so that the release notes will not be available on the website until the release is done.

You can see the new release notes here: https://tst-lsavoie.github.io/earthenterprise/geedocs/answer/7160000.html.