### PR TITLE
Removed short version number

### DIFF
--- a/earth_enterprise/src/fusion_version.txt
+++ b/earth_enterprise/src/fusion_version.txt
@@ -17,8 +17,6 @@
 # compiled source in earth_enterprise/src.
 # You will also need to update the installer separately in:
 #  earth_enterprise/installer/
-# Format is 2 lines (comment lines ignored):
-# 1st) full version number: e.g., 3.1.2.3,
-# 2nd) is short number (i.e., drop trailing 0's, i.e., 3.1.0 -> 3.1, or 4.0.0 -> 4)
+# Format is 1 line (comment lines ignored):
+#   full version number: e.g., 3.1.2.3, 5.2.4, etc
 5.2.0
-5.2


### PR DESCRIPTION
Fixes  #368

Tested building (including portable) and also ran all unit tests.  The only thing that seems to use this is a script called update_fusion_version.py that updates install files that no longer seem to exist ('installer/config/GoogleEarthInstaller.iap_xml', 'installer/config/GoogleFusionInstaller.iap_xml',  'installer/config/GoogleFusionToolsInstaller.iap_xml'). 
