### PR TITLE
Script for building release archives

### DIFF
--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 # This script creates archive files that can be distributed as a release. The
-# files that github provides do not include files stored in git lfs, so this
-# process is required to create working archives that we can publish on github.
-# The resulting archives will be placed in the current directory.  Because this
-# script downloads and packages a large repo it may take a long time to run.
+# automatically generated files on the github releases page do not include the
+# files stored in git lfs, so this process is required to create working
+# archives that we can publish on the github releases page.
+
+# This script places the generated archives in the current directory.  Because
+# this script downloads and packages a large repo it may take a long time to
+# run.
 
 # This script works under /tmp and it assumes that previous artifacts under /tmp
 # (such as previously downloaded repos or previously created archives) can be

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -37,7 +37,7 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" --depth 1 https://github.com/google/${REPO_NAME}.git || exit
+git clone -b "${1}" --depth 1 "https://github.com/google/${REPO_NAME}.git" || exit
 
 # Remove the git-related files from the repo
 find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -20,6 +20,14 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
+# Verify that git lfs is installed
+GIT_LFS_ENV=`git lfs env`
+SMUDGE_HOOK=`expr match "${GIT_LFS_ENV}" '.*git config filter\.lfs\.clean = "\(.*\)".*'`
+if [ -z "${SMUDGE_HOOK}" ]; then
+  echo "You must install git lfs before running this script."
+  exit
+fi
+
 REPO_NAME="earthenterprise"
 CLONE_DIR="/tmp"
 
@@ -30,9 +38,9 @@ RUN_DIR=`pwd`
 # Download the repository
 cd ${CLONE_DIR}
 rm -Rf ${REPO_NAME}
-git clone git@github.com:google/${REPO_NAME}.git
-cd ${REPO_NAME}
-git checkout ${1}
+git clone git@github.com:google/${REPO_NAME}.git || exit
+cd ${REPO_NAME} || exit
+git checkout ${1} || exit
 
 # Remove the git-related files from the repo
 FILES=`find . -name ".git*"`

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -40,14 +40,9 @@ cd "${CLONE_DIR}"
 git clone -b "${1}" --depth 1 git@github.com:google/${REPO_NAME}.git || exit
 
 # Remove the git-related files from the repo
-cd "${REPO_NAME}"
-FILES=`find . -name ".git*"`
-for FILE in ${FILES}; do
-  rm -Rf "${FILE}"
-done
+find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +
 
 # Create the archives
-cd "${CLONE_DIR}"
 tar czf "${TAR_FILE}" "${REPO_NAME}"
 zip -rq "${ZIP_FILE}" "${REPO_NAME}"
 

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -1,22 +1,17 @@
 #!/bin/bash
 
 # This script creates archive files that can be distributed as a release. The
-# automatically generated files on the github releases page do not include the
-# files stored in git lfs, so this process is required to create working
-# archives that we can publish on the github releases page.
+# automatically generated files on the GitHub releases page do not include the
+# files stored in Git LFS, so this process is required to create working
+# archives that we can publish on the GitHub releases page.
 
 # This script places the generated archives in the current directory.  Because
 # this script downloads and packages a large repo it may take a long time to
 # run.
 
-# This script works under /tmp and it assumes that previous artifacts under /tmp
-# (such as previously downloaded repos or previously created archives) can be
-# safely deleted.
-
 if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <committish>"
-  echo "where <committish> is a commit, branch, or tag that defines the release"
-  echo "to be archived."
+  echo "Usage: $0 <branch>"
+  echo "where <branch> is a branch or tag that defines the release to be archived."
   exit 1
 fi
 
@@ -29,33 +24,32 @@ if [ -z "${SMUDGE_HOOK}" ]; then
 fi
 
 REPO_NAME="earthenterprise"
-CLONE_DIR="/tmp"
-
 TAR_FILE=${REPO_NAME}.tar.gz
 ZIP_FILE=${REPO_NAME}.zip
 RUN_DIR=`pwd`
 
+# Make a temporary directory
+CLONE_DIR=`mktemp -d`
+
 # Download the repository
-cd ${CLONE_DIR}
-rm -Rf ${REPO_NAME}
-git clone git@github.com:google/${REPO_NAME}.git || exit
-cd ${REPO_NAME} || exit
-git checkout ${1} || exit
+cd "${CLONE_DIR}"
+git clone -b "${1}" --depth 1 git@github.com:google/${REPO_NAME}.git || exit
 
 # Remove the git-related files from the repo
+cd "${REPO_NAME}"
 FILES=`find . -name ".git*"`
 for FILE in ${FILES}; do
-  rm -Rf ${FILE}
+  rm -Rf "${FILE}"
 done
 
 # Create the archives
-cd ${CLONE_DIR}
-rm -f ${TAR_FILE} ${ZIP_FILE}
-tar czf ${TAR_FILE} ${REPO_NAME}
-zip -rq ${ZIP_FILE} ${REPO_NAME}
+cd "${CLONE_DIR}"
+tar czf "${TAR_FILE}" "${REPO_NAME}"
+zip -rq "${ZIP_FILE}" "${REPO_NAME}"
 
 # Clean up
-mv ${TAR_FILE} ${RUN_DIR}
-mv ${ZIP_FILE} ${RUN_DIR}
-rm -Rf ${REPO_NAME}
+mv "${TAR_FILE}" "${RUN_DIR}"
+mv "${ZIP_FILE}" "${RUN_DIR}"
+cd
+rm -Rf "${CLONE_DIR}"
 

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -37,7 +37,7 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" --depth 1 git@github.com:google/${REPO_NAME}.git || exit
+git clone -b "${1}" --depth 1 https://github.com/google/${REPO_NAME}.git || exit
 
 # Remove the git-related files from the repo
 find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script creates archive files that can be distributed as a release. The
+# files that github provides do not include files stored in git lfs, so this
+# process is required to create working archives that we can publish on github.
+# The resulting archives will be placed in the current directory.  Because this
+# script downloads and packages a large repo it may take a long time to run.
+
+# This script works under /tmp and it assumes that previous artifacts under /tmp
+# (such as previously downloaded repos or previously created archives) can be
+# safely deleted.
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <committish>"
+  echo "where <committish> is a commit, branch, or tag that defines the release"
+  echo "to be archived."
+  exit 1
+fi
+
+REPO_NAME="earthenterprise"
+CLONE_DIR="/tmp"
+
+TAR_FILE=${REPO_NAME}.tar.gz
+ZIP_FILE=${REPO_NAME}.zip
+RUN_DIR=`pwd`
+
+# Download the repository
+cd ${CLONE_DIR}
+rm -Rf ${REPO_NAME}
+git clone git@github.com:google/${REPO_NAME}.git
+cd ${REPO_NAME}
+git checkout ${1}
+
+# Remove the git-related files from the repo
+FILES=`find . -name ".git*"`
+for FILE in ${FILES}; do
+  rm -Rf ${FILE}
+done
+
+# Create the archives
+cd ${CLONE_DIR}
+rm -f ${TAR_FILE} ${ZIP_FILE}
+tar czf ${TAR_FILE} ${REPO_NAME}
+zip -rq ${ZIP_FILE} ${REPO_NAME}
+
+# Clean up
+mv ${TAR_FILE} ${RUN_DIR}
+mv ${ZIP_FILE} ${RUN_DIR}
+rm -Rf ${REPO_NAME}
+

--- a/build_release_archive.sh
+++ b/build_release_archive.sh
@@ -9,6 +9,10 @@
 # this script downloads and packages a large repo it may take a long time to
 # run.
 
+# Example usage: to create archives for 5.2.0 (which is on the release_5.2.0)
+# branch, run
+# ./build_release_archive.sh release_5.2.0
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <branch>"
   echo "where <branch> is a branch or tag that defines the release to be archived."


### PR DESCRIPTION
The automatically generated archives produced by github do not
include the git lfs files, so they are not suitable for building
the release.  Thus, we make our own archive files.  This script
provides an easy way to do that.