### PR TITLE
make tutorial owned by gefusionuser:gegroup

### DIFF
--- a/earth_enterprise/tutorial/FusionTutorial/download_tutorial.sh
+++ b/earth_enterprise/tutorial/FusionTutorial/download_tutorial.sh
@@ -13,4 +13,5 @@ if [ ! -d "$SCRIPTDIR/Imagery" ]; then
 	wget "http://data.opengee.org/FusionTutorial-Full.tar.gz" -O "$TMPFILE"
 	tar -xvzf "$TMPFILE" -C "$SCRIPTDIR"
 	rm -f "$TMPFILE"
+	chown -R gefusionuser:gegroup "$SCRIPTDIR"
 fi


### PR DESCRIPTION
This is a very trivial change I am proposing only because geconfigureassetroot complains when creating a new user volume with the src is set to the tutorial as downloaded by the tutorial install script, which downloads and unpacks the tutorial as owned by root.