### PR TITLE
Added function to work around xpath issues in el6

### DIFF
--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -69,6 +69,18 @@ CENTOSKEY="centos"
 OS_RELEASE1="/etc/os-release"
 OS_RELEASE2="/etc/system-release"
 
+xml_file_get_xpath()
+{
+    local FILE="$1"
+    local XPATH="$2"
+
+    # Warning: `xmllint --noent` doesn't recognize named entities like
+    # "&lt;" and "&gt;":
+    echo "cat $XPATH" | xmllint --noent --nocdata --shell "$FILE" |
+    # Skip the first and the last line:
+        tail -n +2 | head -n -1
+}
+
 software_check()
 {
     local software_check_retval=0

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -225,18 +225,6 @@ show_fusion_running_message()
 	echo -e "To use this installer to upgrade, you must stop all fusion services.\n"	
 }
 
-xml_file_get_xpath()
-{
-    local FILE="$1"
-    local XPATH="$2"
-
-    # Warning: `xmllint --noent` doesn't recognize named entities like
-    # "&lt;" and "&gt;":
-    echo "cat $XPATH" | xmllint --noent --nocdata --shell "$FILE" |
-    # Skip the first and the last line:
-        tail -n +2 | head -n -1
-}
-
 load_systemrc_config()
 {
 	if [ -f "$SYSTEMRC" ]; then

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -225,13 +225,25 @@ show_fusion_running_message()
 	echo -e "To use this installer to upgrade, you must stop all fusion services.\n"	
 }
 
+xml_file_get_xpath()
+{
+    local FILE="$1"
+    local XPATH="$2"
+
+    # Warning: `xmllint --noent` doesn't recognize named entities like
+    # "&lt;" and "&gt;":
+    echo "cat $XPATH" | xmllint --noent --nocdata --shell "$FILE" |
+    # Skip the first and the last line:
+        tail -n +2 | head -n -1
+}
+
 load_systemrc_config()
 {
 	if [ -f "$SYSTEMRC" ]; then
 		# read existing config information
-		ASSET_ROOT=$(xmllint --xpath '//Systemrc/assetroot/text()' $SYSTEMRC)
-		GEFUSIONUSER_NAME=$(xmllint --xpath '//Systemrc/fusionUsername/text()' $SYSTEMRC)
-		GROUPNAME=$(xmllint --xpath '//Systemrc/userGroupname/text()' $SYSTEMRC)		
+		ASSET_ROOT=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/assetroot/text()")
+		GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+		GROUPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
 	fi
 }
 

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -742,8 +742,9 @@ check_asset_root_volume_size()
 check_fusion_master_or_slave()
 {
     if [ -f "$ASSET_ROOT/.config/volumes.xml" ]; then
-        EXISTING_HOST=$(xmllint --xpath "//VolumeDefList/volumedefs/item[1]/host/text()" $ASSET_ROOT/.config/volumes.xml | $NEWLINECLEANER)
-
+        #EXISTING_HOST=$(xmllint --xpath "//VolumeDefList/volumedefs/item[1]/host/text()" $ASSET_ROOT/.config/volumes.xml | $NEWLINECLEANER)
+	EXISTING_HOST=$(xml_file_get_xpath "$ASSET_ROOT/.config/volumes.xml" "//VolumeDefList/volumedefs/item[1]/host/text()")
+	EXISTING_HOST=`echo "$EXISTING_HOST" | $NEWLINECLEANER)`
         case "$EXISTING_HOST" in
 			$HOSTNAME_F|$HOSTNAME_A|$HOSTNAME_S|$HOSTNAME)
                 IS_SLAVE=false

--- a/earth_enterprise/src/installer/uninstall_fusion.sh
+++ b/earth_enterprise/src/installer/uninstall_fusion.sh
@@ -202,18 +202,6 @@ show_fusion_running_message()
 	echo -e "To use this uninstaller, you must stop all fusion services.\n"	
 }
 
-xml_file_get_xpath()
-{
-    local FILE="$1"
-    local XPATH="$2"
-
-    # Warning: `xmllint --noent` doesn't recognize named entities like
-    # "&lt;" and "&gt;":
-    echo "cat $XPATH" | xmllint --noent --nocdata --shell "$FILE" |
-    # Skip the first and the last line:
-        tail -n +2 | head -n -1
-}
-
 load_systemrc_config()
 {
     local load_systemrc_config_retval=0

--- a/earth_enterprise/src/installer/uninstall_fusion.sh
+++ b/earth_enterprise/src/installer/uninstall_fusion.sh
@@ -396,13 +396,8 @@ change_volume_ownership()
 
             local volume_name="test"
             local index=1
-###
-	    echo "$CONFIG_VOLUME"
-	    exit 0
-###
-            #local max_index=$(expr "$(xmllint --xpath 'count(//VolumeDefList/volumedefs/item/localpath)' $CONFIG_VOLUME)")
-            local temp=$(xml_file_get_xpath "$CONFIG_VOLUME" "//VolumeDefList/volumedefs/item/localpath")
-	    local max_index=`echo "$temp" | grep localpath | grep -v / | wc -l`
+            local xpath_output=$(xml_file_get_xpath "$CONFIG_VOLUME" "//VolumeDefList/volumedefs/item/localpath")
+	    local max_index=`echo "$xpath_output" | grep localpath | wc -l`
             while [ $index -le $max_index ]; 
             do                
                 volume_name=$(xml_file_get_xpath "$CONFIG_VOLUME" "//VolumeDefList/volumedefs/item[$index]/localpath/text()")


### PR DESCRIPTION
Added xml_file_get_xpath( ) to install_fusion.sh. Git-lfs is not being detected in src/SConscript 

`File "/home/basilh/workspace/ee_bh/earth_enterprise/src/SConstruct", line 507, in <module>
It appears that git lfs is not installed.  Please
install git lfs (instructions are available at
https://git-lfs.github.com).  Then run
'git lfs pull' to pull down large files before
building.
scons: *** [build] Error 1
scons: building terminated because of errors.
`

When relevant portions are commented out, build still fails:

`set -x && cd /home/basilh/workspace/ee_bh/earth_enterprise/src/NATIVE-DBG-x86_64/third_party/libjs/mozilla && tar xzf`
`/home/basilh/workspace/ee_bh/earth_enterprise/third_party/libjs/js-1.8.0-rc1.tar.gz js/src/config` `js/src/editline && touch /home/basilh/workspace/ee_bh/earth_enterprise/src/NATIVE-DBG-x86_64/third_party/libjs/.extract_libjs`
`+ cd /home/basilh/workspace/ee_bh/earth_enterprise/src/NATIVE-DBG-x86_64/third_party/libjs/mozilla`
`+ tar xzf /home/basilh/workspace/ee_bh/earth_enterprise/third_party/libjs/js-1.8.0-rc1.tar.gz `js/src/config js/src/editline`

`gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
scons: *** Error 2
scons: *** [NATIVE-DBG-x86_64/third_party/libjs/.extract_libjs] Error 2
scons: building terminated because of errors.
scons: *** [build] Error 2
scons: building terminated because of errors.
`