### PR TITLE
Issue 654 - add missing proj-devel rpm dependency, remove circular dependencies in rpms

### DIFF
--- a/earth_enterprise/BUILD_RPMS.md
+++ b/earth_enterprise/BUILD_RPMS.md
@@ -27,6 +27,12 @@ java-1.7.0-openjdk-devel```.  There are no other special prerequisites, as the
 SCons build target pulls down osPackage and dependencies as needed before
 creating RPMs.
 
+Ensure that all required Debian or Yum repositories are enabled on your 
+platform.  For EL6 and EL7 systems, the EPEL repository must be installed 
+and enabled. 
+RHEL satellite based systems also require the *optional* repository ( i.e., rhui-DISTRO-rhel-server-releases-optional) repository to provide some libraries 
+including xerces-c and some perl libraries.
+
 ## Creating RPMs
 
 A new SCons target was added to make RPMs, **package_install**, that can be run
@@ -54,19 +60,19 @@ of the Git repo checkout directly.
 After the SCons **package_install** target completes the rpm command can
 install and test the RPMs created on CentOS or RHEL.  To do this, change to the
 *rpms/build/distributions* directory.  Use ```sudo rpm -Uhv
-opengee-postgis-*.rpm``` and ```sudo rpm -Uhv opengee-common-*.rpm``` to get
+opengee-common-*.rpm``` and ```sudo rpm -Uhv opengee-postgis-*.rpm``` to get
 the base dependencies installed, in that order.  Afterward use ```sudo rpm -Uhv
 opengee-fusion-*.rpm```, and then ```sudo rpm -Uhv opengee-server-*.rpm``` to
 install and test the RPM packaged Open GEE Fusion and Server.
 
-Yum can also be used to install opengee RPM files, and will also automatically
-install required system dependencies.  However, since the opengee packages are
-not in a repository, using ```sudo yum install opengee-server-*.rpm``` or
+Use `yum` to install opengee RPM files so that it will also automatically
+install required system dependencies if they are in enabled repositories.  However, 
+if the opengee packages installed from local files, use ```sudo yum install *.rpm``` 
+in the `rpms/build/distributions` directory to install all rpms and dependencies
+in one step.  Note that using ```sudo yum install opengee-server-*.rpm``` or
 ```sudo yum install opengee-fusion-*.rpm``` will not automatically install
-**opengee-common** or **opengee-postgis**, and yum will refuse to install if
-they are not already installed.  All the rpm packages could be also installed
-together using ```sudo yum install *.rpm``` in the `rpms/build/distributions`
-directory.
+**opengee-common** or **opengee-postgis** if they are not also specified and yum 
+will refuse to install if they were not previously installed.  
 
 The RPMs install Open GEE to the same */opt/google* path that the non-package
 based install scripts did.  If Open GEE is already installed from the Git

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -440,8 +440,21 @@ built from raster, vector, and location properties data.
     license = 'ASL 2.0'
     url = 'https://github.com/google/earthenterprise'
     type = BINARY
+<<<<<<< HEAD
     autoFindProvides = true
     autoFindRequires = true
+=======
+
+    requires('bash')
+    requires('coreutils')
+    requires('findutils')
+    requires('grep')
+    requires('libxml2')
+    requires('net-tools')
+    requires('sed')
+    requires('util-linux')
+    requires('proj')
+>>>>>>> Added proj rpm dependency to opengee-fusion rpm
 
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -150,7 +150,8 @@ task openGeePostGisRpm(type: GeeRpm) {
     type = BINARY
     autoFindProvides = true
     autoFindRequires = true
-
+    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
+    
     from (postGisInstallDir_opt) {
         into new File(packageInstallRootDir, 'opt')
     }
@@ -262,7 +263,6 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     autoFindProvides = true
     autoFindRequires = true
 
-    requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
     requires('chkconfig')
     requires('shadow-utils')
     requires('perl')
@@ -270,8 +270,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     requires('xerces-c')
     requires('ogdi')
     requires('geos')
-    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
-
+    
     requiresCommands(packageSharedCommands +
         ['cat', 'cut', 'getent', 'grep' ])
     
@@ -342,6 +341,9 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     url = 'https://github.com/google/earthenterprise'
     autoFindProvides = true
     autoFindRequires = true
+
+    requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
+    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
 
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
     requiresPre('opengee-common', openGeeVersion, GREATER | EQUAL)
@@ -445,9 +447,12 @@ built from raster, vector, and location properties data.
     type = BINARY
     autoFindProvides = true
     autoFindRequires = true
-    
-    requires('proj-devel')
+
+    requires('proj-devel') /* This dependency is not being picked up automatically by GeeRpm task */
+    requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
+    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
+
 
     requiresCommands(
         packageSharedCommands +

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -263,6 +263,9 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     autoFindProvides = true
     autoFindRequires = true
 
+    /* When the scons release=1 package target is run as a non-root user, scons does 
+    not include /sbin in the path, so auto-detection of chkconfig fails, so this 
+    dependency is explicit */
     requires('chkconfig')
     requires('shadow-utils')
     requires('sudo')
@@ -339,8 +342,7 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     autoFindRequires = true
 
     requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
-    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
-
+    
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
     requiresPre('opengee-common', openGeeVersion, GREATER | EQUAL)
 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -342,7 +342,7 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     autoFindRequires = true
 
     requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
-    
+    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
     requiresPre('opengee-common', openGeeVersion, GREATER | EQUAL)
 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -265,11 +265,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
 
     requires('chkconfig')
     requires('shadow-utils')
-    requires('perl')
     requires('sudo')
-    requires('xerces-c')
-    requires('ogdi')
-    requires('geos')
     
     requiresCommands(packageSharedCommands +
         ['cat', 'cut', 'getent', 'grep' ])

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -267,6 +267,9 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     requires('shadow-utils')
     requires('perl')
     requires('sudo')
+    requires('xerces-c')
+    requires('ogdi')
+    requires('geos')
     conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
 
     requiresCommands(packageSharedCommands +
@@ -440,22 +443,10 @@ built from raster, vector, and location properties data.
     license = 'ASL 2.0'
     url = 'https://github.com/google/earthenterprise'
     type = BINARY
-<<<<<<< HEAD
     autoFindProvides = true
     autoFindRequires = true
-=======
-
-    requires('bash')
-    requires('coreutils')
-    requires('findutils')
-    requires('grep')
-    requires('libxml2')
-    requires('net-tools')
-    requires('sed')
-    requires('util-linux')
-    requires('proj')
->>>>>>> Added proj rpm dependency to opengee-fusion rpm
-
+    
+    requires('proj-devel')
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
 
     requiresCommands(

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -445,10 +445,8 @@ built from raster, vector, and location properties data.
     autoFindRequires = true
 
     requires('proj-devel') /* This dependency is not being picked up automatically by GeeRpm task */
-    requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
-    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
-
+    
 
     requiresCommands(
         packageSharedCommands +


### PR DESCRIPTION
Tested clean packaging builds on a clean CentOS 6 docker image and ran tests on a fresh minimal CentOS 6 container. 