### PR TITLE
Issue #678: Performance logging tests

### DIFF
--- a/earth_enterprise/src/common/SConscript
+++ b/earth_enterprise/src/common/SConscript
@@ -185,5 +185,9 @@ env.test('timeutils_unittest',
          'timeutils_unittest.cpp',
          LIBS=['gecommon', 'gtest'])
 
+env.test('performancelogger_unittest',
+         'performancelogger_unittest.cpp',
+         LIBS=['gecommon', 'gtest'])
+
 env.install('common_lib', [gecommon])
 env.install('common_lib', [geutil])

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -29,9 +29,6 @@ using namespace getime;
 // Initialize static members of Profiler class
 PerformanceLogger * const PerformanceLogger::_instance = new PerformanceLogger();
 
-// Initialize static members of BlockProfiler class
-PerformanceLogger * const BlockPerformanceLogger::perfLogger = PerformanceLogger::instance();
-
 // Log a profiling message
 void PerformanceLogger::log(
     const string & operation,
@@ -59,24 +56,4 @@ void PerformanceLogger::log(
   }
 
   notify(NFY_NOTICE, "%s\n", message.str().c_str());
-}
-
-// Begin profiling
-BlockPerformanceLogger::BlockPerformanceLogger(
-    const string & operation,
-    const string & object,
-    const size_t size
-  ) :
-    operation(operation),
-    object(object),
-    size(size),
-    startTime(getMonotonicTime())
-{
-  // Nothing to do - just initialize class members above
-}
-
-// Stop profiling and log results
-BlockPerformanceLogger::~BlockPerformanceLogger() {
-  const timespec endTime = getMonotonicTime();
-  perfLogger->log(operation, object, startTime, endTime, size);
 }

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -50,26 +50,23 @@ class BlockPerformanceLogger {
         const std::string & operation,
         const std::string & object,
         const size_t size = 0) :
-      perfLogger(PerfLoggerCls::instance()),
       operation(operation),
       object(object),
       size(size),
       startTime(getime::getMonotonicTime()),
-      ended(false) {
-      // Nothing to do - just initialize class members above
-    }
+      ended(false) {}
     void end() {
       if (!ended) {
         ended = true;
         const timespec endTime = getime::getMonotonicTime();
-        perfLogger->log(operation, object, startTime, endTime, size);
+        PerfLoggerCls::instance()
+            ->log(operation, object, startTime, endTime, size);
       }
     }
     ~BlockPerformanceLogger() {
       end();
     }
   private:
-    PerfLoggerCls * const perfLogger;
     const std::string operation;
     const std::string object;
     const size_t size;

--- a/earth_enterprise/src/common/performancelogger_unittest.cpp
+++ b/earth_enterprise/src/common/performancelogger_unittest.cpp
@@ -1,0 +1,108 @@
+// Copyright 2018 The Open GEE Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include <time.h>
+
+#include "performancelogger.h"
+
+using namespace std;
+using namespace testing;
+
+// Mock of the PerformanceLogger class
+class MockPerformanceLogger {
+  public:
+    int calls;
+    string operation;
+    string object;
+    timespec startTime;
+    timespec endTime;
+    size_t size;
+
+    static MockPerformanceLogger * const instance() { return _instance; }
+    void log(
+        const string & operation,
+        const string & object,
+        const timespec startTime,
+        const timespec endTime,
+        const size_t size = 0) {
+      ++calls;
+      this->operation = operation;
+      this->object = object;
+      this->startTime = startTime;
+      this->endTime = endTime;
+      this->size = size;
+    }
+    void reset() {
+      calls = 0;
+      operation = "";
+      object = "";
+      startTime.tv_sec = startTime.tv_nsec = 0;
+      endTime.tv_sec = endTime.tv_nsec = 0;
+      size = 0;
+    }
+  private:
+    static MockPerformanceLogger * const _instance;
+    MockPerformanceLogger() {
+      reset();
+    }
+};
+
+MockPerformanceLogger * const MockPerformanceLogger::_instance =
+    new MockPerformanceLogger();
+
+// For convenience
+MockPerformanceLogger * const perfLogger = MockPerformanceLogger::instance();
+
+class BlockPerformanceLoggerTest : public testing::Test {
+  protected:
+    virtual void SetUp() {
+      // Reset the performance logger between each test
+      perfLogger->reset();
+    }
+};
+
+TEST_F(BlockPerformanceLoggerTest, Standard) {
+  BlockPerformanceLogger<MockPerformanceLogger> * logger =
+      new BlockPerformanceLogger<MockPerformanceLogger>("operation", "object", 123);
+  EXPECT_EQ(perfLogger->calls, 0);
+  delete logger;
+
+  EXPECT_EQ(perfLogger->calls, 1);
+  EXPECT_EQ(perfLogger->operation, "operation");
+  EXPECT_EQ(perfLogger->object, "object");
+  EXPECT_TRUE(perfLogger->startTime.tv_sec > 0 || perfLogger->startTime.tv_nsec > 0);
+  EXPECT_TRUE(perfLogger->endTime.tv_sec > 0 || perfLogger->endTime.tv_nsec > 0);
+  EXPECT_EQ(perfLogger->size, 123);
+}
+
+TEST_F(BlockPerformanceLoggerTest, NoSize) {
+  BlockPerformanceLogger<MockPerformanceLogger> * logger =
+      new BlockPerformanceLogger<MockPerformanceLogger>("operation", "object");
+  EXPECT_EQ(perfLogger->calls, 0);
+  delete logger;
+
+  EXPECT_EQ(perfLogger->calls, 1);
+  EXPECT_EQ(perfLogger->operation, "operation");
+  EXPECT_EQ(perfLogger->object, "object");
+  EXPECT_TRUE(perfLogger->startTime.tv_sec > 0 || perfLogger->startTime.tv_nsec > 0);
+  EXPECT_TRUE(perfLogger->endTime.tv_sec > 0 || perfLogger->endTime.tv_nsec > 0);
+  EXPECT_EQ(perfLogger->size, 0);
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/earth_enterprise/src/common/timeutils_unittest.cpp
+++ b/earth_enterprise/src/common/timeutils_unittest.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <iomanip>
+#include <sstream>
 #include <time.h>
+#include <unistd.h>
 
 #include "timeutils.h"
 
@@ -24,6 +27,18 @@ timespec makeTimespec(time_t sec, time_t nsec) {
   result.tv_sec = sec;
   result.tv_nsec = nsec;
   return result;
+}
+
+TEST(TimeUtilsTest, GetMonotonicTimeTest) {
+  timespec start = getMonotonicTime();
+  sleep(2);
+  timespec end = getMonotonicTime();
+  EXPECT_GE(end.tv_sec, start.tv_sec + 2);
+}
+
+TEST(TimeUtilsTest, TimespecToDoubleTest) {
+  timespec x = makeTimespec(123, 456789123);
+  EXPECT_EQ(timespecToDouble(x), (double)123.456789123);
 }
 
 void testTimespecDiff(time_t x_sec, time_t x_nsec,
@@ -64,6 +79,69 @@ TEST(TimeUtilsTest, TimespecDiff_SmallMinusLarge) {
   EXPECT_DEATH_IF_SUPPORTED(timespecDiff(makeTimespec(10, 0), makeTimespec(11, 0)), ".*");
 }
 #endif
+
+TEST(TimeUtilsTest, TimespecLT_Sec) {
+  timespec x = makeTimespec(1, 123);
+  timespec y = makeTimespec(2, 123);
+  EXPECT_TRUE(x < y);
+  EXPECT_FALSE(y < x);
+}
+
+TEST(TimeUtilsTest, TimespecLT_NSec) {
+  timespec x = makeTimespec(1, 123);
+  timespec y = makeTimespec(1, 124);
+  EXPECT_TRUE(x < y);
+  EXPECT_FALSE(y < x);
+}
+
+TEST(TimeUtilsTest, TimespecLT_Both) {
+  timespec x = makeTimespec(1, 123);
+  timespec y = makeTimespec(2, 124);
+  EXPECT_TRUE(x < y);
+  EXPECT_FALSE(y < x);
+}
+
+TEST(TimeUtilsTest, TimespecLT_Same) {
+  timespec x = makeTimespec(1, 123);
+  timespec y = makeTimespec(1, 123);
+  EXPECT_FALSE(x < y);
+  EXPECT_FALSE(y < x);
+}
+
+TEST(TimeUtilsTest, TimespecGE_Sec) {
+  timespec x = makeTimespec(2, 123);
+  timespec y = makeTimespec(1, 123);
+  EXPECT_TRUE(x >= y);
+  EXPECT_FALSE(y >= x);
+}
+
+TEST(TimeUtilsTest, TimespecGE_NSec) {
+  timespec x = makeTimespec(1, 124);
+  timespec y = makeTimespec(1, 123);
+  EXPECT_TRUE(x >= y);
+  EXPECT_FALSE(y >= x);
+}
+
+TEST(TimeUtilsTest, TimespecGE_Both) {
+  timespec x = makeTimespec(2, 124);
+  timespec y = makeTimespec(1, 123);
+  EXPECT_TRUE(x >= y);
+  EXPECT_FALSE(y >= x);
+}
+
+TEST(TimeUtilsTest, TimespecGE_Same) {
+  timespec x = makeTimespec(1, 123);
+  timespec y = makeTimespec(1, 123);
+  EXPECT_TRUE(x >= y);
+  EXPECT_TRUE(y >= x);
+}
+
+TEST(TimeUtilsTest, StreamInsertionTest) {
+  timespec x = makeTimespec(9, 87654321);
+  std::stringstream stream;
+  stream << std::setprecision(6) << x;
+  EXPECT_EQ(stream.str(), "9.08765");
+}
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/earth_enterprise/src/common/timeutils_unittest.cpp
+++ b/earth_enterprise/src/common/timeutils_unittest.cpp
@@ -34,6 +34,7 @@ TEST(TimeUtilsTest, GetMonotonicTimeTest) {
   sleep(2);
   timespec end = getMonotonicTime();
   EXPECT_GE(end.tv_sec, start.tv_sec + 2);
+  EXPECT_LT(end.tv_sec, start.tv_sec + 3);
 }
 
 TEST(TimeUtilsTest, TimespecToDoubleTest) {


### PR DESCRIPTION
This PR adds unit tests for the performance logger added in PR #683. It also fixes bugs found through unit testing. Most notably it removes the PERF_LOG_BLOCK macro which often didn't profile an entire block.