### PR TITLE
Globe Assembly and Diassembly fails on Red Hat 6 (and CentOS 6)

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -332,6 +332,11 @@ def RunCmd(os_cmd):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     results = p.communicate()[1]
+    return_code = p.returncode
+    if return_code != 0:
+      errorMessage = "%s (return code %d)" % (results, return_code)
+      results = errorMessage
+
     return results.split("\n")
   except Exception, e:
     # print "FAILURE: %s" % e.__str__()

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -332,10 +332,9 @@ def RunCmd(os_cmd):
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     results = p.communicate()[1]
-    return_code = p.returncode
-    if return_code != 0:
-      errorMessage = "%s (return code %d)" % (results, return_code)
-      results = errorMessage
+    if p.returncode != 0:
+      results = "{0} (return code {1})".format(results, p.returncode)
+      return ["", results]
 
     return results.split("\n")
   except Exception, e:

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -331,12 +331,14 @@ def RunCmd(os_cmd):
     p = subprocess.Popen(os_cmd, shell=False,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
-    results = p.communicate()[1]
-    if p.returncode != 0:
-      results = "{0} (return code {1})".format(results, p.returncode)
+    results = p.communicate()[0]
+    err_data = p.communicate()[1]
+    return_code = p.returncode
+    if return_code != 0:
+      results = "{0} (return code {1})".format(err_data, return_code)
       return ["", results]
-
-    return results.split("\n")
+    else:
+      return results.split("\n")
   except Exception, e:
     # print "FAILURE: %s" % e.__str__()
     return ["", e.__str__()]

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -328,9 +328,12 @@ def RunCmd(os_cmd):
   try:
     if isinstance(os_cmd, str):
       os_cmd = shlex.split(os_cmd)
-    results = subprocess.check_output(os_cmd)
+    p = subprocess.Popen(os_cmd, shell=False,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    results = p.communicate()[1]
     return results.split("\n")
-  except subprocess.CalledProcessError as e:
+  except Exception, e:
     # print "FAILURE: %s" % e.__str__()
     return ["", e.__str__()]
 


### PR DESCRIPTION
This fix #677 

'check_output' was introduced in python 2.7. Using that function for Red Hat 6 that uses python 2.6 give the reported error ("'module' object has no attribute 'check_output' ".).

- Enable 'cutter': sudo /opt/google/bin/gecutter enable
- Use an existing '.glc' or create one using 'Cutter' 
- Register that '.glc' in GEE Server (or simply copy it to '/opt/google/gehttpd/htdocs/cutter/globes/')
- Try to Disassemble the registered '.glc':
- Go to the GEE Server administrative page (https://server.host.name/admin).
- Go to 'Settings' → 'Glc Disassembly'.
- Select the GLC from the drop down.
- Enter a 'New output directory' that's different from the input directory.
- Click 'Dissassemble glc'

--> An error is posted: FAILED 'module' object has no attribute 'check_output'

Expected behavior: no error. Disassembling should work.

The same error is encountered when trying to assemble a globe:
Start with at least 2 glm or glb files registered in GEE Server
- Open GLC Assembler
- Add 2 glm or glb files as layers in the GLC
- Select "Use Search" on one of the globes
- Fill out the rest of the fields as normal, including KML for polygon
- Click Assemble GLC
Expected: GLC assembly completes without error
Actual: fails with: "FAILED 'module' object has no attribute 'check_output' ".