### PR TITLE
Fix links in installer

### DIFF
--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -448,7 +448,7 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     }
 
     from(stagedInstallDir_server_geplaces) {
-	into new File(packageInstallRootDir, 'opt/google/share/geplaces')
+        into new File(packageInstallRootDir, 'opt/google/share/geplaces')
     }
 
     from(stagedInstallDir_server_searchexample) {
@@ -465,6 +465,12 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
             it.exclude()
         }
     }
+
+    // Create links
+    link('/opt/google/etc', '/etc/opt/google')
+    link('/opt/google/log', '/var/opt/google/log')
+    link('/opt/google/run', '/var/opt/google/run')
+    link('/opt/google/gehttpd/htdocs/shared_assets/docs', '/opt/google/share/doc')
 }
 
 task openGeeServerDeb (type: Deb) {
@@ -580,6 +586,12 @@ built from raster, vector, and location properties data.
             }
         }
     }
+
+    // Create links
+    link('/opt/google/etc', '/etc/opt/google')
+    link('/opt/google/log', '/var/opt/google/log')
+    link('/opt/google/run', '/var/opt/google/run')
+    link('/opt/google/gehttpd/htdocs/shared_assets/docs', '/opt/google/share/doc')
 }
 
 task openGeeFusionDeb (type: Deb) {

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/index.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/index.html
@@ -61,8 +61,10 @@
     <a href="/cutter/" onclick="gees.admin.settingsDropdown()" target="new">Launch Cutter</a>
     <div class="SettingsLabel">Support</div>
     <a href="/shared_assets/docs/manual/" target="new">Documentation</a>
+    <!-- The following are not working and are temporarily disabled
     <a href="javascript:void(0)" onclick="gees.tools.launch.apacheLogs();gees.admin.settingsDropdown()">Apache logs</a>
     <a href="geecheck.html" onclick="gees.admin.settingsDropdown()" target="new">Diagnostics</a>
+    -->
 
   </div>
 


### PR DESCRIPTION
Fixes #671.

Adds links that the installers create but the RPMs do not.  Also removes non-working links from the server admin page.