### PR TITLE
Fix short version number

### DIFF
--- a/earth_enterprise/src/fusion_version.txt
+++ b/earth_enterprise/src/fusion_version.txt
@@ -21,4 +21,4 @@
 # 1st) full version number: e.g., 3.1.2.3,
 # 2nd) is short number (i.e., drop trailing 0's, i.e., 3.1.0 -> 3.1, or 4.0.0 -> 4)
 5.2.0
-5.2.0
+5.2


### PR DESCRIPTION
Fixes the short version number in fusion_version.txt to match what the comment says.  I don't think the short version number is used anywhere, but I don't want to make unnecessary changes right before a release.  I wrote #368 to take this out for 5.2.1 when we'll have more time for testing.