### PR TITLE
Added travis_wait to prevent timeout on Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq libperl4-corelibs-perl libtool xorg-dev doxygen python-dev alien swig libgtest-dev libstdc++6 libxml2-dev gettext libxinerama-dev libxft-dev libxrandr-dev libxcursor-dev libgdbm-dev libc6 libc6-dev libmng-dev zlib1g-dev libcap-dev libpng12-0 libpng12-dev freeglut3-dev flex libx11-dev bison++ bisonc++ libjpeg-dev libjpeg8-dev python2.7 python2.7-dev python2.7-psycopg2 libogdi3.2-dev libgif-dev libxerces-c-dev libgeos-dev libgeos++-dev libfreetype6 libfreetype6-dev python-imaging libproj-dev python-setuptools libgif-dev libxerces-c-dev libcap-dev libpq-dev openssl libxml2-utils libxmu-dev
 
-script: skip
+script: echo "Running build..."
 
 jobs:
   include:
     - stage: gee build
-    - script: 
-      - cd earth_enterprise
-      - scons -j3 release=1 build > build.log
+      script: 
+        - cd earth_enterprise 
+        - scons -j3 release=1 build > build.log
     - stage: gee-test
-    - script:
+      script:
       - cd earth_enterprise/src/NATIVE-REL-x86_64/bin/tests
       - travis_wait 20 ./RunAllTests.pl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
       script: 
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
+        - if [ -f $HOME/cache/third_party.tgz ]; then ls -a NATIVE-REL-x86_64; fi
         - scons -j3 release=1 third_party > build.log
         - mkdir -p $HOME/cache
         - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64
@@ -29,6 +30,7 @@ jobs:
       script:
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
+        - if [ -f $HOME/cache/third_party.tgz ]; then ls -a NATIVE-REL-x86_64; fi
         - cd ..
         - scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script: echo "Running build..."
 
 cache:
   files:
-    $HOME/third_party.tgz
+    third_party.tgz
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - stage: build third party
       script: 
         - cd earth_enterprise/src 
-        - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
+        - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
         - scons -j3 release=1 third_party > build.log
         - mkdir -p $HOME/cache
         - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - if [ -f $HOME/cache/third_party.tgz ]; then ls -a NATIVE-REL-x86_64; fi
         - scons -j3 release=1 third_party > build.log
         - mkdir -p $HOME/cache
-        - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64
+        - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64 .sconsign.dblite .sconf_temp
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
         - cd earth_enterprise/src 
         - if [ -f $HOME/third_party.tgz ]; then tar xvf $HOME/third_party.tgz yes; fi
         - scons -j3 release=1 third_party > build.log
-        - tar cvfz $HOME/third_party.tgz NATIVE-REL-x86_64]
+        - tar cvfz $HOME/third_party.tgz NATIVE-REL-x86_64
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
       script: 
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
-        - if [ -f $HOME/cache/third_party.tgz ]; then ls -a NATIVE-REL-x86_64; fi
         - scons -j3 release=1 third_party > build.log
         - mkdir -p $HOME/cache
         - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64 .sconsign.dblite .sconf_temp
@@ -30,7 +29,6 @@ jobs:
       script:
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
-        - if [ -f $HOME/cache/third_party.tgz ]; then ls -a NATIVE-REL-x86_64; fi
         - cd ..
         - scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,22 @@ before_install:
 script: echo "Running build..."
 
 cache:
+  timeout: 600
   files:
-    third_party.tgz
+    - third_party.tgz
 
 jobs:
   include:
     - stage: build third party
       script: 
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz yes; fi
+        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
         - scons -j3 release=1 third_party > build.log
         - tar cfz $HOME/third_party.tgz NATIVE-REL-x86_64
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz yes; fi
+        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
         - cd ..
         - scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,26 @@ before_install:
 
 script: echo "Running build..."
 
+cache:
+  files:
+    $HOME/third_party.tgz
+
 jobs:
   include:
-    - stage: gee build
+    - stage: build third party
       script: 
-        - cd earth_enterprise 
-        - scons -j3 release=1 build > build.log
-    - stage: gee-test
+        - cd earth_enterprise/src 
+        - if [ -f $HOME/third_party.tgz ]; then tar xvf $HOME/third_party.tgz yes; fi
+        - scons -j3 release=1 third_party > build.log
+        - tar cvfz $HOME/third_party.tgz NATIVE-REL-x86_64]
+    - stage: build fusion and test
       script:
-      - cd earth_enterprise/src/NATIVE-REL-x86_64/bin/tests
-      - travis_wait 20 ./RunAllTests.pl
+        - cd earth_enterprise/src 
+        - if [ -f $HOME/third_party.tgz ]; then tar xvf $HOME/third_party.tgz yes; fi
+        - cd ..
+        - scons -j3 release=1 build > build.log
+        - cd src/NATIVE-REL-x86_64/bin/tests
+        - travis_wait 20 ./RunAllTests.pl
 
 notifications:
   slack: opengee:YjzzzTnc7pgITPsrQPATIGwc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script: echo "Running build..."
 cache:
   timeout: 600
   directories:
-    - cache
+    - $HOME/cache
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_script:
 
 jobs:
   include:
-    - stage: build
+    - stage: gee-build
     - script: scons -j3 release=1 build > build.log
-    - stage: test
+    - stage: gee-test
     - script:
       - cd src/NATIVE-REL-x86_64/bin/tests
       - travis_wait 20 ./RunAllTests.pl

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ before_install:
 before_script:
   - cd earth_enterprise
 
-script:
-  - scons -j3 release=1 build > build.log
-  - cd src/NATIVE-REL-x86_64/bin/tests
-  - travis_wait 20 ./RunAllTests.pl
+jobs:
+  include:
+    - stage: build
+    - script: scons -j3 release=1 build > build.log
+    - stage: test
+    - script:
+      - cd src/NATIVE-REL-x86_64/bin/tests
+      - travis_wait 20 ./RunAllTests.pl
 
 notifications:
   slack: opengee:YjzzzTnc7pgITPsrQPATIGwc

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,18 @@ jobs:
       script: 
         - cd earth_enterprise/src 
         - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
-        - scons -j3 release=1 third_party > build.log
+        - ls $HOME
+        #- scons -j3 release=1 third_party > build.log
+        - touch NATIVE-REL-x86_64
         - tar cfz $HOME/third_party.tgz NATIVE-REL-x86_64
+        - ls $HOME
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 
         - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
+        - ls $HOME
         - cd ..
-        - scons -j3 release=1 build > build.log
+        #- scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests
         - travis_wait 20 ./RunAllTests.pl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
         - ls $HOME/cache
         #- scons -j3 release=1 third_party > build.log
         - touch NATIVE-REL-x86_64
+        - mkdir -p $HOME/cache
         - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64
         - ls $HOME/cache
     - stage: build fusion and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,25 @@ script: echo "Running build..."
 
 cache:
   timeout: 600
-  files:
-    - third_party.tgz
+  directories:
+    - cache
 
 jobs:
   include:
     - stage: build third party
       script: 
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
-        - ls $HOME
+        - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
+        - ls $HOME/cache
         #- scons -j3 release=1 third_party > build.log
         - touch NATIVE-REL-x86_64
-        - tar cfz $HOME/third_party.tgz NATIVE-REL-x86_64
-        - ls $HOME
+        - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64
+        - ls $HOME/cache
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
-        - ls $HOME
+        - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
+        - ls $HOME/cache
         - cd ..
         #- scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,15 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq libperl4-corelibs-perl libtool xorg-dev doxygen python-dev alien swig libgtest-dev libstdc++6 libxml2-dev gettext libxinerama-dev libxft-dev libxrandr-dev libxcursor-dev libgdbm-dev libc6 libc6-dev libmng-dev zlib1g-dev libcap-dev libpng12-0 libpng12-dev freeglut3-dev flex libx11-dev bison++ bisonc++ libjpeg-dev libjpeg8-dev python2.7 python2.7-dev python2.7-psycopg2 libogdi3.2-dev libgif-dev libxerces-c-dev libgeos-dev libgeos++-dev libfreetype6 libfreetype6-dev python-imaging libproj-dev python-setuptools libgif-dev libxerces-c-dev libcap-dev libpq-dev openssl libxml2-utils libxmu-dev
 
-
-before_script:
-  - cd earth_enterprise
-
 jobs:
   include:
     - stage: gee-build
-    - script: scons -j3 release=1 build > build.log
+    - script: 
+      - cd earth_enterprise
+      - scons -j3 release=1 build > build.log
     - stage: gee-test
     - script:
-      - cd src/NATIVE-REL-x86_64/bin/tests
+      - cd earth_enterprise/src/NATIVE-REL-x86_64/bin/tests
       - travis_wait 20 ./RunAllTests.pl
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq libperl4-corelibs-perl libtool xorg-dev doxygen python-dev alien swig libgtest-dev libstdc++6 libxml2-dev gettext libxinerama-dev libxft-dev libxrandr-dev libxcursor-dev libgdbm-dev libc6 libc6-dev libmng-dev zlib1g-dev libcap-dev libpng12-0 libpng12-dev freeglut3-dev flex libx11-dev bison++ bisonc++ libjpeg-dev libjpeg8-dev python2.7 python2.7-dev python2.7-psycopg2 libogdi3.2-dev libgif-dev libxerces-c-dev libgeos-dev libgeos++-dev libfreetype6 libfreetype6-dev python-imaging libproj-dev python-setuptools libgif-dev libxerces-c-dev libcap-dev libpq-dev openssl libxml2-utils libxmu-dev
 
+script: skip
+
 jobs:
   include:
-    - stage: gee-build
+    - stage: gee build
     - script: 
       - cd earth_enterprise
       - scons -j3 release=1 build > build.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 script:
   - scons -j3 release=1 build > build.log
   - cd src/NATIVE-REL-x86_64/bin/tests
-  - ./RunAllTests.pl
+  - travis_wait 20 ./RunAllTests.pl
 
 notifications:
   slack: opengee:YjzzzTnc7pgITPsrQPATIGwc

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
       script: 
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
-        - ls $HOME/cache
         #- scons -j3 release=1 third_party > build.log
         - touch NATIVE-REL-x86_64
         - mkdir -p $HOME/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ jobs:
     - stage: build third party
       script: 
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xvf $HOME/third_party.tgz yes; fi
+        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz yes; fi
         - scons -j3 release=1 third_party > build.log
-        - tar cvfz $HOME/third_party.tgz NATIVE-REL-x86_64
+        - tar cfz $HOME/third_party.tgz NATIVE-REL-x86_64
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 
-        - if [ -f $HOME/third_party.tgz ]; then tar xvf $HOME/third_party.tgz yes; fi
+        - if [ -f $HOME/third_party.tgz ]; then tar xf $HOME/third_party.tgz yes; fi
         - cd ..
         - scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,15 @@ jobs:
       script: 
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/third_party.tgz; fi
-        #- scons -j3 release=1 third_party > build.log
-        - touch NATIVE-REL-x86_64
+        - scons -j3 release=1 third_party > build.log
         - mkdir -p $HOME/cache
         - tar cfz $HOME/cache/third_party.tgz NATIVE-REL-x86_64
-        - ls $HOME/cache
     - stage: build fusion and test
       script:
         - cd earth_enterprise/src 
         - if [ -f $HOME/cache/third_party.tgz ]; then tar xf $HOME/cache/third_party.tgz; fi
-        - ls $HOME/cache
         - cd ..
-        #- scons -j3 release=1 build > build.log
+        - scons -j3 release=1 build > build.log
         - cd src/NATIVE-REL-x86_64/bin/tests
         - travis_wait 20 ./RunAllTests.pl
 


### PR DESCRIPTION
Splits build into 2 jobs (third_party & fusion build/tests)

This ensures that the build doesn't hit the 50 minute/job timeout. Total build time doesn't have a timeout value.

Test run: https://travis-ci.org/google/earthenterprise/builds/282885682