### PR TITLE
fix #359 (fusion): Gracefully handle errors when saving

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
@@ -160,7 +160,7 @@ bool AssetBase::Save() {
     }
 
     QString error_msg;
-    if (!SubmitEditRequest(&error_msg, true)) {
+    if (!SubmitEditRequest(&error_msg, last_save_error_)) {
       QMessageBox::critical(this, tr("Save ") + AssetPrettyName(),
                             tr("Unable to save: ") + Name() + "\n" +
                             error_msg,
@@ -329,8 +329,7 @@ void AssetBase::Build(void) {
 
 void AssetBase::AboutToShowFileMenu() {
   bool dirty = IsModified();
-  //save_action_->setEnabled(dirty && !save_error_);
-  save_action_->setEnabled(!save_error_);
+  save_action_->setEnabled(dirty && !save_error_);
   saveas_action_->setEnabled(!save_error_);
   build_action_->setEnabled(!dirty);
 }

--- a/earth_enterprise/src/fusion/fusionui/AssetBase.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetBase.h
@@ -51,6 +51,8 @@ class AssetBase : public QMainWindow {
   bool OkToQuit();
   void RestoreLayout();
   void SetErrorMsg(const QString& text, bool red);
+  void SetSaveError(bool state);
+  void SetLastSaveError(bool state);
 
  signals:
   void NameChanged(const QString& text);
@@ -58,7 +60,7 @@ class AssetBase : public QMainWindow {
  protected:
   virtual QWidget* BuildMainWidget(QWidget* parent) = 0;
   virtual bool IsModified() = 0;
-  virtual bool SubmitEditRequest(QString* error_msg, bool save_error_) = 0;
+  virtual bool SubmitEditRequest(QString* error_msg, bool save_error) = 0;
 
   void InstallMainWidget();
   void SetName(const QString& text);
@@ -103,6 +105,7 @@ class AssetBase : public QMainWindow {
   khMetaData meta_;
   QString asset_path_;
   bool save_error_;
+  bool last_save_error_;
 };
 
 #endif // !KHSRC_FUSION_FUSIONUI_ASSETBASE_H__

--- a/earth_enterprise/src/fusion/fusionui/AssetDerived.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetDerived.h
@@ -54,7 +54,7 @@ class AssetDerived : public AssetBase {
   typename Defs::Widget* main_widget_;
 
  private:
-  void Init(void);
+  void Init(bool re_init = false);
   typename Defs::Request AssembleEditRequest(void);
 
   // Reset IDs(asset_uuid, fuid_resource, fuid_channel, indexVersion) in fuse

--- a/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
@@ -112,8 +112,6 @@ template <class Defs, class FinalClass>
     // Re-assemble request after updating model-object.
     request = AssembleEditRequest();
   }
-  std::string buf, ref;
-  request.SaveToString(buf, ref);
 
 
   if (Defs::kSubmitFunc(request, *error_msg, 0 /* timeout */)) {

--- a/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
@@ -97,12 +97,12 @@ bool AssetDerived<Defs, FinalClass>::IsModified() {
 }
 
 template <class Defs, class FinalClass>
-  bool AssetDerived<Defs, FinalClass>::SubmitEditRequest(QString* error_msg, bool save_error_) {
+  bool AssetDerived<Defs, FinalClass>::SubmitEditRequest(QString* error_msg, bool last_save_error) {
   typename Defs::Request request = AssembleEditRequest();
-  if (!save_error_ && request == saved_edit_request_ )
+  if (!last_save_error && request == saved_edit_request_ )
     return true;
 
-  if (save_error_ || request.assetname != saved_edit_request_.assetname) {
+  if (last_save_error || request.assetname != saved_edit_request_.assetname) {
     // It is a "SaveAs"'s edit request, or earlier request was not
     // successfully saved, so resetting IDs in fuse config to force
     // generating of new ones.
@@ -112,6 +112,9 @@ template <class Defs, class FinalClass>
     // Re-assemble request after updating model-object.
     request = AssembleEditRequest();
   }
+  std::string buf, ref;
+  request.SaveToString(buf, ref);
+
 
   if (Defs::kSubmitFunc(request, *error_msg, 0 /* timeout */)) {
     // TODO: To be consistent, the model (gstVectorProject-object)
@@ -127,11 +130,13 @@ template <class Defs, class FinalClass>
 }
 
 template <class Defs, class FinalClass>
-void AssetDerived<Defs, FinalClass>::Init(void) {
+void AssetDerived<Defs, FinalClass>::Init(bool re_init) {
   // defer to final class
   final()->FinalPreInit();
 
-  InstallMainWidget();
+  if (re_init == false) {
+    InstallMainWidget();
+  }
   SetName(saved_edit_request_.assetname);
   SetMeta(saved_edit_request_.meta);
 
@@ -171,7 +176,7 @@ template <class Defs, class FinalClass>
 void AssetDerived<Defs, FinalClass>::ReInit(
     const typename Defs::Request &request) {
   saved_edit_request_ = request;
-  Init();
+  Init(true);
 }
 
 #endif // FUSION_FUSIONUI_ASSETDERIVEDIMPL_H__

--- a/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
+++ b/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.cpp
@@ -34,6 +34,7 @@
 #include "autoingest/.idl/gstProvider.h"
 #include "autoingest/.idl/storage/RasterProductConfig.h"
 #include "fusion/autoingest/khFusionURI.h"
+#include "fusion/fusionui/AssetBase.h"
 #include "fusion/fusionui/QDateWrapper.h"
 #include "fusion/fusionui/Preferences.h"
 #include "common/khStringUtils.h"
@@ -255,6 +256,7 @@ void RasterAssetWidget::AddSource() {
   if (FileDialog()->exec() != QDialog::Accepted)
     return;
 
+  bool modified = false;
   QStringList files = FileDialog()->selectedFiles();
   for (QStringList::Iterator it = files.begin(); it != files.end(); ++it) {
     if (source_list->findItem(*it, Qt::ExactMatch)) {
@@ -266,7 +268,12 @@ void RasterAssetWidget::AddSource() {
       continue;
     } else {
       source_list->insertItem(*it);
+      modified = true;
     }
+  }
+
+  if (modified) {
+	this->GetAssetBase()->SetSaveError(false);
   }
 
   // adding a source may enable mosaic config
@@ -283,6 +290,7 @@ void RasterAssetWidget::DeleteSource() {
     return;
 
   source_list->removeItem(row);
+  this->GetAssetBase()->SetSaveError(false);
 
   // deleting a source may disable mosaic config
   AdjustMosaicEnabled();

--- a/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.h
+++ b/earth_enterprise/src/fusion/fusionui/RasterAssetWidget.h
@@ -64,6 +64,7 @@ class RasterAssetWidget : public RasterAssetWidgetBase {
   std::string GetMosaicFill() const;
   void RestoreAllMaskOptions();
   AssetDefs::Type AssetType() const { return asset_type_; }
+  virtual AssetBase* GetAssetBase() const = 0;
 
   AssetDefs::Type asset_type_;
   QFileDialog* file_dialog_;
@@ -78,6 +79,7 @@ class ImageryAssetWidget : public RasterAssetWidget,
  public:
   inline ImageryAssetWidget(QWidget* parent, AssetBase* base) :
       RasterAssetWidget(parent, AssetDefs::Imagery), AssetWidgetBase(base) { }
+  AssetBase* GetAssetBase() const { return AssetWidgetBase::GetAssetBase(); }
 };
 
 class TerrainAssetWidget : public RasterAssetWidget,
@@ -85,6 +87,7 @@ class TerrainAssetWidget : public RasterAssetWidget,
  public:
   inline TerrainAssetWidget(QWidget* parent, AssetBase* base) :
       RasterAssetWidget(parent, AssetDefs::Terrain), AssetWidgetBase(base) { }
+  AssetBase* GetAssetBase() const { return AssetWidgetBase::GetAssetBase(); }
 };
 
 


### PR DESCRIPTION
Fixes #359 
- Canceling a Save no longer disables saving.
- Save error state can be updated from within the UI (and thus cleared when the sources list is modified).
- Fixes a bug where Saving generates a new window class, which is completely disconnected from the actual window that the User is interacting with.

Fixes #335 
- Changing a value in the Resource dialog now registers as needing a save.

Fixed #321 
- Adding/removing images in the Resource dialog now registers as needing a save.