### PR TITLE
issue with duplicate resources in imagery projects

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetDerivedImpl.h
@@ -134,11 +134,12 @@ void AssetDerived<Defs, FinalClass>::Init(bool re_init) {
 
   if (re_init == false) {
     InstallMainWidget();
-  }
-  SetName(saved_edit_request_.assetname);
-  SetMeta(saved_edit_request_.meta);
 
-  main_widget_->Prefill(saved_edit_request_);
+    SetName(saved_edit_request_.assetname);
+    SetMeta(saved_edit_request_.meta);
+
+    main_widget_->Prefill(saved_edit_request_);
+  }
 
   // defer to final class
   final()->FinalExtraInit();


### PR DESCRIPTION
This is preliminary because where this is may break other things.  It may be that the re_init flag has to be passed down thru prefill and handled explicitly in the derived imagery asset class, and ignored in others.