### PR TITLE
Added upgrade document (5.2.0 to 5.2.1)

### DIFF
--- a/earth_enterprise/Upgrade.md
+++ b/earth_enterprise/Upgrade.md
@@ -1,20 +1,14 @@
 # Upgrading Earth Enterprise Fusion and Server to 5.2.1
 
-Upgrading is currently supported from Earth Enterprise 5.1.3 and 5.2.0 versions.
+Upgrading to GEE 5.2.1 is supported from Earth Enterprise 5.1.3 and 5.2.0 versions.
 
 ## Upgrading GEE 5.2.0 to 5.2.1
 
-1. Do not uninstall GEE 5.2.0. We recommend that you upgrade your GEE 5.2.0 by simply installing 5.2.1. If you decide
-that you want to uninstall GEE 5.2.0, first make sure to backup your postgreSQL databases:
+1. Do not uninstall GEE 5.2.0. We recommend that you upgrade your GEE 5.2.0 by simply installing GEE 5.2.1. Installing GEE 5.2.1 on top of GEE 5.2.0 will ensure that your postgreSQL databases are backed up and upgraded correctly to the new postgreSQL version used by GEE 5.2.1. [Install Fusion or Earth Server](https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server)
 
-    Backup postGreSQL databases
-        * Create a backup folder: mkdir -p SomeBackupFolder
-        * Create a backup folder and make gepguser owner: chown gepguser SomeBackupFolder
-        * Dump postGreSQL databases using '/opt/google/bin/geresetpgdb' script: run_as_user gepguser "/opt/google/bin/geresetpgdb backup     
-          SomeBackupFolder
+1. If you decide that you want to uninstall GEE 5.2.0 before installing GEE 5.2.1, first make sure to backup your postgreSQL databases, so you can restore them later when you install GEE 5.2.1.
 
-1. Installing GEE 5.2.1 on top of GEE 5.2.0 will ensure that your postgreSQL databases are backedup and upgraded to
-the new postgreSQL version used by GEE 5.2.1.
-
-1. [Install Fusion or Earth Server](https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server)
-
+    * Create a backup folder: mkdir -p /tmp/MyBackupFolder
+    * Make gepguser owner of the created folder: chown gepguser /tmp/MyBackupFolder
+    * Dump postGreSQL databases using '/opt/google/bin/geresetpgdb' script. This script needs to be run under user 'gepguser'. 
+    This can be achieved by switching to that user then executing: "/opt/google/bin/geresetpgdb backup /tmp/MyBackupFolder

--- a/earth_enterprise/Upgrade.md
+++ b/earth_enterprise/Upgrade.md
@@ -4,11 +4,11 @@ Upgrading to GEE 5.2.1 is supported from Earth Enterprise 5.1.3 and 5.2.0 versio
 
 ## Upgrading GEE 5.2.0 to 5.2.1
 
-1. Do not uninstall GEE 5.2.0. We recommend that you upgrade your GEE 5.2.0 by simply installing GEE 5.2.1. Installing GEE 5.2.1 on top of GEE 5.2.0 will ensure that your postgreSQL databases are backed up and upgraded correctly to the new postgreSQL version used by GEE 5.2.1. [Install Fusion or Earth Server](https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server)
+1. Do not uninstall GEE 5.2.0. We recommend that you upgrade GEE 5.2.0 by simply installing GEE 5.2.1. Installing GEE 5.2.1 on top of GEE 5.2.0 will ensure that your postgreSQL databases are backed up and upgraded correctly to the new postgreSQL version used by GEE 5.2.1. [Install Fusion or Earth Server](https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server)
 
-1. If you decide that you want to uninstall GEE 5.2.0 before installing GEE 5.2.1, first make sure to backup your postgreSQL databases, so you can restore them later when you install GEE 5.2.1.
+1. If you decide that you want to uninstall GEE 5.2.0 before installing GEE 5.2.1, first make sure to backup your postgreSQL databases. Please keep in mind that those backup, made by 5.2.0, would not be compatible with GEE 5.2.1 postgreSQL databases.
 
     * Create a backup folder: mkdir -p /tmp/MyBackupFolder
     * Make gepguser owner of the created folder: chown gepguser /tmp/MyBackupFolder
     * Dump postGreSQL databases using '/opt/google/bin/geresetpgdb' script. This script needs to be run under user 'gepguser'. 
-    This can be achieved by switching to that user then executing: "/opt/google/bin/geresetpgdb backup /tmp/MyBackupFolder
+    This can be achieved by switching to user 'gepguser' then executing: "/opt/google/bin/geresetpgdb backup /tmp/MyBackupFolder

--- a/earth_enterprise/Upgrade.md
+++ b/earth_enterprise/Upgrade.md
@@ -1,0 +1,20 @@
+# Upgrading Earth Enterprise Fusion and Server to 5.2.1
+
+Upgrading is currently supported from Earth Enterprise 5.1.3 and 5.2.0 versions.
+
+## Upgrading GEE 5.2.0 to 5.2.1
+
+1. Do not uninstall GEE 5.2.0. We recommend that you upgrade your GEE 5.2.0 by simply installing 5.2.1. If you decide
+that you want to uninstall GEE 5.2.0, first make sure to backup your postgreSQL databases:
+
+    Backup postGreSQL databases
+        * Create a backup folder: mkdir -p SomeBackupFolder
+        * Create a backup folder and make gepguser owner: chown gepguser SomeBackupFolder
+        * Dump postGreSQL databases using '/opt/google/bin/geresetpgdb' script: run_as_user gepguser "/opt/google/bin/geresetpgdb backup     
+          SomeBackupFolder
+
+1. Installing GEE 5.2.1 on top of GEE 5.2.0 will ensure that your postgreSQL databases are backedup and upgraded to
+the new postgreSQL version used by GEE 5.2.1.
+
+1. [Install Fusion or Earth Server](https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server)
+


### PR DESCRIPTION
Document recommend to install 5.2.1 on top of 5.2.0 to ensure that PostgreSQL databases are upgraded to the new PostgreSQL version (9.6.5). It, also, outline the steps to follow to back up PostgreSQL databases in case one wanted to uninstall 5.2.0.