### PR TITLE
Fix out of bounds error in box filter

### DIFF
--- a/earth_enterprise/src/fusion/tools/boxfilter.cpp
+++ b/earth_enterprise/src/fusion/tools/boxfilter.cpp
@@ -108,10 +108,9 @@ const uchar *BoxFilterTiledImage::GetImageTile(int tile_x, int tile_y,
 // don't have a similar function for the top row of the SAT because the
 // calculation will just wrap around the horizontal band which is set to 0,
 // so the extra elements will have no effect.
-static inline
-void ComputeLeftSAT(int **elem,  // pointer to element in SAT table
-                    uchar value,  // corresponding image value
-                    int prev_row_offset) {  // offset to previous row elem
+inline void ComputeLeftSAT(int **elem,  // pointer to element in SAT table
+                           uchar value,  // corresponding image value
+                           int prev_row_offset) {  // offset to previous row elem
   **elem =
       + *(*elem + prev_row_offset)
       + value;
@@ -120,35 +119,29 @@ void ComputeLeftSAT(int **elem,  // pointer to element in SAT table
 
 // Computes a single SAT element given current values and an offset to
 // the previous row of values in the table.
-static inline
-void ComputeSAT(int *elem,  // pointer to element in SAT table
-                uchar value,  // corresponding image value
-                int prev_row_offset) {  // offset to previous row elem
-  *elem =
-      - *(elem + prev_row_offset - 1)
-      + *(elem + prev_row_offset)
-      + *(elem - 1)
-      + value;
+inline void ComputeSAT(int *elem,  // pointer to element in SAT table
+                       uchar value,  // corresponding image value
+                       int prev_row_offset) {  // offset to previous row elem
+  *elem = - *(elem + prev_row_offset - 1) + *(elem + prev_row_offset)
+          + *(elem - 1)                   + value;
 }
 
 // Computes a horizontal span of entries in the SAT with a single input
 // value, moving ptrs forward.
-static inline
-void ComputeSATSpanValue(int **psat,   // ptr to first SAT element
-                         int length,   // length of the span
-                         uchar value,  // constant image value (border)
-                         int prev_row_offset) {
+inline void ComputeSATSpanValue(int **psat,   // ptr to first SAT element
+                                int length,   // length of the span
+                                uchar value,  // constant image value (border)
+                                int prev_row_offset) {
   for (int *psat_end = (*psat) + length; (*psat) < psat_end; ++(*psat))
     ComputeSAT((*psat), value, prev_row_offset);
 }
 
 // Computes a horizontal span of entries in the SAT with a row of
 // input values, moving ptrs forward.
-static inline
-void ComputeSATSpanValues(int **psat,  // ptr to first SAT element
-                          int length,  // length of the span
-                          const uchar **values,  // ptr to image values
-                          int prev_row_offset) {
+inline void ComputeSATSpanValues(int **psat,  // ptr to first SAT element
+                                 int length,  // length of the span
+                                 const uchar **values,  // ptr to image values
+                                 int prev_row_offset) {
   for (int *psat_end = (*psat) + length; (*psat) < psat_end;
        ++(*psat), ++(*values))
     ComputeSAT((*psat), **values, prev_row_offset);
@@ -180,6 +173,7 @@ void ComputeSATSpanFromLeft(int **psat,  // ptr to the row in the SAT
 //
 // This function is heavily optimized.  It uses a Summed Area Table (SAT) to
 // speed up the calculation of the sum of the pixels within the box.
+// For more information about SATs, see https://en.wikipedia.org/wiki/Summed-area_table.
 // We don't keep the whole SAT in memory, only one sliding horizontal band
 // across the whole image width (it slides down as we process each image tile)
 // and a vertical band (sliding right) for the current row of tiles.

--- a/earth_enterprise/src/fusion/tools/boxfilter.cpp
+++ b/earth_enterprise/src/fusion/tools/boxfilter.cpp
@@ -152,12 +152,11 @@ inline void ComputeSATSpanValues(int **psat,  // ptr to first SAT element
 // forward. The first box_halfw+1 elements are outside the image and are
 // computed from the border value.  The remaining box_halfw elements are
 // computed from the image.
-static inline
-void ComputeSATSpanFromLeft(int **psat,  // ptr to the row in the SAT
-                             uchar border,  // border vlaue
-                             int prev_row_offset,  // offset to the previous row
-                             int box_halfw,  // (width of box -1) / 2
-                             const uchar **pimg) {  // ptr to image row
+inline void ComputeLeftSATSpan(int **psat,  // ptr to the row in the SAT
+                               uchar border,  // border vlaue
+                               int prev_row_offset,  // offset to the prev row
+                               int box_halfw,  // (width of box -1) / 2
+                               const uchar **pimg) {  // ptr to image row
   // Compute the far left value
   ComputeLeftSAT(psat, border, prev_row_offset);
   // Compute the padding outside the image
@@ -329,7 +328,7 @@ void BoxFilterTiledImage::BoxFilter(int box_width, int box_height,
           if (tile_col == 0) {
             if (tile_row == 0) {
               // Compute first part of top tile row.
-              ComputeSATSpanFromLeft(&psat, border, sat_prev_row_offset,
+              ComputeLeftSATSpan(&psat, border, sat_prev_row_offset,
                                      box_halfw, &pimg);
             } else {  // It is already computed from tile above us.
               psat += box_width;
@@ -361,7 +360,7 @@ void BoxFilterTiledImage::BoxFilter(int box_width, int box_height,
           // Handle case where row >= box_height.
           // Take care of the first box_width elements of SAT row.
           if (tile_col == 0) {  // Leftmost tile column: compute.
-            ComputeSATSpanFromLeft(&psat, border, sat_prev_row_offset,
+            ComputeLeftSATSpan(&psat, border, sat_prev_row_offset,
                                    box_halfw, &pimg);
           } else {  // Copy box_width elements from vertical band.
             memcpy(psat, &sat_vband[0] + row * box_width,

--- a/earth_enterprise/src/fusion/tools/boxfilter_test.cpp
+++ b/earth_enterprise/src/fusion/tools/boxfilter_test.cpp
@@ -150,7 +150,7 @@ class BoxFilterUnitTest : public UnitTest<BoxFilterUnitTest> {
     }
 
     return true;
-  };
+  }
 
   int RandomInt(int low, int high) {
     return low + static_cast<int>((high - low) * (rand() / (RAND_MAX + 1.0)));


### PR DESCRIPTION
Fixes #515.

The box filter uses a summed area table (SAT) in which each value in a matrix is based on values above and to the left of that value. However, there is no code to handle the left of the matrix (which has no values to the left).  This PR adds code to handle the left column which prevents writing outside the bounds of the matrix, which in turn prevents a seg fault in some cases.  There is no need to handle this for the top of the matrix because the code includes an optimization that wraps around to the bottom of the matrix and thus doesn't write out of bounds.

To test this change:
- Download the input data from https://drive.google.com/open?id=0B1_3KrIKN1M1aHM5OWtzRmd5ZWc
- Unzip the file and move the Data and Imagery folders to /gevol/src.
- Run the command `time /opt/google/bin/gepolymaskgen --base_image /gevol/src/Imagery/San_Diego_2014_NAIP_JP2/m_3211609_nw_11_1_20140530_20140721.jp2 --invert --feather -300 --feather_border 1 --and_neg_mask /gevol/src/Data/gshhg-shp-2.3.6/GSHHS_shp/f/GSHHS_f_L1.shp  --invert --output_mask san_diego_2014_naip-custom-mask.tif`.  If you run this on the master branch, it will seg fault after a few minutes.  With the changes in this PR, it will not seg fault.

Lots of the changes in this PR are just whitespace.  To see the PR with whitespace ignored, add `?w=1` to the end of the URL: https://github.com/google/earthenterprise/pull/542/files?w=1.