### PR TITLE
Adding check to ensure files actually exist before continuing on to d…

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -1192,7 +1192,7 @@ class PublishManagerHelper(stream_manager.StreamManager):
     root = constants.CUTTER_GLOBES_PATH
     for name in os.listdir(root):
       # Ignore globes that are registered.
-      if name not in registered_portable_set:
+      if (name not in registered_portable_set) and (os.path.isfile(name)):
         db_info = basic_types.DbInfo()
         db_info.name = name
         db_info.type = db_info.name[-3:]


### PR DESCRIPTION
Adding check to ensure files actually exist before continuing on to database object creation (#252)

Tested on CentOS7 using the following steps:
1) Install GEE Server
2) Push and publish a test database using tutorial blue marble tiff
3) As sudo, create a symlink in `/opt/google/gehttpd/htdocs/cutter/globes` to a globe file that doesn't exist
4) Load admin console `http://localhost/admin`
5) Ensure the console finishes loading and test database pushed from step 2 appears
Note: Unable to test portable databases popup functionality because I don't have access to any portable globes so it always reports empty.

Fixes #252 