### PR TITLE
Issue #666: initialize variable in gerewritedbroot

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
@@ -298,7 +298,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
 
 int main(int argc, char *argv[]) {
   std::string progname = argv[0];
-  bool help;
+  bool help = false;
   bool use_ssl_for_kml = false;
   std::string source;
   std::string icon_directory;


### PR DESCRIPTION
Fixes #666.

To test, run
```
sudo /opt/google/bin/gecutter enable
gerewritedbroot --source=http://bplinux --icon_directory=/tmp/icons --dbroot_file=/tmp/dbroot --kml_map_file=/tmp/kml_map
```
If you get
```
Fusion Fatal:	Unable to get dbroot from source.
```
the bug is fixed.  If you get a usage message, the bug is not fixed.