### PR TITLE
#435:   change build_lib compile flags to include -std=gnu++98

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Linux/build_lib
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Linux/build_lib
@@ -1,5 +1,5 @@
 cp ../shared/* .
 swig -python -c++ glc_unpacker.i
-g++ -O2 -fPIC -I/usr/include/python2.7 -c glc_unpacker_wrap.cxx
-g++ -O2 -c -fPIC glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
-g++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.so
+g++ -std=gnu++98 -O2 -fPIC -I/usr/include/python2.7 -c glc_unpacker_wrap.cxx
+g++ -std=gnu++98 -O2 -c -fPIC glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
+g++ -std=gnu++98 -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.so

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Mac/build_lib
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Mac/build_lib
@@ -1,5 +1,5 @@
 cp ../shared/* .
 swig -python -c++ glc_unpacker.i
-g++ -arch x86_64 -c glc_unpacker_wrap.cxx -I/usr/include/python2.6 -I/usr/lib/python2.6
-g++ -arch x86_64 -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
-g++ -arch x86_64 -bundle -flat_namespace -undefined suppress -o _glc_unpacker.so glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o 
+g++ -std=gnu++98 -arch x86_64 -c glc_unpacker_wrap.cxx -I/usr/include/python2.6 -I/usr/lib/python2.6
+g++ -std=gnu++98 -arch x86_64 -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
+g++ -std=gnu++98 -arch x86_64 -bundle -flat_namespace -undefined suppress -o _glc_unpacker.so glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o 

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
@@ -1,6 +1,6 @@
 copy /Y ..\shared\* .
 copy /Y ..\Windows\khTypes.h .
 swig -python -c++ glc_unpacker.i
-g++ -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
-g++ -c glc_unpacker_wrap.cxx -I{exec_prefix}\include
-g++ -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L{exec_prefix}\libs -lpython27
+g++ -std=gnu++98 -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
+g++ -std=gnu++98 -c glc_unpacker_wrap.cxx -I{exec_prefix}\include
+g++ -std=gnu++98 -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L{exec_prefix}\libs -lpython27


### PR DESCRIPTION
Fixes #435 

Portable wasn't compiling with newer g++ versions , so addition of flag -std=gnu++98 fixed compiler compatibility issues 