### PR TITLE
(#663) Fix DB reset script issues

### DIFF
--- a/earth_enterprise/src/server/geresetpgdb
+++ b/earth_enterprise/src/server/geresetpgdb
@@ -231,32 +231,7 @@ fi
 if [ "$type" == "backup" ]; then
   do_dump
 elif [ "$type" == "hard" ]; then
-  if [ ! -e "$VARPGDIR/data" ]; then
-    # create a new db instance from scratch
-    # TODO: This will need to be removed when we unbundle PostgreSQL
-    "$BINDIR/initdb" --auth=trust -D "$VARPGDIR/data" >/dev/null
-  else
-    # Start postmaster.
-    if [ ! -f "$VARPGDIR/data/postmaster.pid" ]; then
-      "$BINDIR/pg_ctl" -D "$VARPGDIR/data" -l "$VARPGDIR/logs/pg.log" start -w
-    fi
-
-    # Do reset and recreate database instance.
-    echo Removing geserve-databases...
-    do_reset
-
-    # Also drop example databases
-    if [ `"$BINDIR/psql" -lqt | cut -d \| -f 1 | grep -w geplaces | wc -l` == 1 ]; then
-      "$BINDIR/dropdb" -U geuser geplaces
-    fi
-    if [ `"$BINDIR/psql" -lqt | cut -d \| -f 1 | grep -w searchexample | wc -l` == 1 ]; then
-      "$BINDIR/dropdb" -U geuser searchexample
-    fi
-
-    # Remove geuser
-    echo Removing geuser...
-    "$BINDIR/psql" postgres -q -c "DROP USER IF EXISTS geuser"
-  fi
+  do_hard_reset
 else
 
   # Check if PostgreSQL version have been changed.
@@ -274,9 +249,9 @@ else
       echo "WARNING: PostgresSQL have been updated. You must indicate the path to the backup data."
       exit 1
     fi
-  else
-    # Do backup for any reset except 'hard' or if we are upgrading to a new database version. In that case,
-    # it must have been done with the previous version of the PostgreSQL binaries
+  elif [ "$type" != "restore" ]; then
+    # Do backup for any reset except 'hard' or 'restore' or if we are upgrading to a new database version.
+    # In that case, it must have been done with the previous version of the PostgreSQL binaries
     do_dump
   fi
 


### PR DESCRIPTION
Fixes #663 

Verification steps:

"restore" target:
1. Start with a GEE Server with at least one published map/globe
1. In admin console, note the map(s)/globe(s) published
1. Stop geserver service
1. Create a backup of the GEE postgres database using `sudo -u gepguser /opt/google/bin/geresetpgdb backup /tmp/pgdb_backup`
1. Reset database using  `sudo -u gepguser /opt/google/bin/geresetpgdb soft`
1. Start geserver service
1. In admin console, there should be no maps/globes published
1. Stop geserver service
1. Restore database using  `sudo -u gepguser /opt/google/bin/geresetpgdb restore /tmp/pgdb_backup`
1. Start geserver service
1. In admin console, the original map(s)/globe(s) will be present

"hard" target:
1. Stop geserver service
1. Remove the directory `/var/opt/google/pgsql/data/base`
1. Attempt to start geserver service (it should fail)
1. Stop geserver service (because apache will probably be running)
1. Reset database using `sudo -u gepguser /opt/google/bin/geresetpgdb hard`
1. Start geserver service 
1. It should start properly with a clean database install