### PR TITLE
refactor #595 (build): move open jpeg 2.3.0 into third party build

### DIFF
--- a/earth_enterprise/src/third_party/SConscript
+++ b/earth_enterprise/src/third_party/SConscript
@@ -67,6 +67,7 @@ else:
       'libcurl',
       'qt',
       'glu',
+      'openjpeg',
       'gdal',
       'postgresql',
       'postgis',  # requires postgresql config, geos, proj libs.

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -29,7 +29,7 @@ Import('third_party_env')
 import os
 
 gdal_version = 'gdal-2.1.2'
-openjpeg_version = 'openjpeg-v2.3.0-linux-x86_64'
+#openjpeg_version = 'openjpeg-v2.3.0-linux-x86_64'
 # kakadu_version = 'v5_2_6-00418C'
 # geoexpress_version = 'MrSID_DSDK-8.5.0.3422'
 
@@ -51,14 +51,15 @@ make_cmd_cpu = 'make -j%d' % GetOption('num_jobs')
 ge_version = gdal_version.replace('gdal', 'gdal-ge')
 
 current_dir = Dir('.').abspath
+openjpeg_dir = Dir('../openjpeg/install/opt/google/').abspath 
 build_root = '%s/%s' % (current_dir, gdal_version)
 gdal_source = File('#/../../earth_enterprise/third_party/gdal/%s.tar.gz'
                    % gdal_version).abspath
 
 
 ## Specify path to openjpeg library here:
-openjpeg_source = File('#/../../earth_enterprise/third_party/openjpeg/%s.tar.gz'
-                      % openjpeg_version).abspath
+#openjpeg_source = File('#/../../earth_enterprise/third_party/openjpeg/%s.tar.gz'
+#                      % openjpeg_version).abspath
 
 # Specify path to kakadu library here:
 # kakadu_source = File('#/../../earth_enterprise/third_party/kakadu/%s.zip'
@@ -98,13 +99,13 @@ gdal_extract = gdal_env.Command(
 
 
 # [2] Extract openjpeg
-gdal_target = '%s/.extract_openjpeg' % current_dir
-openjpeg_extract = gdal_env.Command(
-    gdal_target, [openjpeg_source, gdal_extract],
-    [gdal_env.MultiCommand(
-        'cd %s\n'
-        'tar xzf %s\n'
-        'touch %s' % (build_root, openjpeg_source, gdal_target))])
+#gdal_target = '%s/.extract_openjpeg' % current_dir
+#openjpeg_extract = gdal_env.Command(
+#    gdal_target, [openjpeg_source, gdal_extract],
+#    [gdal_env.MultiCommand(
+#        'cd %s\n'
+#        'tar xzf %s\n'
+#        'touch %s' % (build_root, openjpeg_source, gdal_target))])
 
 
 # [2] Patch gdal
@@ -186,7 +187,8 @@ if gdal_env['bundle_3rd_libs']:
       '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
       '--with-geotiff=internal --with-xerces=%s --with-geos=%s/bin/geos-config '
 #      '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
-      '--with-openjpeg=%s/%s '
+#      '--with-openjpeg=%s/%s '
+      '--with-openjpeg=%s '
       '--with-mrsid=%s '
       '--with-python=%s '
       '--with-xml2=%s/bin '
@@ -199,7 +201,8 @@ if gdal_env['bundle_3rd_libs']:
            root_dir, root_dir,
            root_dir, root_dir,
 #           build_root, kakadu_version, build_root, geoexpress_version,
-           build_root, openjpeg_version, mrSIDDSDKPath,
+           openjpeg_dir, # build_root, openjpeg_version,
+           mrSIDDSDKPath,
            gdal_env['python_bin'],
            root_dir,
            root_dir,
@@ -213,7 +216,8 @@ else:
         '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
         '--with-geotiff=internal --with-xerces --with-geos '
 #        '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
-        '--with-openjpeg=%s/%s '
+#        '--with-openjpeg=%s/%s '
+        '--with-openjpeg=%s '
         '--with-mrsid=%s '
         '--with-python=%s '
         '--with-xml2 '
@@ -224,14 +228,17 @@ else:
             build_root,
             gdal_env['ENV']['mod_env'], optdir,
 #            build_root, kakadu_version, build_root, geoexpress_version,
-            build_root, openjpeg_version, mrSIDDSDKPath,
+#            build_root, openjpeg_version,
+            openjpeg_dir, # build_root, openjpeg_version,
+            mrSIDDSDKPath,
             gdal_env['python_bin'],
             gdal_target))
 
 
 gdal_configure = gdal_env.Command(
 #    gdal_target, [geoexpress_extract, gdal_kakadu_build],
-    gdal_target, [gdal_extract, gdal_patch, openjpeg_extract ],
+#    gdal_target, [gdal_extract, gdal_patch, openjpeg_extract ],
+    gdal_target, [gdal_extract, gdal_patch ],
     [gdal_env.MultiCommand(configure_cmd)])
 
 # [8] Build gdal
@@ -280,21 +287,22 @@ gdal_install = gdal_env.Command(
 
 
 # [10] Copy Openjpeg libraries (gdal master installer)
-gdal_target = '%s/.openjpeg_install' % current_dir
-openjpeg_install = gdal_env.Command(
-    gdal_target, gdal_install,
-    [gdal_env.MultiCommand(
-        'cd %s\n'
-        'cp -d  %s/lib/*.so* %s/lib\n'
-        'touch %s' % (
-            build_root, openjpeg_version, install_root, gdal_target))])
+#gdal_target = '%s/.openjpeg_install' % current_dir
+#openjpeg_install = gdal_env.Command(
+#    gdal_target, gdal_install,
+#    [gdal_env.MultiCommand(
+#        'cd %s\n'
+#        'cp -d  %s/lib/*.so* %s/lib\n'
+#        'touch %s' % (
+#            build_root, openjpeg_version, install_root, gdal_target))])
 
 
 # [11] Install these into various directories as required for build
 gdal_target = '%s/.install_for_build' % current_dir
 gdal_install_build = gdal_env.Command(
 #    gdal_target, [gdal_install, geoexpress_install],
-    gdal_target, [gdal_install, openjpeg_install],
+#    gdal_target, [gdal_install, openjpeg_install],
+    gdal_target, [gdal_install ],
     [gdal_env.rsync_cmd % (
         '%s/bin/' % install_root,
         '%s/' % Dir(gdal_env.exportdirs['bin']).abspath),

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -29,9 +29,6 @@ Import('third_party_env')
 import os
 
 gdal_version = 'gdal-2.1.2'
-#openjpeg_version = 'openjpeg-v2.3.0-linux-x86_64'
-# kakadu_version = 'v5_2_6-00418C'
-# geoexpress_version = 'MrSID_DSDK-8.5.0.3422'
 
 # Check if MrSID decoding library is installed and get the decoding SDK path
 mrSIDLibName = 'libltidsdk.so'
@@ -57,28 +54,7 @@ gdal_source = File('#/../../earth_enterprise/third_party/gdal/%s.tar.gz'
                    % gdal_version).abspath
 
 
-## Specify path to openjpeg library here:
-#openjpeg_source = File('#/../../earth_enterprise/third_party/openjpeg/%s.tar.gz'
-#                      % openjpeg_version).abspath
-
-# Specify path to kakadu library here:
-# kakadu_source = File('#/../../earth_enterprise/third_party/kakadu/%s.zip'
-#                      % kakadu_version).abspath
-
-# kakadu patch files:
-# kakadu_patches = {'kakadu-fPIC.patch': 2, 'kakadu-static-kdu.patch': 1}
-
-# Specify path to MrSID libary here:
-# geoexpress_source = File('#/../../earth_enterprise/third_party/geoexpres'
-#                          's/%s-linux.x86-64.gcc44.tar.gz' % geoexpress_version
-#                         ).abspath
-
-
 gdal_env = third_party_env.DeepCopy()
-
-# kakadu_lib_defs = "-DKDU_MAJOR_VERSION=5 -DKDU_MINOR_VERSION=2 -DKDU_PATCH_VERSION=6"
-# gdal_env['ENV']['mod_env'] = 'env CFLAGS="%s" CXXFLAGS="%s" ' % (
-#     kakadu_lib_defs, kakadu_lib_defs)
 
 optdir = gdal_env['optdir']
 root_dir = Dir(gdal_env.exportdirs['root']).abspath
@@ -98,16 +74,6 @@ gdal_extract = gdal_env.Command(
         'touch %s'% (current_dir, current_dir, gdal_source, gdal_target))])
 
 
-# [2] Extract openjpeg
-#gdal_target = '%s/.extract_openjpeg' % current_dir
-#openjpeg_extract = gdal_env.Command(
-#    gdal_target, [openjpeg_source, gdal_extract],
-#    [gdal_env.MultiCommand(
-#        'cd %s\n'
-#        'tar xzf %s\n'
-#        'touch %s' % (build_root, openjpeg_source, gdal_target))])
-
-
 # [2] Patch gdal
 gdal_target = '%s/.patch_gdal' % current_dir
 gdal_patch = gdal_env.Command(
@@ -122,60 +88,6 @@ gdal_patch = gdal_env.Command(
                       gdal_target))])
 
 
-# [3] Extract Kakadu
-# gdal_target = '%s/.extract_kakadu' % current_dir
-# kakadu_extract = gdal_env.Command(
-#     gdal_target, [kakadu_source, gdal_extract],
-#     [gdal_env.MultiCommand(
-#         'cd %s\n'
-#         'unzip -q -o %s\n'
-#         'touch %s' % (build_root, kakadu_source, gdal_target))])
-
-# kakadu 5.2
-# [4] Patch Kakadu
-# gdal_target = '%s/.patch_kakadu' % current_dir
-# kakadu_patch = gdal_env.Command(
-#     gdal_target, kakadu_extract +
-#     map(gdal_env.GetBuildPath, kakadu_patches.keys()),
-#     [gdal_env.MultiCommand(
-#         'cd %s/%s\n'
-#         '%s\n'
-#         'touch %s' % (
-#             build_root, kakadu_version, '\n'.join(map(
-#                 lambda i: 'patch -g0 -p%d -s < %s' % (
-#                     kakadu_patches[i], gdal_env.GetBuildPath(i)),
-#                 kakadu_patches.keys())), gdal_target))])
-
-# [5] Extract Geoexpress (Mrsid)
-# gdal_target = '%s/.extract_geoexpress' % current_dir
-# geoexpress_extract = gdal_env.Command(
-#    gdal_target, [geoexpress_source, gdal_extract],
-#    [gdal_env.MultiCommand(
-#         'cd %s\n'
-#         'tar xzf %s\n'
-#         'touch %s' % (build_root, geoexpress_source, gdal_target))])
-
-# [6] Build kakadu
-# Note: kakadu build uses -DKDU_PENTIUM_GCC which don't work well with anything
-# later than gcc 4.1.1 ; Removing this flag and using gcc 4.4.0 gives good
-# image but with image regressions. So to keep things unchanged use gcc 4.1.1
-# for Kakadu. i.e /opt/google/bin/g++
-# make_cmd = '%s CC="%s"' % (make_cmd_cpu, gdal_env['ENV']['CXX'])
-# gdal_target = '%s/.build_kakadu' % current_dir
-# gdal_kakadu_build = gdal_env.Command(
-#     gdal_target, kakadu_patch,
-#     [gdal_env.MultiCommand(
-#         'cd %s\n'
-#         '%s CC=%s/g++ -C %s/coresys/make -f Makefile-Linux-x86-gcc libkdu.a\n'
-#         'mkdir -p %s/%s/java/kdu_jni\n'
-#         '%s%s -C %s/apps/make -f Makefile-Linux-x86-gcc\n'
-#         'ln -f %s/lib/Linux-x86-gcc/libkdu.a %s/lib\n'
-#         'touch %s' % (
-#             build_root, make_cmd, '%s/bin' % optdir, kakadu_version,
-#             build_root, kakadu_version, gdal_env['ENV']['mod_env'], make_cmd,
-#             kakadu_version, kakadu_version, kakadu_version, gdal_target))])
-
-
 # [7] Configure gdal
 gdal_target = '%s/.configure_gdal' % current_dir
 
@@ -186,8 +98,6 @@ if gdal_env['bundle_3rd_libs']:
       '--disable-static --with-threads --with-expat=%s --with-ogdi=%s '
       '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
       '--with-geotiff=internal --with-xerces=%s --with-geos=%s/bin/geos-config '
-#      '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
-#      '--with-openjpeg=%s/%s '
       '--with-openjpeg=%s '
       '--with-mrsid=%s '
       '--with-python=%s '
@@ -200,8 +110,7 @@ if gdal_env['bundle_3rd_libs']:
            gdal_env['ENV']['mod_env'], optdir,
            root_dir, root_dir,
            root_dir, root_dir,
-#           build_root, kakadu_version, build_root, geoexpress_version,
-           openjpeg_dir, # build_root, openjpeg_version,
+           openjpeg_dir,
            mrSIDDSDKPath,
            gdal_env['python_bin'],
            root_dir,
@@ -215,8 +124,6 @@ else:
         '--disable-static --with-threads --with-expat --with-ogdi '
         '--with-libtiff=internal --without-netcdf --with-png=internal --with-jpeg '
         '--with-geotiff=internal --with-xerces --with-geos '
-#        '--with-kakadu=%s/%s --with-mrsid=%s/%s-linux.x86-64.gcc44/Raster_DSDK '
-#        '--with-openjpeg=%s/%s '
         '--with-openjpeg=%s '
         '--with-mrsid=%s '
         '--with-python=%s '
@@ -227,9 +134,7 @@ else:
         'touch %s' % (
             build_root,
             gdal_env['ENV']['mod_env'], optdir,
-#            build_root, kakadu_version, build_root, geoexpress_version,
-#            build_root, openjpeg_version,
-            openjpeg_dir, # build_root, openjpeg_version,
+            openjpeg_dir,
             mrSIDDSDKPath,
             gdal_env['python_bin'],
             gdal_target))
@@ -237,7 +142,6 @@ else:
 
 gdal_configure = gdal_env.Command(
 #    gdal_target, [geoexpress_extract, gdal_kakadu_build],
-#    gdal_target, [gdal_extract, gdal_patch, openjpeg_extract ],
     gdal_target, [gdal_extract, gdal_patch ],
     [gdal_env.MultiCommand(configure_cmd)])
 
@@ -275,33 +179,10 @@ gdal_install = gdal_env.Command(
             other_dir, other_dir, install_root,
             gdal_target))])
 
-# [10] Copy Geoexpress libraries (gdal master installer)
-# gdal_target = '%s/.geoxpress_install' % current_dir
-# geoexpress_install = gdal_env.Command(
-#    gdal_target, gdal_install,
-#    [gdal_env.MultiCommand(
-#         'cd %s\n'
-#         'cp -d  %s-linux.x86-64.gcc44/Raster_DSDK/lib/libltidsdk.so* %s/lib\n'
-#        'touch %s' % (
-#        build_root, geoexpress_version, install_root, gdal_target))])
-
-
-# [10] Copy Openjpeg libraries (gdal master installer)
-#gdal_target = '%s/.openjpeg_install' % current_dir
-#openjpeg_install = gdal_env.Command(
-#    gdal_target, gdal_install,
-#    [gdal_env.MultiCommand(
-#        'cd %s\n'
-#        'cp -d  %s/lib/*.so* %s/lib\n'
-#        'touch %s' % (
-#            build_root, openjpeg_version, install_root, gdal_target))])
-
-
 # [11] Install these into various directories as required for build
 gdal_target = '%s/.install_for_build' % current_dir
 gdal_install_build = gdal_env.Command(
 #    gdal_target, [gdal_install, geoexpress_install],
-#    gdal_target, [gdal_install, openjpeg_install],
     gdal_target, [gdal_install ],
     [gdal_env.rsync_cmd % (
         '%s/bin/' % install_root,

--- a/earth_enterprise/src/third_party/openjpeg/SConscript
+++ b/earth_enterprise/src/third_party/openjpeg/SConscript
@@ -116,10 +116,10 @@ if 'install' in COMMAND_LINE_TARGETS:
       '%s/lib/' % install_root_opt,
       '%s/' % openjpeg_env.installdirs['common_lib'],
       openjpeg_install_build, 'install')
-  openjpeg_env.InstallFileOrDir(
-      '%s/share/doc/packages/' % install_root_opt,
-      '%s/doc/packages/' % (
-          openjpeg_env.installdirs['common_share']),
-      openjpeg_install_build, 'install')
+#  openjpeg_env.InstallFileOrDir(
+#      '%s/share/doc/packages/' % install_root_opt,
+#      '%s/doc/packages/' % (
+#          openjpeg_env.installdirs['common_share']),
+#      openjpeg_install_build, 'install')
 
 Return('openjpeg_extract openjpeg_install_build')

--- a/earth_enterprise/src/third_party/openjpeg/SConscript
+++ b/earth_enterprise/src/third_party/openjpeg/SConscript
@@ -49,6 +49,7 @@ openjpeg_extract = openjpeg_env.Command(
 #  env_opt = ''
 #else:
 #  env_opt = ''
+env_opt = ''
 
 if openjpeg_env['release'] or openjpeg_env['optimize']:
   config_opt = '-DCMAKE_BUILD_TYPE:enum=Release '

--- a/earth_enterprise/src/third_party/openjpeg/SConscript
+++ b/earth_enterprise/src/third_party/openjpeg/SConscript
@@ -45,10 +45,10 @@ openjpeg_extract = openjpeg_env.Command(
         'touch %s' % (
             current_dir, current_dir, openjpeg_source, openjpeg_target))])
 
-if third_party_env['is_hardy'] and not third_party_env['native_cc']:
-  env_opt = ''
-else:
-  env_opt = ''
+#if third_party_env['is_hardy'] and not third_party_env['native_cc']:
+#  env_opt = ''
+#else:
+#  env_opt = ''
 
 if openjpeg_env['release'] or openjpeg_env['optimize']:
   config_opt = '-DCMAKE_BUILD_TYPE:enum=Release '

--- a/earth_enterprise/src/third_party/openjpeg/SConscript
+++ b/earth_enterprise/src/third_party/openjpeg/SConscript
@@ -1,0 +1,125 @@
+#-*- Python -*-
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+Import('third_party_env')
+openjpeg_version = 'openjpeg-2.3.0'
+#ge_version = openjpeg_version.replace('curl', 'curl-ge')
+
+num_cpu = GetOption('num_jobs')
+
+openjpeg_source = File('#/../../earth_enterprise/third_party/openjpeg/%s'
+                      '.tar.gz' % openjpeg_version).abspath
+
+openjpeg_env = third_party_env.DeepCopy()
+root_dir = Dir(openjpeg_env.exportdirs['root']).abspath
+opt_dir = Dir(openjpeg_env['optdir']).abspath
+
+current_dir = Dir('.').abspath
+build_root = '%s/%s' % (current_dir, openjpeg_version)
+install_root = '%s/install' % current_dir
+install_root_opt = '%s%s' % (install_root, opt_dir)
+
+# [1] Extract openjpeg
+openjpeg_target = '%s/.extract' % current_dir
+openjpeg_extract = openjpeg_env.Command(
+    openjpeg_target, openjpeg_source,
+    [openjpeg_env.MultiCommand(
+        'mkdir -p %s\n'
+        'cd %s\n'
+        'tar xzf %s\n'
+        'touch %s' % (
+            current_dir, current_dir, openjpeg_source, openjpeg_target))])
+
+if third_party_env['is_hardy'] and not third_party_env['native_cc']:
+  env_opt = ''
+else:
+  env_opt = ''
+
+if openjpeg_env['release'] or openjpeg_env['optimize']:
+  config_opt = '-DCMAKE_BUILD_TYPE:enum=Release '
+else:
+  config_opt = '-DCMAKE_BUILD_TYPE:enum=Debug '
+
+#openjpeg_env['ENV']['mod_env'] = openjpeg_env['ENV']['mod_env'] + 'LDFLAGS=-lrt '
+
+# [3] Configure openjpeg
+openjpeg_target = '%s/.configure' % current_dir
+openjpeg_configure = openjpeg_env.Command(
+    openjpeg_target, openjpeg_extract,
+    [openjpeg_env.MultiCommand(
+        'cd %s\n'
+        '%s%s cmake . -DBUILD_STATIC_LIBS:bool=off '
+               ' -DCMAKE_INSTALL_PREFIX=%s '
+        '%s\n'
+        'touch %s' % (build_root,
+                      openjpeg_env['ENV']['mod_env'], env_opt,
+                        install_root_opt,
+                      config_opt,
+                      openjpeg_target))])
+
+# [4] Build
+openjpeg_target = '%s/.build' % current_dir
+openjpeg_build = openjpeg_env.Command(
+    openjpeg_target, openjpeg_configure,
+    [openjpeg_env.MultiCommand(
+        'cd %s\n'
+        '%smake -j%d\n'
+        'touch %s' % (build_root, openjpeg_env['ENV']['mod_env'],
+                      num_cpu,
+                      openjpeg_target))])
+
+# [5] Create openjpeg master installer
+openjpeg_target = '%s/.install' % current_dir
+openjpeg_install = openjpeg_env.Command(
+    openjpeg_target, openjpeg_build,
+    [openjpeg_env.MultiCommand(
+        'cd %s\n'
+        'make install\n'
+        'touch %s' % (build_root,
+                      openjpeg_target))])
+
+# [6] Install these into various directories as required for build
+openjpeg_target = '%s/.install_for_build' % current_dir
+openjpeg_install_build = openjpeg_env.Command(
+    openjpeg_target, openjpeg_install,
+    [openjpeg_env.rsync_cmd % (
+        '%s/include/' % install_root_opt,
+        '%s/include/' % root_dir),
+     openjpeg_env.rsync_cmd % (
+         '%s/lib/' % install_root_opt,
+         '%s/lib/' % root_dir),
+     openjpeg_env.rsync_cmd % (
+         '%s/bin/' % install_root_opt,
+         '%s/bin/' % root_dir),
+     Touch('$TARGET')])
+
+Default(openjpeg_install_build)
+openjpeg_env.ExecuteOnClean('rm -rf %s' % current_dir)
+
+if 'install' in COMMAND_LINE_TARGETS:
+  openjpeg_env.InstallFileOrDir(
+      '%s/lib/' % install_root_opt,
+      '%s/' % openjpeg_env.installdirs['common_lib'],
+      openjpeg_install_build, 'install')
+  openjpeg_env.InstallFileOrDir(
+      '%s/share/doc/packages/' % install_root_opt,
+      '%s/doc/packages/' % (
+          openjpeg_env.installdirs['common_share']),
+      openjpeg_install_build, 'install')
+
+Return('openjpeg_extract openjpeg_install_build')

--- a/earth_enterprise/third_party/openjpeg/openjpeg-2.3.0.tar.gz
+++ b/earth_enterprise/third_party/openjpeg/openjpeg-2.3.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c3d7548c5385f6ec870b67ba7a2996b6d67a6cfbf8621a8a0297e2ffaf3716e
+size 2224847

--- a/earth_enterprise/third_party/openjpeg/openjpeg-v2.3.0-linux-x86_64.tar.gz
+++ b/earth_enterprise/third_party/openjpeg/openjpeg-v2.3.0-linux-x86_64.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b08712433ad606c91a679a1a99356413044d9ab955b8de08af9b8bec704bb683
-size 318972


### PR DESCRIPTION
1. Remove openjpeg binary tarball from inclusion into gdal.
2. Add openjpeg source tarball;  add to compile and install process.
