### PR TITLE
Package missing liblwgeom.so library, update opengee-postgis rpm version. 

### DIFF
--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -269,6 +269,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     requires('shadow-utils')
     requires('perl')
     requires('sudo')
+    conflicts('opengee-postgis', '2.0', LESS )
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
 
     requiresCommands(packageSharedCommands +

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -141,7 +141,7 @@ task stageOpenGeeInstall(type: Exec, dependsOn: 'compileOpenGee') {
 task openGeePostGisRpm(type: GeeRpm) {
     packageName = 'opengee-postgis'
     release = "1.${rpmPlatformString}"
-    version = '1.5.8'
+    version = '2.3.4'
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -264,12 +264,12 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
     autoFindProvides = true
     autoFindRequires = true
 
-    requires('opengee-postgis', '1.5.8', GREATER | EQUAL)
+    requires('opengee-postgis', '2.3.4', GREATER | EQUAL)
     requires('chkconfig')
     requires('shadow-utils')
     requires('perl')
     requires('sudo')
-    conflicts('opengee-postgis', '2.0', GREATER | EQUAL)
+    conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
 
     requiresCommands(packageSharedCommands +
         ['cat', 'cut', 'getent', 'grep' ])

--- a/earth_enterprise/src/third_party/postgis/SConscript
+++ b/earth_enterprise/src/third_party/postgis/SConscript
@@ -108,6 +108,7 @@ postgis_install = postgis_env.Command(
         'rm -rf %s/lib\n'
         'mkdir -p %s/share/doc/packages/%s\n'
         'cp -pr COPYING CREDITS README.postgis %s/share/doc/packages/%s\n'
+        'mkdir -p %s/share/postgresql/extension\n'
         'cp -pr %s/liblwgeom/.libs/*.so* %s/share/postgresql/extension\n'
         'cd %s%s\n'
         'tar cf - * | (cd %s; tar xf -)\n'
@@ -120,6 +121,7 @@ postgis_install = postgis_env.Command(
                       install_root_opt,
                       install_root_opt, ge_version,
                       install_root_opt, ge_version,
+                      install_root_opt, 
                       build_root, install_root_opt, 
                       install_root, root_dir,
                       install_root_opt,

--- a/earth_enterprise/src/third_party/postgis/SConscript
+++ b/earth_enterprise/src/third_party/postgis/SConscript
@@ -108,6 +108,7 @@ postgis_install = postgis_env.Command(
         'rm -rf %s/lib\n'
         'mkdir -p %s/share/doc/packages/%s\n'
         'cp -pr COPYING CREDITS README.postgis %s/share/doc/packages/%s\n'
+        'cp -pr %s/liblwgeom/.libs/*.so* %s/share/postgresql/extension\n'
         'cd %s%s\n'
         'tar cf - * | (cd %s; tar xf -)\n'
         'cd %s/share/postgresql/contrib\n'
@@ -119,6 +120,7 @@ postgis_install = postgis_env.Command(
                       install_root_opt,
                       install_root_opt, ge_version,
                       install_root_opt, ge_version,
+                      build_root, install_root_opt, 
                       install_root, root_dir,
                       install_root_opt,
                       install_root_opt,


### PR DESCRIPTION
Fixes failure when installing the new opengee-server RPMs based on opengee-postgis (PG 9.6/PostGIS 2.3.4) it failed because it could not find any version of liblwgeom.so, as it was not being packaged or installed. 

Also, opengee-postgis RPM has an updated version so that it can only be installed with compatible versions of geserver and associated code.

Notes:
* This library is normally provided by all postgis 2.3.x packages.
* It is built by OpenGEE SConscript in third_party/postgis

