### PR TITLE
portable build failure - CentOS 7 - old version of pexpect #431

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.6
+#!/usr/bin/python
 #
 # Copyright 2017 Google Inc.
 #

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
@@ -20,6 +20,9 @@
 import os
 import pexpect
 
+""" Try loading fdpexpect for version 3.* and above.
+    if not successful, fallback to fdpexpect from older pexpect package.
+"""
 try:
    import pexpect.fdpexpect as fdpexpect
 except ImportError:

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
@@ -20,9 +20,8 @@
 import os
 import pexpect
 
-""" Try loading fdpexpect for version 3.* and above.
-    if not successful, fallback to fdpexpect from older pexpect package.
-"""
+# Try loading fdpexpect for version 3.* and above.
+# if not successful, fallback to fdpexpect from older pexpect package.
 try:
    import pexpect.fdpexpect as fdpexpect
 except ImportError:

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.6
+#!/usr/bin/python
 #
 # Copyright 2017 Google Inc.
 #
@@ -19,7 +19,12 @@
 
 import os
 import pexpect
-import pexpect.fdpexpect
+
+try:
+   import pexpect.fdpexpect as fdpexpect
+except ImportError:
+   import fdpexpect
+	
 import subprocess
 import sys
 
@@ -43,8 +48,8 @@ def ExecuteCmd(os_cmd, use_shell=False):
   try:
     process = subprocess.Popen(os_cmd, stdin=None, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE, bufsize=0, shell=use_shell)
-    stdout_stream = pexpect.fdpexpect.fdspawn(process.stdout)
-    stderr_stream = pexpect.fdpexpect.fdspawn(process.stderr)
+    stdout_stream = fdpexpect.fdspawn(process.stdout)
+    stderr_stream = fdpexpect.fdspawn(process.stderr)
     # process.returncode is None until the subprocess completes. Then, it gets
     # filled in with the subprocess exit code.
     while process.returncode is None:


### PR DESCRIPTION
resolves #431 