### PR TITLE
#689: Fix RPATHs for Qt and Security

### DIFF
--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -232,12 +232,14 @@ if gprof:
 
 # setup -rpath-link and -rpath options
 rpathlink_dirs = [Dir(exportdirs['lib']).abspath]
-rpath_dirs = [Dir(exportdirs['lib']).abspath,
-              "'$$ORIGIN/../qt/lib'",
+# SetUID binaries don't use RPATH's containing '$ORIGIN' (since that would be
+# exploitable).  Use absolute paths to library install locations instead:
+rpath_dirs = ["'$$ORIGIN/../qt/lib'",
               "'$$ORIGIN/../lib64'",
               "'$$ORIGIN/../lib'",
               '%s/lib64' % optdir,
-              '%s/lib' % optdir]
+              '%s/lib' % optdir,
+              '%s/qt/lib' % optdir]
 
 # setup crosstool directories.
 if not native_cc:

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -106,7 +106,7 @@ foreach my $test (@tests) {
     my @testcases;
     my $prev = "";
 
-    if (open(OUTPUT, "$test 2>&1 |")) {
+    if (open(OUTPUT, "LD_LIBRARY_PATH=\"../../lib\" $test 2>&1 |")) {
         while (<OUTPUT>) {
             my $line = $_;
 

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -417,6 +417,11 @@ class khEnvironment(Environment):
 
     DefineProtocolBufferBuilder(self)
 
+  def bash_escape(self, value):
+    """Escapes a given value as a BASH string."""
+
+    return "'{0}'".format(value.replace("'", "'\\''"))
+
   def DeepCopy(self):
     other = self.Clone()
     other.MultiCommand = SCons.Action.ActionFactory(other.MultiCommandFunc,

--- a/earth_enterprise/src/third_party/libcurl/SConscript
+++ b/earth_enterprise/src/third_party/libcurl/SConscript
@@ -34,6 +34,7 @@ build_root = '%s/%s' % (current_dir, libcurl_version)
 install_root = '%s/install' % current_dir
 install_root_opt = '%s%s' % (install_root, opt_dir)
 
+
 # [1] Extract libcurl
 libcurl_target = '%s/.extract' % current_dir
 libcurl_extract = libcurl_env.Command(
@@ -62,15 +63,24 @@ libcurl_target = '%s/.configure' % current_dir
 libcurl_configure = libcurl_env.Command(
     libcurl_target, libcurl_extract,
     [libcurl_env.MultiCommand(
-        'cd %s\n'
-        '%s%s ./configure --prefix=%s '
-        '--with-ssl --without-ca-bundle '
-        '--without-zlib --without-libidn --without-krb4 --without-gnutls '
-        '--enable-shared --disable-static %s\n'
-        'touch %s' % (build_root,
-                      libcurl_env['ENV']['mod_env'], env_opt, opt_dir,
-                      config_opt,
-                      libcurl_target))])
+        ('cd {build_root_escaped}\n'
+         'export LD_LIBRARY_PATH={build_lib_dir_escaped}\n'
+         '{mod_env}{env_opt} ./configure --prefix={opt_dir_escaped} '
+            '--with-ssl --without-ca-bundle '
+            '--without-zlib --without-libidn --without-krb4 --without-gnutls '
+            '--enable-shared --disable-static {config_opt}\n'
+         'touch {libcurl_target_escaped}'
+        ).format(
+            build_root_escaped = libcurl_env.bash_escape(build_root),
+            build_lib_dir_escaped =
+                libcurl_env.bash_escape(libcurl_env.exportdirs['lib']),
+            mod_env = libcurl_env['ENV']['mod_env'],
+            env_opt = env_opt,
+            opt_dir_escaped = libcurl_env.bash_escape(opt_dir),
+            config_opt = config_opt,
+            libcurl_target_escaped = libcurl_env.bash_escape(libcurl_target)
+        )
+    )])
 
 # [4] Build
 libcurl_target = '%s/.build' % current_dir

--- a/earth_enterprise/src/third_party/postgresql/SConscript
+++ b/earth_enterprise/src/third_party/postgresql/SConscript
@@ -59,11 +59,21 @@ postgresql_target = '%s/.configure' % current_dir
 postgresql_configure = postgresql_env.Command(
     postgresql_target, postgresql_extract,
     [postgresql_env.MultiCommand(
-        'cd %s\n'
-        '%s ./configure --prefix=/opt/google --mandir=/opt/google/share/man '
-        '--disable-rpath --enable-thread-safety --with-openssl --with-python '
-        '--without-perl --without-readline --without-pam --without-krb5 %s\n'
-        'touch %s' % (build_root, env_opt, config_opt, postgresql_target))])
+        ('cd {build_root_escaped}\n'
+         'export LD_LIBRARY_PATH={build_lib_dir_escaped}\n'
+         '{env_opt} ./configure --prefix=/opt/google --mandir=/opt/google/share/man '
+            '--disable-rpath --enable-thread-safety --with-openssl --with-python '
+            '--without-perl --without-readline --without-pam --without-krb5 {config_opt}\n'
+         'touch {postgresql_target_escaped}'
+        ).format(
+            build_root_escaped = postgresql_env.bash_escape(build_root),
+            build_lib_dir_escaped =
+                postgresql_env.bash_escape(postgresql_env.exportdirs['lib']),
+            env_opt = env_opt,
+            config_opt = config_opt,
+            postgresql_target_escaped =
+                postgresql_env.bash_escape(postgresql_target)
+        ))])
 
 # [3] Build
 make_options = '-j%d' % num_cpu


### PR DESCRIPTION
* Added the install path of the QT library bundled with GEE to the RPATHs of
  GEE binaries.  The relative path to that directory is already added to the
  RPATHs, but SetUID binaries don't load libraries from relative paths to avoid
  security vulnerabilities, so absolute paths are necessary for them.

* Removed the path to the build location of GEE libraries from the RPATHs of
  GEE binaries.  Having an RPATH to an unexpected directory under the home of a
  regular usuer is a security vulnerability.

Fixes #689.