### PR TITLE
Issue 651: Remove unnecessary gtest dependency from libgeprotobuf

### DIFF
--- a/earth_enterprise/src/google/protobuf/SConscript
+++ b/earth_enterprise/src/google/protobuf/SConscript
@@ -70,6 +70,18 @@ stub_files = [
   'substitute.cc'
 ]
 
+# Remove gtest from the list of required libraries. For some reason the LIBS
+# variable includes "gtest" here, which makes libgeprotobuf unnecessarily
+# depend on gtest-devel. This is a hack to fix that problem, but it's a fairly
+# safe hack.
+try:
+  local_libs = local_env['LIBS']
+  local_libs = [lib for lib in local_libs if lib is not "gtest"]
+  local_env['LIBS'] = local_libs
+except:
+  # No libraries were defined; nothing to do
+  pass
+
 # Compile the cc files and add them to the "proto.a" lib.
 geprotobuf = local_env.sharedLib('geprotobuf', cpp_files
                     + map(lambda f: 'io/' + f, io_files)

--- a/earth_enterprise/src/google/protobuf/SConscript
+++ b/earth_enterprise/src/google/protobuf/SConscript
@@ -74,13 +74,10 @@ stub_files = [
 # variable includes "gtest" here, which makes libgeprotobuf unnecessarily
 # depend on gtest-devel. This is a hack to fix that problem, but it's a fairly
 # safe hack.
-try:
+if 'LIBS' in local_env:
   local_libs = local_env['LIBS']
   local_libs = [lib for lib in local_libs if lib is not "gtest"]
   local_env['LIBS'] = local_libs
-except:
-  # No libraries were defined; nothing to do
-  pass
 
 # Compile the cc files and add them to the "proto.a" lib.
 geprotobuf = local_env.sharedLib('geprotobuf', cpp_files


### PR DESCRIPTION
Fixes #651 

This issue removes the dependency of gtest from libgeprotobuf.  It's a bit hacky since it's not clear why gtest is being included as a dependency in the first place, but it does the job.

Verification steps:
1. Build RPMs on a CentOS 7 box.
1. Install the RPMs on a separate CentOS 7 box that doesn't have gtest or gtest-devel installed.
1. Run `sudo /etc/init.d/geserver restart`.  There should be no failures.
1. Run `sudo /opt/google/bin/geserveradmin`.  It should print out a help message and not complain about missing libraries. 
  