### PR TITLE
test: Unit testing wrapper script - xml output for junit

### DIFF
--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -111,7 +111,7 @@ foreach my $test (@tests) {
               }
 
               #find class name if possible 
-              my $classname = $line;
+              my $classname = $basename;
               my $testname = $line;
               if($line =~ /(\w+)\.(\w+)/) {
                 $classname = $1;

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -58,7 +58,7 @@ foreach my $test (@tests) {
 }
 
 #xml headers
-print $fh "<? xml version=\"1.0\" ?>\n";
+print $fh "<?xml version=\"1.0\" ?>\n";
 print $fh "<testsuites>\n";
 
 $| = 1;

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -21,6 +21,14 @@ use Cwd 'abs_path';
 use strict;
 use warnings;
 
+my $OSLABEL = "";
+my $argc = scalar(@ARGV);
+if($argc > 1) {
+  if($ARGV[0] eq "-o") {
+    $OSLABEL = $ARGV[1].".";
+  }
+}
+
 # This script should be run from NATIVE-*-x86_64/bin/tests
 my $scriptDir = dirname(abs_path($0));
 if ($scriptDir !~ /NATIVE-[a-zA-Z0-9_-]*\/bin\/tests$/) {
@@ -125,7 +133,7 @@ foreach my $test (@tests) {
               $ms *= 0.001;
 
               #add the xml to the list of testcases for this file
-              push(@testcases, "\t\t<testcase classname=\"$classname\" name=\"$testname\" time=\"$ms\">\n");
+              push(@testcases, "\t\t<testcase classname=\"$OSLABEL$classname\" name=\"$testname\" time=\"$ms\">\n");
             }
 
         }

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -84,7 +84,7 @@ foreach my $test (@tests) {
             #is this a test case with an individual result?
             if ($line =~ /OK|succeeded|FAILED/i && $line !~ /[0-9]+ of [0-9]+/) {
               $test_count++;
-              my $ms = 0;
+              my $ms = 0.0;
 
               #count failures
               if($line =~ /FAILED/) {
@@ -108,7 +108,7 @@ foreach my $test (@tests) {
                 $classname = $1;
                 $testname = $2;
               }
-              push(@testcases, "\t\t<testcase classname=\"$classname\" name=\"$testname\" time=\"$ms ms\">\n");
+              push(@testcases, "\t\t<testcase classname=\"$classname\" name=\"$testname\" time=\"$ms\">\n");
             }
 
             #save test output in case we are logging a failure
@@ -140,13 +140,14 @@ foreach my $test (@tests) {
 
     ### print xml for the test file we just ran 
     $testsuite .= " name=\"$basename\" tests=\"$test_count\">\n";
-    $stdout_data .= "\t\t\t</system-out>\n";
+    $stdout_data .= $test_output;
+    $stdout_data .= "\n\t\t\t</system-out>\n";
 
     #if there was a failure, save the output in the stderr-data xml block
     if($failed > 0) {
       $stderr_data .= $test_output;
     }
-    $stderr_data .= "\t\t\t</system-err>\n";
+    $stderr_data .= "\n\t\t\t</system-err>\n";
 
     print $fh $testsuite;
 

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -75,6 +75,7 @@ foreach my $test (@tests) {
         my @output;
         while (<OUTPUT>) {
             my $line = $_;
+            $test_output .= $line;
 
             #there are a lot of these from some of the test files and we don't care about them
             if ($line =~ /^Fusion Notice:/) {
@@ -108,11 +109,11 @@ foreach my $test (@tests) {
                 $classname = $1;
                 $testname = $2;
               }
+              $ms *= 0.001;
               push(@testcases, "\t\t<testcase classname=\"$classname\" name=\"$testname\" time=\"$ms\">\n");
             }
 
             #save test output in case we are logging a failure
-            $test_output .= $_;
         }
         if (close(OUTPUT)) {
             $testsuite .= "errors=\"0\" failures=\"$failed\" "; #FIXME  count errors 
@@ -163,5 +164,6 @@ foreach my $test (@tests) {
 
 #close the top level xml tag
 print $fh "</testsuites>\n";
+close($fh);
 
 exit $result;

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -107,7 +107,6 @@ foreach my $test (@tests) {
     my $prev = "";
 
     if (open(OUTPUT, "$test 2>&1 |")) {
-        my @output;
         while (<OUTPUT>) {
             my $line = $_;
 

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -50,7 +50,7 @@ foreach my $test (@tests) {
 }
 
 #xml headers
-print $fh "<?xml version=\"1.0\" ?>\n";
+print $fh "<? xml version=\"1.0\" ?>\n";
 print $fh "<testsuites>\n";
 
 $| = 1;
@@ -155,14 +155,18 @@ foreach my $test (@tests) {
 
     ### print xml for the test file we just ran 
     $testsuite .= " name=\"$basename\" tests=\"$test_count\">\n";
-    $stdout_data .= $test_output;
-    $stdout_data .= "\n\t\t\t</system-out>\n";
+    #$stdout_data .= $test_output;
 
     #if there was a failure, save the output in the stderr-data xml block
     if($failures > 0) {
       $stderr_data .= $test_output;
+      $stdout_data .= "\n\t\t\t</system-out>\n";
+      $stderr_data .= "\n\t\t\t</system-err>\n";
     }
-    $stderr_data .= "\n\t\t\t</system-err>\n";
+    else { #experiment to see if this is why jenkins is getting slap-happy with test cases
+      $stderr_data = "";
+      $stdout_data = "";
+    }
 
     print $fh $testsuite;
 

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -71,6 +71,7 @@ foreach my $test (@tests) {
     my $errors = 0;
     my $test_output = "";
     my @testcases;
+    my $prev = "";
 
     if (open(OUTPUT, "$test 2>&1 |")) {
         my @output;
@@ -110,13 +111,15 @@ foreach my $test (@tests) {
                 $ms = $2;
               }
 
-              #find class name if possible 
+              #find class name if possible.. If not, use the filename
               my $classname = $basename;
               my $testname = $line;
               if($line =~ /(\w+)\.(\w+)/) {
                 $classname = $1;
                 $testname = $2;
               }
+              next if($prev && "$classname.$testname" eq $prev);
+              $prev = "$classname.$testname";
 
               #convert milliseconds to seconds for junit
               $ms *= 0.001;

--- a/scripts/get-gee-build-environment.sh
+++ b/scripts/get-gee-build-environment.sh
@@ -43,7 +43,7 @@ MIN_GCC_VERSION="4.8"
 
 # Whether to assume answer of yes to all questions (used when installing
 # packages).  Set to true to run without user interaction.
-: ${ASSUME_YES:="yes"}
+: ${ASSUME_YES:=""}
 
 # Check for a known package manager:
 if type apt-get >/dev/null 2>&1; then
@@ -308,7 +308,7 @@ elif [ "$PACKAGE_MANAGER" == "apt-get" ]; then
             libperl4-corelibs-perl libpng12-0 libpng12-dev libpq-dev \
             libproj-dev libstdc++6 libtool libx11-dev libxcursor-dev \
             libxerces-c-dev libxft-dev libxinerama-dev libxml2-dev \
-            libxml2-utils libxrandr-dev openssl libxmu-dev python-psycopg2 \
+            libxml2-utils libxrandr-dev openssl \
             python-dev python2.7 python2.7-dev python-imaging \
             python-setuptools rsync scons software-properties-common swig \
             wget xorg-dev zlib1g-dev || return 1

--- a/scripts/get-gee-build-environment.sh
+++ b/scripts/get-gee-build-environment.sh
@@ -43,7 +43,7 @@ MIN_GCC_VERSION="4.8"
 
 # Whether to assume answer of yes to all questions (used when installing
 # packages).  Set to true to run without user interaction.
-: ${ASSUME_YES:=""}
+: ${ASSUME_YES:="yes"}
 
 # Check for a known package manager:
 if type apt-get >/dev/null 2>&1; then
@@ -308,7 +308,7 @@ elif [ "$PACKAGE_MANAGER" == "apt-get" ]; then
             libperl4-corelibs-perl libpng12-0 libpng12-dev libpq-dev \
             libproj-dev libstdc++6 libtool libx11-dev libxcursor-dev \
             libxerces-c-dev libxft-dev libxinerama-dev libxml2-dev \
-            libxml2-utils libxrandr-dev openssl \
+            libxml2-utils libxrandr-dev openssl libxmu-dev python-psycopg2 \
             python-dev python2.7 python2.7-dev python-imaging \
             python-setuptools rsync scons software-properties-common swig \
             wget xorg-dev zlib1g-dev || return 1


### PR DESCRIPTION
Updated unit test wrapper script , behaves the same as before when run manually but also creates an Output.xml file that can be read as test output by Jenkins. Also has a few command line options to increase verbosity of that xml file and to specify labels (so that xml output by multiple OSs/images can be distinguished from one another by Jenkins).  Note this does require some minor changes to pipeline scripts.