### PR TITLE
fix #670: restore admin diagnostics

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -134,7 +134,7 @@ sudo yum install -y scons perl-Perl4-CoreLibs xorg-x11-server-devel \
   libmng-devel libcap-devel libpng-devel libXmu-devel freeglut-devel \
   zlib-devel libX11-devel bison-devel openjpeg-devel openjpeg2-devel \
   geos-devel proj-devel ogdi-devel giflib-devel xerces-c xerces-c-devel \
-  cmake GitPython rpm-build rpmrebuild rsync shunit2
+  cmake GitPython rpm-build rpmrebuild rsync shunit2 python-unittest2
 ```
 
 If you encounter an error about git dependency conflicts, consider 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -399,6 +399,7 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     // `opengee-server` bundles Apache, and Apache requires utilities from the
     // `initscripts` package:
     requires('initscripts')
+    requires('python-unittest2')
 
     requiresCommands(
         packageSharedCommands +

--- a/earth_enterprise/rpms/opengee-server/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/post-install.sh
@@ -58,7 +58,7 @@ main_postinstall()
 
     # 8) Run geecheck config script
     # If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
-    if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
+    if [ -f "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin/set_geecheck_config.py" ] ; then
         cd "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin"
         python ./set_geecheck_config.py
     fi

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -331,8 +331,9 @@ def RunCmd(os_cmd):
     p = subprocess.Popen(os_cmd, shell=False,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
-    results = p.communicate()[0]
-    err_data = p.communicate()[1]
+    output = p.communicate()
+    results = output[0]
+    err_data = output[1]
     return_code = p.returncode
     if return_code != 0:
       results = "{0} (return code {1})".format(err_data, return_code)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck.py
@@ -21,8 +21,13 @@ import sys
 import StringIO
 import time
 import traceback
-import unittest
 import os
+
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 
 # Capture the error and out streams for use in test reports.
 gee_err_stream = StringIO.StringIO()

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -24,10 +24,10 @@ LATEST_VERSION = '5.2.1'
 
 SUPPORTED_OS_LIST = {
     'redhat': {'min_release': '6.0',
-               'max_release': '6.5'},
+               'max_release': '7.4'},
     'Ubuntu': {'min_release': '10.04',
                'max_release': '16.04'},
-    'CentOS': {'min_release': '6.5',
+    'CentOS': {'min_release': '6.0',
                'max_release': '7.4'}
 }
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -114,8 +114,15 @@ def GetLinuxDetails():
     # platform.linux_distribution() and platform.dist() were deprecated, they
     # return 'debian' as the os, didn't find an elegant alternative and the
     # functions use the files in /etc/ to do their magic.
+    #
+    # This has become further complicated by changes in how CentOS 7 uses the
+    # /etc files.
     with open("/etc/issue") as f:
-      return f.read().split()
+      ret = f.read().split()
+    if ret[0] == '\S':
+      with open("/etc/redhat-release") as f:
+        ret = f.read().split()
+    return ret
   except IOError:
     raise AssertionError('Linux distribution details not available.')
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -26,9 +26,9 @@ SUPPORTED_OS_LIST = {
     'redhat': {'min_release': '6.0',
                'max_release': '6.5'},
     'Ubuntu': {'min_release': '10.04',
-               'max_release': '14.04'},
-    'CentOS Linux': {'min_release': '6.5',
-                     'max_release': '6.5'}
+               'max_release': '16.04'},
+    'CentOS': {'min_release': '6.5',
+               'max_release': '7.4'}
 }
 
 BAD_HOSTNAMES = ['', 'linux', 'localhost', 'dhcp', 'bootp']

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/disk_space_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/disk_space_test.py
@@ -16,8 +16,14 @@
 
 
 import os
-import unittest
 import xml.etree.ElementTree as ET
+
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
+
 
 
 def getDiskInfo():

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/dns_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/dns_test.py
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 
-import unittest
+
 from geecheck_tests import common
 
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/fusion_version_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/fusion_version_test.py
@@ -30,7 +30,9 @@ class TestVersion(unittest.TestCase):
     """Check if Fusion release is the latest available."""
 
     latest_version = common.GetLatestVersion()
+    # Extract the main version information.
     fusion_version = common.GetFusionVersion()
+    fusion_version = ".".join(fusion_version.split('.')[0:3])
 
     error_msg = ('Running Fusion version %s. Upgrade to version %s.' %
                  (fusion_version, latest_version))
@@ -45,7 +47,9 @@ class TestVersion(unittest.TestCase):
     """Check if GEE Server release is the latest available."""
 
     latest_version = common.GetLatestVersion()
+    # Extract the main version information.
     gee_server_version = common.GetGeeServerVersion()
+    gee_server_version = ".".join(gee_server_version.split('.')[0:3])
 
     error_msg = ('Running GEE Server version %s. Upgrade to (%s).' %
                  (gee_server_version, latest_version))

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/fusion_version_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/fusion_version_test.py
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 
-import unittest
 from geecheck_tests import common
 
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/os_supported_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/os_supported_test.py
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 
-import unittest
 from geecheck_tests import common
 
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/running_services_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/running_services_test.py
@@ -15,7 +15,12 @@
 # limitations under the License.
 
 
-import unittest
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
+
 from geecheck_tests import common
 
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/sample_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/sample_test.py
@@ -16,7 +16,12 @@
 
 
 import os
-import unittest
+# Need to use unittest2 for Python 2.6.
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
+
 
 """A sample unit test for geecheck.
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/index.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/index.html
@@ -61,10 +61,10 @@
     <a href="/cutter/" onclick="gees.admin.settingsDropdown()" target="new">Launch Cutter</a>
     <div class="SettingsLabel">Support</div>
     <a href="/shared_assets/docs/manual/" target="new">Documentation</a>
-    <!-- The following are not working and are temporarily disabled
+    <!-- The following is not working and is temporarily disabled
     <a href="javascript:void(0)" onclick="gees.tools.launch.apacheLogs();gees.admin.settingsDropdown()">Apache logs</a>
-    <a href="geecheck.html" onclick="gees.admin.settingsDropdown()" target="new">Diagnostics</a>
     -->
+    <a href="geecheck.html" onclick="gees.admin.settingsDropdown()" target="new">Diagnostics</a>
 
   </div>
 


### PR DESCRIPTION
Fixes #670 

The code was already in place to create the missing geecheck.conf file, except that the variable used didn't actually exist. So, replacing that variable fixes the rpm.

However, as of this writing, *all* tests are non-functional (leading to a brief "No tests were run." response). Regardless, the error message that #670 addresses is fixed by this PR; additional work may follow on.