### PR TITLE
fix #668 (fusion) dual config push fails

### DIFF
--- a/earth_enterprise/.gitignore
+++ b/earth_enterprise/.gitignore
@@ -5,3 +5,9 @@
 /*.files
 /*.includes
 
+# vs code files
+/*.vscode
+
+# compiled python
+/**/*.pyc
+

--- a/earth_enterprise/src/common/ManifestEntry.h
+++ b/earth_enterprise/src/common/ManifestEntry.h
@@ -25,12 +25,13 @@
 #include "common/khTypes.h"
 #include "common/khFileUtils.h"
 
+struct ManifestEntry;
 
 struct ManifestEntry {
   std::string orig_path;
   std::string current_path;
   uint64 data_size;
-  std::vector<std::string> dependents;
+  std::vector<ManifestEntry> dependents;
 
   ManifestEntry() : data_size(0) {}
 

--- a/earth_enterprise/src/common/ManifestEntry.h
+++ b/earth_enterprise/src/common/ManifestEntry.h
@@ -58,7 +58,8 @@ struct ManifestEntry {
   bool operator==(const ManifestEntry &other) const {
     return orig_path == other.orig_path
     && current_path == other.current_path
-        && data_size == other.data_size;
+        && data_size == other.data_size
+        && dependents == other.dependents;
   }
 };
 

--- a/earth_enterprise/src/common/ManifestEntry.h
+++ b/earth_enterprise/src/common/ManifestEntry.h
@@ -21,6 +21,7 @@
 #define COMMON_MANIFESTENTRY_H__
 
 #include <string>
+#include <vector>
 #include "common/khTypes.h"
 #include "common/khFileUtils.h"
 
@@ -29,8 +30,9 @@ struct ManifestEntry {
   std::string orig_path;
   std::string current_path;
   uint64 data_size;
+  std::vector<std::string> dependents;
 
-  ManifestEntry() {}
+  ManifestEntry() : data_size(0) {}
 
   explicit ManifestEntry(const std::string& orig_path_) :
       orig_path(orig_path_),

--- a/earth_enterprise/src/common/khFileUtils.cpp
+++ b/earth_enterprise/src/common/khFileUtils.cpp
@@ -805,7 +805,7 @@ khTmpFilename(const std::string &basename, mode_t mode)
 
 
 std::string
-khCreateTmpDir(const std::string prefix)
+khCreateTmpDir(const std::string &prefix)
 {
   std::string dirname = khTmpDirPath() + "/" + prefix;
 

--- a/earth_enterprise/src/common/khFileUtils.h
+++ b/earth_enterprise/src/common/khFileUtils.h
@@ -102,7 +102,7 @@ std::string khTmpFilename(const std::string &basename, mode_t mode = 0666);
 
 // Creates a temporary directory under /tmp (or as defined in the env).
 // The directory is created with permissions 0700.
-std::string khCreateTmpDir(const std::string prefix);
+std::string khCreateTmpDir(const std::string &prefix);
 
 void khGetNumericFilenames(const std::string &pattern,
                            std::vector<std::string>& out);

--- a/earth_enterprise/src/common/khxml/khdom.h
+++ b/earth_enterprise/src/common/khxml/khdom.h
@@ -1247,4 +1247,27 @@ DestroyDocument(khxml::DOMDocument *doc) throw();
 extern bool
 DestroyParser(khxml::DOMLSParser *parser) throw();
 
+// specialized version of SingleDeleter for document object to be
+// used with khDeleteGuard<>
+template<typename U>
+class DomDeleter {
+ public:
+  static void Delete(U* ptr) { DestroyDocument(ptr); }
+};
+
+template <typename T, template<class U> class deleter>
+class khDeleteGuard;
+
+typedef khDeleteGuard<khxml::DOMDocument, DomDeleter> khDomDeleteGuard;
+
+// specialized version of SingleDeleter for parser object to
+// be used with khDeleteGuard<>
+template<typename U>
+class ParserDeleter {
+ public:
+  static void Delete(U* ptr) { DestroyParser(ptr); }
+};
+
+typedef khDeleteGuard<khxml::DOMLSParser, ParserDeleter> khParserDeleteGuard;
+
 #endif  // GEO_EARTH_ENTERPRISE_SRC_COMMON_KHXML_KHDOM_H_

--- a/earth_enterprise/src/fusion/autoingest/tools/gedisconnectedsend.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/gedisconnectedsend.cpp
@@ -144,6 +144,15 @@ void PopulateFileMap(geFilePool &file_pool,
         if (filelists) {
           (*filelists)[i].push_back(entry->orig_path);
         }
+        for(size_t idx = 0; idx < entry->dependents.size(); ++idx)
+        {
+          const std::string& dep_file = entry->dependents[idx];
+          NameSizePair* name_size = &files[dep_file];
+          *name_size = std::make_pair(dep_file, khDiskUsage(dep_file));
+          if (filelists) {
+            (*filelists)[i].push_back(dep_file);
+          }
+        }
       }
     }
   } catch (const std::exception &e) {

--- a/earth_enterprise/src/fusion/autoingest/tools/gedisconnectedsend.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/gedisconnectedsend.cpp
@@ -133,6 +133,7 @@ void PopulateFileMap(geFilePool &file_pool,
       DbManifest dbmanifest(&(*dbpaths)[i]);
 
       std::vector<ManifestEntry> manifest;
+      notify(NFY_DEBUG, "Building manifest for: %s", (*dbpaths)[i].c_str());
       dbmanifest.GetDisconnectedManifest(file_pool, manifest, tmp_dir);
       if (filelists) {
         (*filelists)[i].reserve(manifest.size());
@@ -146,14 +147,15 @@ void PopulateFileMap(geFilePool &file_pool,
         }
         for(size_t idx = 0; idx < entry->dependents.size(); ++idx)
         {
-          const std::string& dep_file = entry->dependents[idx];
-          NameSizePair* name_size = &files[dep_file];
-          *name_size = std::make_pair(dep_file, khDiskUsage(dep_file));
+          const ManifestEntry& dep_entry = entry->dependents[idx];
+          NameSizePair* dep_name_size = &files[dep_entry.current_path];
+          *dep_name_size = std::make_pair(dep_entry.orig_path, dep_entry.data_size);
           if (filelists) {
-            (*filelists)[i].push_back(dep_file);
+            (*filelists)[i].push_back(dep_entry.orig_path);
           }
         }
       }
+      notify(NFY_DEBUG, "Done building file map for: %s", (*dbpaths)[i].c_str());
     }
   } catch (const std::exception &e) {
     notify(NFY_FATAL, "%s", e.what());

--- a/earth_enterprise/src/fusion/dbmanifest/SConscript
+++ b/earth_enterprise/src/fusion/dbmanifest/SConscript
@@ -29,4 +29,15 @@ dbmanifest = env.sharedLib(
           'gedbroot',
           'geautoingest'])
 
+dbmanifest_test = env.test('dbmanifest_unittest',
+                         ['dbmanifest_unittest.cpp'],
+                         LIBS=['gtest',
+                               'dbmanifest',
+                               'geutil',
+                               'gecommon',
+                               'xerces-c',
+                               'gexml',
+                               'qt-mt'])
+
 env.install('common_lib', [dbmanifest])
+# , 'geutil', 'gecommon', 'gexml', 'xerces-c'

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
@@ -263,7 +263,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
     // assetroot).
     geindex::IndexManifest::GetManifest(file_pool, fusion_config_.index_path_,
                                         *stream_manifest, tmp_dir, "", "");
-    notify(NFY_DEBUG, "Processing %ld POI files 1", fusion_config_.poi_file_paths_.size());
+    notify(NFY_DEBUG, "Processing %ld POI files with empty prefix", fusion_config_.poi_file_paths_.size());
     for (uint i = 0; i < fusion_config_.poi_file_paths_.size(); ++i) {
       const std::string poi_file = fusion_config_.poi_file_paths_[i];
       if (!khExists(poi_file)) {
@@ -303,7 +303,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
       }
     }
 
-    notify(NFY_DEBUG, "Processing %ld POI files 2", fusion_config_.poi_file_paths_.size());
+    notify(NFY_DEBUG, "Processing %ld POI files with prefix", fusion_config_.poi_file_paths_.size());
     // The *.poi file paths are in the GedbFusionConfig.
     for (uint i = 0; i < fusion_config_.poi_file_paths_.size(); ++i) {
       const std::string& orig = fusion_config_.poi_file_paths_[i];
@@ -356,14 +356,18 @@ void DbManifest::GetPoiDataFiles(const std::string& poi_file,
                     "No data files defined for POI file %s", poi_file.c_str());
             }
             for (uint i = 0; i < data_files.size(); ++i) {
+
               const std::string& data_file = data_files[i];
+              
+              // poi data files have to be set aside until after AddDB processing is done
+              // so we hide them in a special location now within the manifest and will
+              // use them when we crate an 'upload' manifest during DBsync processing
               if (stream_manifest != search_manifest) {
-                stream_manifest->push_back(ManifestEntry(data_file));
+                notify(NFY_DEBUG, "Adding POI datafile as a dependent file to stream manifest: %s", data_file.c_str());
                 stream_manifest->at(stream_poi_file_idx).dependents.push_back(data_file);
               }
-              search_manifest->push_back(ManifestEntry(data_file));
               search_manifest->at(search_poi_file_idx).dependents.push_back(data_file);
-              notify(NFY_DEBUG, "Adding POI datafile: %s", data_file.c_str());
+              notify(NFY_DEBUG, "Adding POI datafile as a dependent file to search manifest: %s", data_file.c_str());
             }
           } else {
             notify(NFY_WARN,

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
@@ -339,7 +339,9 @@ void DbManifest::GetPoiDataFiles(const std::string& poi_file,
                      std::vector<ManifestEntry>* search_manifest)
 {
   notify(NFY_DEBUG,
-        "Parsing poi file %s looking for data files", poi_file.c_str());
+        "Parsing POI file %s looking for data files", poi_file.c_str());
+  size_t stream_poi_file_idx = stream_manifest->size() - 1;
+  size_t search_poi_file_idx = search_manifest->size() - 1;
   khxml::DOMLSParser *parser = CreateDOMParser();
   if (parser) {
     khxml::DOMDocument *doc = ReadDocument(parser, poi_file);
@@ -351,36 +353,37 @@ void DbManifest::GetPoiDataFiles(const std::string& poi_file,
             FromElementWithChildName(el_search_table, "SearchDataFile", data_files);
             if (data_files.empty()) {
               notify(NFY_WARN,
-                    "No data files defined for poi file %s", poi_file.c_str());
+                    "No data files defined for POI file %s", poi_file.c_str());
             }
             for (uint i = 0; i < data_files.size(); ++i) {
               const std::string& data_file = data_files[i];
-              if (stream_manifest != search_manifest)
-              {
+              if (stream_manifest != search_manifest) {
                 stream_manifest->push_back(ManifestEntry(data_file));
+                stream_manifest->at(stream_poi_file_idx).dependents.push_back(data_file);
               }
               search_manifest->push_back(ManifestEntry(data_file));
+              search_manifest->at(search_poi_file_idx).dependents.push_back(data_file);
               notify(NFY_DEBUG, "Adding POI datafile: %s", data_file.c_str());
             }
           } else {
             notify(NFY_WARN,
-                  "No search table element found in poi file %s", poi_file.c_str());
+                  "No search table element found in POI file %s", poi_file.c_str());
           }
         } else {
           notify(NFY_WARN,
-                 "No document element loading poi file %s", poi_file.c_str());
+                 "No document element loading POI file %s", poi_file.c_str());
         }
       } catch(const std::exception &e) {
-        notify(NFY_WARN, "%s while loading poi file %s", e.what(), poi_file.c_str());
+        notify(NFY_WARN, "%s while loading POI file %s", e.what(), poi_file.c_str());
       } catch(...) {
-        notify(NFY_WARN, "Unable to load poi file %s", poi_file.c_str());
+        notify(NFY_WARN, "Unable to load POI file %s", poi_file.c_str());
       }
     } else {
-      notify(NFY_WARN, "Unable to read poi file %s", poi_file.c_str());
+      notify(NFY_WARN, "Unable to read POI file %s", poi_file.c_str());
     }
     DestroyParser(parser);
   } else {
-    notify(NFY_WARN, "Unable to get parser for poi file %s", poi_file.c_str());
+    notify(NFY_WARN, "Unable to get parser for POI file %s", poi_file.c_str());
   }
 }
 

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.cpp
@@ -263,6 +263,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
     // assetroot).
     geindex::IndexManifest::GetManifest(file_pool, fusion_config_.index_path_,
                                         *stream_manifest, tmp_dir, "", "");
+    notify(NFY_DEBUG, "Processing %ld POI files 1", fusion_config_.poi_file_paths_.size());
     for (uint i = 0; i < fusion_config_.poi_file_paths_.size(); ++i) {
       const std::string poi_file = fusion_config_.poi_file_paths_[i];
       if (!khExists(poi_file)) {
@@ -272,7 +273,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
           stream_manifest->push_back(ManifestEntry(poi_file));
         }
         search_manifest->push_back(ManifestEntry(poi_file));
-        GetPoiDataFiles(poi_file, search_manifest);
+        GetPoiDataFiles(poi_file, stream_manifest, search_manifest);
       }
     }
     // These file paths are listed directly in the GedbFusionConfig.
@@ -302,6 +303,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
       }
     }
 
+    notify(NFY_DEBUG, "Processing %ld POI files 2", fusion_config_.poi_file_paths_.size());
     // The *.poi file paths are in the GedbFusionConfig.
     for (uint i = 0; i < fusion_config_.poi_file_paths_.size(); ++i) {
       const std::string& orig = fusion_config_.poi_file_paths_[i];
@@ -316,7 +318,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
           stream_manifest->push_back(ManifestEntry(orig, curr));
         }
         search_manifest->push_back(ManifestEntry(orig, curr));
-        GetPoiDataFiles(curr, search_manifest);
+        GetPoiDataFiles(curr, stream_manifest, search_manifest);
       }
     }
 
@@ -333,6 +335,7 @@ void DbManifest::GetManifest(geFilePool &file_pool,
 // Read POI file and extract the data file names from within it and then add
 // them to the manifest too
 void DbManifest::GetPoiDataFiles(const std::string& poi_file,
+                     std::vector<ManifestEntry>* stream_manifest,
                      std::vector<ManifestEntry>* search_manifest)
 {
   notify(NFY_DEBUG,
@@ -352,7 +355,12 @@ void DbManifest::GetPoiDataFiles(const std::string& poi_file,
             }
             for (uint i = 0; i < data_files.size(); ++i) {
               const std::string& data_file = data_files[i];
+              if (stream_manifest != search_manifest)
+              {
+                stream_manifest->push_back(ManifestEntry(data_file));
+              }
               search_manifest->push_back(ManifestEntry(data_file));
+              notify(NFY_DEBUG, "Adding POI datafile: %s", data_file.c_str());
             }
           } else {
             notify(NFY_WARN,

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
@@ -137,10 +137,9 @@ class DbManifest {
                    const std::string& publish_prefix);
 
 // Read POI file and extract the data file names from within it and then add
-// them to the manifest too
-void GetPoiDataFiles(const std::string& poi_file,
-                     std::vector<ManifestEntry>* stream_manifest,
-                     std::vector<ManifestEntry>* search_manifest);
+// them to the manifest entries as dependant files
+void GetPoiDataFiles(ManifestEntry* stream_manifest_entry,
+                     ManifestEntry* search_manifest_entry);
 
   // For mapdb and creates the following files in db_path_:
   // [1] json/maps.json.DEFAULT

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
@@ -136,6 +136,11 @@ class DbManifest {
                    const std::string& tmp_dir,
                    const std::string& publish_prefix);
 
+// Read POI file and extract the data file names from within it and then add
+// them to the manifest too
+void GetPoiDataFiles(const std::string& poi_file,
+                     std::vector<ManifestEntry>* search_manifest);
+
   // For mapdb and creates the following files in db_path_:
   // [1] json/maps.json.DEFAULT
   // [2] search_tabs/searchtabs.js

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest.h
@@ -139,6 +139,7 @@ class DbManifest {
 // Read POI file and extract the data file names from within it and then add
 // them to the manifest too
 void GetPoiDataFiles(const std::string& poi_file,
+                     std::vector<ManifestEntry>* stream_manifest,
                      std::vector<ManifestEntry>* search_manifest);
 
   // For mapdb and creates the following files in db_path_:

--- a/earth_enterprise/src/fusion/dbmanifest/dbmanifest_unittest.cpp
+++ b/earth_enterprise/src/fusion/dbmanifest/dbmanifest_unittest.cpp
@@ -1,0 +1,165 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Unit Tests for DB manifest
+
+#include <string>
+#include <gtest/gtest.h>
+
+#include "common/notify.h"
+#include "common/khSimpleException.h"
+#include "common/geFilePool.h"
+#include "common/khConstants.h"
+#include "common/khxml/khxml.h"
+#include "common/khxml/khdom.h"
+#include "fusion/dbmanifest/dbmanifest.h"
+
+class DbManifestTest : public testing::Test {
+
+  protected:
+
+  virtual void SetUp() {
+  }
+
+  virtual void TearDown() {
+  }
+
+  public:
+
+  geFilePool file_pool_;
+  const std::string test_folder_;
+  const std::string vol_root_;
+  const std::string assets_root_;
+  const std::string projects_root_;
+  const std::string vector_project_root_;
+  const std::string fake_vector_project_name_;
+  const std::string fake_vector_project_root_;
+  const std::string poi_file_path_;
+  const std::string poi_data_file_path_;
+  const std::string dbs_root_;
+  const std::string fake_db_name_;
+  const std::string fake_db_root_;
+  const std::string ge_db_key_root_;
+  const std::string ge_unified_index_root_;
+  const std::string db_path_v1_;
+  const std::string toc_file_spec1_;
+  const std::string toc_path1_;
+  const std::string db_header_path_;
+ 
+  DbManifestTest()
+    :test_folder_(khCreateTmpDir("geManifestTesting"))
+    ,vol_root_(khComposePath(test_folder_, "gevol_test"))
+    ,assets_root_(khComposePath(vol_root_, "assets"))
+    ,projects_root_(khComposePath(assets_root_, "Projects"))
+    ,vector_project_root_(khComposePath(assets_root_, "Vector"))
+    ,fake_vector_project_name_("fakeVectorProject")
+    ,fake_vector_project_root_(khComposePath(vector_project_root_, fake_vector_project_name_ + kVectorProjectSuffix))
+    ,poi_file_path_(khComposePath(fake_vector_project_root_, "layer005.kva/poi.kva/ver001/poifile"))
+    ,poi_data_file_path_(khComposePath(fake_vector_project_root_, "layer005.kva/poi.kva/ver001/poifile0"))
+    ,dbs_root_(khComposePath(assets_root_, "Databases"))
+    ,fake_db_name_("fakeDB")
+    ,fake_db_root_(khComposePath(dbs_root_, fake_db_name_ + kDatabaseSuffix))
+    ,ge_db_key_root_(khComposePath(fake_db_root_, kGedbKey))
+    ,ge_unified_index_root_(khComposePath(fake_db_root_, kUnifiedIndexKey, "ver001/unified.geindex"))
+    ,db_path_v1_(khComposePath(ge_db_key_root_, "ver001", kGedbBase))
+    ,toc_file_spec1_(kPostamblePrefix + kDefaultLocaleSuffix)
+    ,toc_path1_(khComposePath(db_path_v1_, kDbrootsDir, toc_file_spec1_))
+    ,db_header_path_(khComposePath(db_path_v1_, kHeaderXmlFile))
+    {}
+
+  ~DbManifestTest() {
+    khPruneDir(test_folder_);
+  }
+
+  void CreateFakeDbFolderWithPoiData(const std::string& file_loc = std::string()) {
+    std::string actual_db_header_path;
+    std::string actual_poi_file_path;
+    std::string actual_poi_data_file_path;
+
+    if (!file_loc.empty()) {
+      actual_db_header_path = khComposePath(file_loc, db_header_path_);
+      actual_poi_file_path = khComposePath(file_loc, poi_file_path_);
+      actual_poi_data_file_path = khComposePath(file_loc, poi_data_file_path_);
+    }
+    else {
+      actual_db_header_path = db_header_path_;
+      actual_poi_file_path = poi_file_path_;
+      actual_poi_data_file_path = poi_data_file_path_;
+    }
+
+    // Create a header file for the DB that has one POI file it points to.
+    khDomDeleteGuard dom(TransferOwnership(CreateEmptyDocument("DbHeader")));
+    khxml::DOMElement* root_elm = dom->getDocumentElement();
+    AddElement(root_elm, "index_path", ge_unified_index_root_);
+    khxml::DOMElement* toc_paths_elm = dom->createElement(ToXMLStr("toc_paths"));
+    root_elm->appendChild(toc_paths_elm);
+    AddElement(toc_paths_elm, "toc_path", toc_path1_);
+    khxml::DOMElement* search_tabs_elm = dom->createElement(ToXMLStr("search_tabs"));
+    root_elm->appendChild(search_tabs_elm);
+    khxml::DOMElement* poi_file_paths_elm = dom->createElement(ToXMLStr("poi_file_paths"));
+    root_elm->appendChild(poi_file_paths_elm);
+    AddElement(poi_file_paths_elm, "poi_file_path", poi_file_path_);
+    khxml::DOMElement* icons_dirs_elm = dom->createElement(ToXMLStr("icons_dirs"));
+    root_elm->appendChild(icons_dirs_elm);
+    AddElement(root_elm, "database_version", "3");
+    AddElement(root_elm, "db_type", "TYPE_GEDB");
+    AddElement(root_elm, "use_google_imagery", "0");
+    AddElement(root_elm, "is_mercator", "0");
+    AddElement(root_elm, "fusion_host", "fusion.tst");
+
+    // write out the header file
+    khEnsureParentDir(actual_db_header_path);
+    WriteDocument(dom, actual_db_header_path);
+
+    // Create the fake poi file
+    khDomDeleteGuard poi_file_dom(TransferOwnership(CreateEmptyDocument("POISearchFile")));
+    khxml::DOMElement* poi_file_root_elm = poi_file_dom->getDocumentElement();
+    khxml::DOMElement* search_table_values_elm = poi_file_dom->createElement(ToXMLStr("SearchTableValues"));
+    poi_file_root_elm->appendChild(search_table_values_elm);
+    AddElement(search_table_values_elm, "SearchDataFile", poi_data_file_path_);
+
+    // write out the poi file
+    khEnsureParentDir(actual_poi_file_path);
+    WriteDocument(poi_file_dom, actual_poi_file_path);
+
+    // write out the poi data file (empty file for these tests)
+    khMakeEmptyFile(actual_poi_data_file_path);
+  }
+};
+
+// Basic constructor tests
+TEST_F(DbManifestTest, EnforcesAbsolutePath) {
+  std::string not_an_absolute_path("../not/an/absolute/path");
+  EXPECT_THROW(TransferOwnership(new DbManifest(&not_an_absolute_path)), khSimpleException);
+}
+
+TEST_F(DbManifestTest, AssetRootDB) {
+  khDeleteGuard<DbManifest> db_manifest;
+  std::string db_path(db_path_v1_);
+
+  CreateFakeDbFolderWithPoiData();
+
+  EXPECT_NO_THROW(db_manifest = TransferOwnership(new DbManifest(&db_path)));
+  EXPECT_EQ(db_path_v1_, db_path); // should be unchanged
+
+  // TODO(RAW): add more checking
+}
+
+// TODO(RAW): cover all use cases: see comments in dbmanifest.cpp
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/earth_enterprise/src/fusion/gepublish/PublishHelper.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublishHelper.cpp
@@ -156,7 +156,8 @@ bool PublishHelper::ProcessGetRequest(const std::string& url,
   else
     *args += host_name;
 
-  notify(NFY_DEBUG, "ProcessGetRequest %s Starting", url.c_str());
+  notify(NFY_DEBUG, "Request %s args: %s", url.c_str(),
+         (username_.empty() ? "nouser" : "user"));
 
   int status = request.Start(*args);
   int max_retries = 3;

--- a/earth_enterprise/src/fusion/gepublish/PublishHelper.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublishHelper.cpp
@@ -156,8 +156,7 @@ bool PublishHelper::ProcessGetRequest(const std::string& url,
   else
     *args += host_name;
 
-  notify(NFY_DEBUG, "Request %s args: %s %s", url.c_str(), args->c_str(),
-         (username_.empty() ? "nouser" : "user"));
+  notify(NFY_DEBUG, "ProcessGetRequest %s Starting", url.c_str());
 
   int status = request.Start(*args);
   int max_retries = 3;

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -1357,7 +1357,7 @@ bool PublisherClient::SyncFiles(
         // like search manifests server does special processing on files in that manifest that
         // can't be done on the dependent files.
         for(size_t dep_idx = 0; dep_idx < manifest_entries[index].dependents.size(); ++dep_idx) {
-          upload_entries.push_back(ManifestEntry(manifest_entries[index].dependents[dep_idx]));
+          upload_entries.push_back(manifest_entries[index].dependents[dep_idx]);
         }
       }
 

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.h
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.h
@@ -217,6 +217,12 @@ class PublisherClient : public PublishHelper {
                      const std::string& src_path,
                      const std::string& dest_path,
                      bool prefer_copy);
+  bool LocalTransferWithRetry(const std::string& server_prefix,
+                     const std::string& host_root,
+                     ServerType server_type,
+                     const std::string& tmpdir,
+                     const std::string& current_path,
+                     const std::string& orig_path);
   bool UploadFiles(ServerType server_type,
                    const std::vector<ManifestEntry>& entries,
                    const std::string& tmpdir,

--- a/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
@@ -449,7 +449,7 @@ class SearchPushManager(search_manager.SearchManager):
     if not self.server_prefix:
       raise exceptions.SearchPushServeException(
           "Unable to read WebDAV Config.")
-    logger.info("Server Prefix: " + self.server_prefix)
+    logger.info("Server Prefix xxxxxxxxx: " + self.server_prefix)
 
   def __ReadPublishRootConfig(self):
     self.allow_symlinks = "N"
@@ -514,6 +514,10 @@ class SearchPushManager(search_manager.SearchManager):
     """
     logger.debug("__UpdatePoiStatus...")
     file_prefix = self.__ServerFilePrefix(client_host_name)
+    if file_prefix is None:
+      logger.info("File prefix is None")
+    else:
+      logger.info("File prefix is '%s'", file_prefix)
     existing_files = []
     i = 0
     while i in range(len(file_paths)):
@@ -535,7 +539,7 @@ class SearchPushManager(search_manager.SearchManager):
       poi_id = self._QueryPoiId(client_host_name, existing_file)
       server_file_path = os.path.normpath(file_prefix + existing_file)
       (num_fields, query_str, balloon_style) = self.__CreatePoiTable(
-          server_file_path, self.__PoiTableName(poi_id))
+          server_file_path, self.__PoiTableName(poi_id), file_prefix)
 
       # Update the poi_table. Change the status to 1 and update query_strs.
       self._DbModify(update_string,
@@ -565,7 +569,7 @@ class SearchPushManager(search_manager.SearchManager):
     """
     return "%s%d" % (SearchPushManager.POI_TABLE_PREFIX, poi_id)
 
-  def __CreatePoiTable(self, poi_file_path, table_name):
+  def __CreatePoiTable(self, poi_file_path, table_name, file_prefix=None):
     """Creates and populates POI table.
 
     Args:
@@ -581,7 +585,11 @@ class SearchPushManager(search_manager.SearchManager):
     Raises:
       SearchSchemaTableUtilException, psycopg2.Warning/Error.
     """
-    return self.table_utility.CreatePoiTable(poi_file_path, table_name.lower())
+    if file_prefix is None:
+      logger.info("File prefix is None")
+    else:
+      logger.info("File prefix is '%s'", file_prefix)
+    return self.table_utility.CreatePoiTable(poi_file_path, table_name.lower(), file_prefix)
 
 
 def main():

--- a/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
@@ -530,7 +530,7 @@ class SearchPushManager(search_manager.SearchManager):
           serve_utils.FileSizeMatched(server_file_path, file_sizes[i])):
 
         existing_files.append(file_paths[i])
-        logger.debug("%s already exists", server_file_path)
+        logger.debug("%s already exist", server_file_path)
 
         file_paths.pop(i)
         file_sizes.pop(i)

--- a/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
@@ -241,6 +241,7 @@ class SearchPushManager(search_manager.SearchManager):
             insert_into_poi_table,
             (client_host_name, poi_file_paths[i], poi_file_sizes[i]))
         poi_id = self._QueryPoiId(client_host_name, poi_file_paths[i])
+        logger.debug("inserted %s into poi_table with id of %d", poi_file_paths[i], poi_id)
 
       assert poi_id != 0
       # Add db_poi mapping table entry.
@@ -452,7 +453,7 @@ class SearchPushManager(search_manager.SearchManager):
     if not self.server_prefix:
       raise exceptions.SearchPushServeException(
           "Unable to read WebDAV Config.")
-    logger.info("Server Prefix xxxxxxxxx: " + self.server_prefix)
+    logger.info("Server Prefix: " + self.server_prefix)
 
   def __ReadPublishRootConfig(self):
     self.allow_symlinks = "N"
@@ -529,11 +530,13 @@ class SearchPushManager(search_manager.SearchManager):
           serve_utils.FileSizeMatched(server_file_path, file_sizes[i])):
 
         existing_files.append(file_paths[i])
+        logger.debug("%s already exists", server_file_path)
 
         file_paths.pop(i)
         file_sizes.pop(i)
       else:
         i += 1
+        logger.debug("%s does not exists", server_file_path)
 
     # Create POI tables for the files that are already uploaded.
     update_string = ("UPDATE poi_table SET status = 1, num_fields = %s,"

--- a/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/core/search_push_manager.py
@@ -186,6 +186,9 @@ class SearchPushManager(search_manager.SearchManager):
           " poi file_paths/file_sizes mismatch: %d/%d" %
           (len(poi_file_paths), len(poi_file_sizes)))
 
+    logger.debug("poi_file_paths: %s", str(poi_file_paths))
+    logger.debug("poi_file_sizes: %s", str(poi_file_sizes))
+
     # Check if database already exists.
     # The assumption is if it already exists, all the files and db-to-files
     # links have already been pushed to the database.

--- a/earth_enterprise/src/server/wsgi/serve/push/search/util/search_schema_parser.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/util/search_schema_parser.py
@@ -227,7 +227,14 @@ class SearchSchemaParser(object):
       data_file_name = elem.text
       if self._file_prefix is not None:
         logger.info("Adding prefix to poi data file: '%s'", self._file_prefix)
-        data_file_name = os.path.normpath(self._file_prefix + data_file_name)
+        data_file_name_with_prefix = os.path.normpath(self._file_prefix + data_file_name)
+        if not os.path.exists(data_file_name_with_prefix) and os.path.exists(data_file_name):
+          # might be talking to an old fusion client so preserve
+          # old behavior if the prefixed file does not exist
+          # but the non-prefixed file does
+          pass
+        else:
+          data_file_name = data_file_name_with_prefix
       else:
         logger.info("Missing file prefix!")
       data_file = open(data_file_name, "r")

--- a/earth_enterprise/src/server/wsgi/serve/push/search/util/search_schema_table_util.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/util/search_schema_table_util.py
@@ -42,7 +42,7 @@ class SearchSchemaTableUtil(object):
     """
     self._poi_db_connection = poi_db_connection
 
-  def CreatePoiTable(self, poi_file, table_name):
+  def CreatePoiTable(self, poi_file, table_name, file_prefix=None):
     """Creates and populates POI table in gepoi database.
 
     Creates POI table with specified table name and populates with data from
@@ -71,8 +71,12 @@ class SearchSchemaTableUtil(object):
 
     # Parse POI search file.
     try:
+      if file_prefix is None:
+        logger.info("file prefix is None")
+      else:
+        logger.info("file prefix is: '%s'", file_prefix)
       (num_fields, query_string, balloon_style) = parser.Parse(
-          poi_file, table_name)
+          poi_file, table_name, file_prefix)
     except (psycopg2.Error, psycopg2.Warning) as e:
       logger.error("Error when parsing/ingesting poifile %s: %s", poi_file, e)
       db_updater.Rollback()


### PR DESCRIPTION
Fixes #668 

Adding support to make sure poi data files are included in the manifest when pushing a database to the server.