### PR TITLE
Issue #173 services need status target

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/gefusion
+++ b/earth_enterprise/src/fusion/autoingest/sysman/gefusion
@@ -58,16 +58,16 @@ function check_if_master {
 }
 
 function stop_daemon {
-    echo -n "Shutting down $2... "
-    pidfile="/var/opt/google/run/$1.pid"
-    if [ -e $pidfile ] ; then
-	if gestopdaemon $1 ; then
-	    echo "Done"
-	else
-	    echo "Failed"
-	fi
+  echo -n "Shutting down $2... "
+  pidfile="/var/opt/google/run/$1.pid"
+  if [ -e $pidfile ] ; then
+    if gestopdaemon $1 ; then
+      echo "Done"
+    else
+      echo "Failed"
+    fi
   else
-  echo "Not running"
+    echo "Not running"
   fi
 }
 
@@ -81,18 +81,12 @@ function check_daemon {
     ps -ef | grep $pid | grep -q $1
     foundPid=$?
     if [ $foundPid -eq 0 ] ; then
-      message="OK"
-      returncode=0
-    else
-      message="Not running"
-      returncode=1
+      echo "$1:  Running (PID $pid)."
+      return 0
     fi
-  else
-    message="Not running"
-    returncode=1
   fi
-  echo "$1  $message"
-  return $returncode
+  echo "$1:  Not running."
+  return 1
 }
 
 start() {
@@ -130,42 +124,34 @@ stop() {
 }
 
 status() {
+  return_code=0
   if check_if_master ; then
-	check_daemon gesystemmanager
-    gesystemmanager_returncode=$?
-  else
-    gesystemmanager_returncode=0
+    check_daemon gesystemmanager || return_code=1
   fi
-  check_daemon geresourceprovider
-  geresourceprovider_returncode=$?
-  if [ $gesystemmanager_returncode -eq 0 ] && [ $geresourceprovider_returncode -eq 0 ] ; then
-    return 0
-  else
-    return 1
-  fi
+  check_daemon geresourceprovider || return_code=1
+  return "$return_code"
 }
 
 case "$1" in
     restart)
-    stop
-    sleep 1
-    start
-    ;;
+      stop
+      sleep 1
+      start
+      ;;
     start)
-    start
-    ;;
+      start
+      ;;
     stop)
-    stop
-    ;;
+      stop
+      ;;
     status)
-	status
-	exit $?
-    ;;
+      status
+      exit $?
+      ;;
     *)
-    echo "usage: $0 {start|stop|restart|status}"
-    exit 1
-    ;;
-
+      echo "usage: $0 {start|stop|restart|status}"
+      exit 1
+      ;;
 esac
 
 exit 0

--- a/earth_enterprise/src/fusion/autoingest/sysman/gefusion
+++ b/earth_enterprise/src/fusion/autoingest/sysman/gefusion
@@ -66,9 +66,33 @@ function stop_daemon {
 	else
 	    echo "Failed"
 	fi
+  else
+  echo "Not running"
+  fi
+}
+
+function check_daemon {
+  # more DRY to use "gefdaemoncheck --checkrunning"
+  #   but it seems to assume --checksysman is true
+  #   thus wont work on non-master hosts.
+  pidfile="/var/opt/google/run/$1.pid"
+  if [ -s $pidfile ] ; then
+    pid=`cat $pidfile`
+    ps -ef | grep $pid | grep -q $1
+    foundPid=$?
+    if [ $foundPid -eq 0 ] ; then
+      message="OK"
+      returncode=0
     else
-	echo "Not running"
+      message="not running"
+      returncode=1
     fi
+  else
+    message="not running"
+    returncode=1
+  fi
+  echo "$1  $message"
+  return $returncode
 }
 
 start() {
@@ -105,6 +129,22 @@ stop() {
   fi
 }
 
+status() {
+  if check_if_master ; then
+	check_daemon gesystemmanager
+    gesystemmanager_returncode=$?
+  else
+    gesystemmanager_returncode=0
+  fi
+  check_daemon geresourceprovider
+  geresourceprovider_returncode=$?
+  if [ $gesystemmanager_returncode -eq 0 ] && [ $geresourceprovider_returncode -eq 0 ] ; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 case "$1" in
     restart)
     stop
@@ -117,8 +157,12 @@ case "$1" in
     stop)
     stop
     ;;
+    status)
+	status
+	exit $?
+    ;;
     *)
-    echo "usage: $0 {start|stop|restart}"
+    echo "usage: $0 {start|stop|restart|status}"
     exit 1
     ;;
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/gefusion
+++ b/earth_enterprise/src/fusion/autoingest/sysman/gefusion
@@ -60,7 +60,7 @@ function check_if_master {
 function stop_daemon {
   echo -n "Shutting down $2... "
   pidfile="/var/opt/google/run/$1.pid"
-  if [ -e $pidfile ] ; then
+  if [ -e "$pidfile" ] ; then
     if gestopdaemon $1 ; then
       echo "Done"
     else
@@ -77,8 +77,8 @@ function check_daemon {
   #   thus wont work on non-master hosts.
   daemon_path=$(which "$1")
   pidfile="/var/opt/google/run/$1.pid"
-  if [ -s $pidfile ] ; then
-    pid=`cat $pidfile`
+  if [ -s "$pidfile" ] ; then
+    pid=`cat "$pidfile"`
     if [ -d "/proc/$pid" ] && [ "$(readlink "/proc/$pid/exe")" = "$daemon_path" ]; then
       echo "$1:  Running (PID $pid)."
       return 0

--- a/earth_enterprise/src/fusion/autoingest/sysman/gefusion
+++ b/earth_enterprise/src/fusion/autoingest/sysman/gefusion
@@ -75,12 +75,11 @@ function check_daemon {
   # more DRY to use "gefdaemoncheck --checkrunning"
   #   but it seems to assume --checksysman is true
   #   thus wont work on non-master hosts.
+  daemon_path=$(which "$1")
   pidfile="/var/opt/google/run/$1.pid"
   if [ -s $pidfile ] ; then
     pid=`cat $pidfile`
-    ps -ef | grep $pid | grep -q $1
-    foundPid=$?
-    if [ $foundPid -eq 0 ] ; then
+    if [ -d "/proc/$pid" ] && [ "$(readlink "/proc/$pid/exe")" = "$daemon_path" ]; then
       echo "$1:  Running (PID $pid)."
       return 0
     fi

--- a/earth_enterprise/src/fusion/autoingest/sysman/gefusion
+++ b/earth_enterprise/src/fusion/autoingest/sysman/gefusion
@@ -84,11 +84,11 @@ function check_daemon {
       message="OK"
       returncode=0
     else
-      message="not running"
+      message="Not running"
       returncode=1
     fi
   else
-    message="not running"
+    message="Not running"
     returncode=1
   fi
   echo "$1  $message"

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -304,7 +304,7 @@ check_server_processes_running()
     retval=0
     wsgi_running_str="true"
   fi
-  echo "wsgi service: $gehttpd_running_str"
+  echo "wsgi service: $wsgi_running_str"
 
   return $retval
 }

--- a/earth_enterprise/src/server/geserver
+++ b/earth_enterprise/src/server/geserver
@@ -56,7 +56,7 @@ dashes='--------------------------------------------------------------------'
 # this script
 RETVAL=0
 
-use_su=`su $GEPGUSER -c "echo -n 1" 2>/dev/null || echo -n 0`
+use_su=`su "$GEPGUSER" -c "echo -n 1" 2>/dev/null || echo -n 0`
 
 run_as_user() {
   if [ $use_su -eq 1 ] ; then
@@ -68,7 +68,7 @@ run_as_user() {
 
 start() {
   echo $dashes
-  run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log start -w";
+  run_as_user "$GEPGUSER" "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log start -w";
   echo
   echo $dashes
   $gehttpd_root/gehttpd_init start
@@ -87,7 +87,7 @@ stop() {
   echo $dashes
   # only stop if already running...
   if [ -f "$pidfile_postmaster" ] ; then
-    run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log stop";
+    run_as_user "$GEPGUSER" "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log stop";
     rm -f "$pidfile_postmaster"
   fi
   echo $dashes
@@ -99,7 +99,7 @@ status_postmaster() {
   if [ -s "$pidfile_postmaster" ] ; then
     pid=`head -1 "$pidfile_postmaster"`
     # redirect to /dev/null because pg_ctl --silent option doesnt work for status subcommand
-    run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data status" >& /dev/null
+    run_as_user "$GEPGUSER" "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data status" >& /dev/null
     if [ "$?" -eq 0 ]; then
       echo "postmaster: Running (PID $pid)."
       return 0

--- a/earth_enterprise/src/server/geserver
+++ b/earth_enterprise/src/server/geserver
@@ -48,6 +48,8 @@ GEPGUSER="IA_GEPGUSER"
 prog=geserver
 gehttpd_root=/opt/google/gehttpd/bin
 gebin_root=/opt/google/bin
+pidfile_gehttpd='/opt/google/gehttpd/logs/httpd.pid'
+pidfile_postmaster='/var/opt/google/pgsql/data/postmaster.pid'
 dashes='--------------------------------------------------------------------'
 
 # Variable where result of start/stop are stored for later return by
@@ -84,13 +86,60 @@ stop() {
   echo
   echo $dashes
   # only stop if already running...
-  if [ -f /var/opt/google/pgsql/data/postmaster.pid ] ; then
+  if [ -f $pidfile_postmaster ] ; then
     run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log stop";
-    rm -f /var/opt/google/pgsql/data/postmaster.pid
+    rm -f $pidfile_postmaster
   fi
   echo $dashes
   echo 'Done Stopping Google Earth Enterprise Server'
   echo
+}
+
+status_postmaster() {
+  if [ -s $pidfile_postmaster ] ; then
+    pid_postmaster=`head -1 $pidfile_postmaster`
+    # redirect to /dev/null because pg_ctl --silent option doesnt work for status subcommand
+    run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data status" >& /dev/null
+    returncode=$?
+  else
+    returncode=1
+  fi
+  if [ $returncode -eq 0 ]; then
+    echo "postmaster: OK"
+  else
+    echo "postmaster: not running"
+  fi
+  return $returncode
+}
+
+status_gehttpd() {
+  if [ -s $pidfile_gehttpd ] ; then
+    pid_gehttpd=`cat $pidfile_gehttpd`
+    # not using 'gehttpd_init status' because it requires lynx install
+    ps -ef | grep $pid_gehttpd | grep -q gehttpd
+    returncode=$?
+  else
+    returncode=1
+  fi
+  if [ $returncode -eq 0 ]; then
+    echo "gehttpd: OK"
+  else
+    echo "gehttpd: not running"
+  fi
+  return $returncode
+}
+
+status()
+{
+  status_postmaster
+  returncode_postmaster=$?
+  status_gehttpd
+  returncode_gehttpd=$?
+  if [ $returncode_postmaster -eq 0 ] && [ $returncode_gehttpd -eq 0 ] ; then
+    RETVAL=0
+  else
+    RETVAL=1
+  fi
 }
 
 # See how we were called.
@@ -106,8 +155,11 @@ case "$1" in
   sleep 1
   start
   ;;
+  status)
+  status
+  ;;
   *)
-  echo $"Usage: $prog {start|stop|restart}"
+  echo $"Usage: $prog {start|stop|restart|status}"
   exit 1
 esac
 

--- a/earth_enterprise/src/server/geserver
+++ b/earth_enterprise/src/server/geserver
@@ -107,7 +107,7 @@ status_postmaster() {
   if [ $returncode -eq 0 ]; then
     echo "postmaster: OK"
   else
-    echo "postmaster: not running"
+    echo "postmaster: Not running"
   fi
   return $returncode
 }
@@ -124,13 +124,12 @@ status_gehttpd() {
   if [ $returncode -eq 0 ]; then
     echo "gehttpd: OK"
   else
-    echo "gehttpd: not running"
+    echo "gehttpd: Not running"
   fi
   return $returncode
 }
 
-status()
-{
+status() {
   status_postmaster
   returncode_postmaster=$?
   status_gehttpd

--- a/earth_enterprise/src/server/geserver
+++ b/earth_enterprise/src/server/geserver
@@ -86,9 +86,9 @@ stop() {
   echo
   echo $dashes
   # only stop if already running...
-  if [ -f $pidfile_postmaster ] ; then
+  if [ -f "$pidfile_postmaster" ] ; then
     run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data -l /var/opt/google/pgsql/logs/pg.log stop";
-    rm -f $pidfile_postmaster
+    rm -f "$pidfile_postmaster"
   fi
   echo $dashes
   echo 'Done Stopping Google Earth Enterprise Server'
@@ -96,70 +96,64 @@ stop() {
 }
 
 status_postmaster() {
-  if [ -s $pidfile_postmaster ] ; then
-    pid_postmaster=`head -1 $pidfile_postmaster`
+  if [ -s "$pidfile_postmaster" ] ; then
+    pid_postmaster=`head -1 "$pidfile_postmaster"`
     # redirect to /dev/null because pg_ctl --silent option doesnt work for status subcommand
     run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data status" >& /dev/null
     returncode=$?
   else
     returncode=1
   fi
-  if [ $returncode -eq 0 ]; then
-    echo "postmaster: OK"
+  if [ "$returncode" -eq 0 ]; then
+    echo "postmaster: Running (PID $pid_postmaster)."
   else
     echo "postmaster: Not running"
   fi
-  return $returncode
+  return "$returncode"
 }
 
 status_gehttpd() {
-  if [ -s $pidfile_gehttpd ] ; then
-    pid_gehttpd=`cat $pidfile_gehttpd`
+  if [ -s "$pidfile_gehttpd" ] ; then
+    pid_gehttpd=`cat "$pidfile_gehttpd"`
     # not using 'gehttpd_init status' because it requires lynx install
-    ps -ef | grep $pid_gehttpd | grep -q gehttpd
+    ps -ef | grep "$pid_gehttpd" | grep -q gehttpd
     returncode=$?
   else
     returncode=1
   fi
-  if [ $returncode -eq 0 ]; then
-    echo "gehttpd: OK"
+  if [ "$returncode" -eq 0 ]; then
+    echo "gehttpd: Running (PID $pid_gehttpd)."
   else
     echo "gehttpd: Not running"
   fi
-  return $returncode
+  return "$returncode"
 }
 
 status() {
-  status_postmaster
-  returncode_postmaster=$?
-  status_gehttpd
-  returncode_gehttpd=$?
-  if [ $returncode_postmaster -eq 0 ] && [ $returncode_gehttpd -eq 0 ] ; then
-    RETVAL=0
-  else
-    RETVAL=1
-  fi
+  RETVAL=0
+  status_postmaster || RETVAL=1
+  status_gehttpd || RETVAL=1
 }
 
 # See how we were called.
 case "$1" in
   start)
-  start
-  ;;
+    start
+    ;;
   stop)
-  stop
-  ;;
+    stop
+    ;;
   restart)
-  stop
-  sleep 1
-  start
-  ;;
+    stop
+    sleep 1
+    start
+    ;;
   status)
-  status
-  ;;
+    status
+    ;;
   *)
-  echo $"Usage: $prog {start|stop|restart|status}"
-  exit 1
+    echo $"Usage: $prog {start|stop|restart|status}"
+    exit 1
 esac
 
 exit $RETVAL

--- a/earth_enterprise/src/server/geserver
+++ b/earth_enterprise/src/server/geserver
@@ -97,36 +97,31 @@ stop() {
 
 status_postmaster() {
   if [ -s "$pidfile_postmaster" ] ; then
-    pid_postmaster=`head -1 "$pidfile_postmaster"`
+    pid=`head -1 "$pidfile_postmaster"`
     # redirect to /dev/null because pg_ctl --silent option doesnt work for status subcommand
     run_as_user $GEPGUSER "$gebin_root/pg_ctl -D /var/opt/google/pgsql/data status" >& /dev/null
-    returncode=$?
-  else
-    returncode=1
+    if [ "$?" -eq 0 ]; then
+      echo "postmaster: Running (PID $pid)."
+      return 0
+    fi
   fi
-  if [ "$returncode" -eq 0 ]; then
-    echo "postmaster: Running (PID $pid_postmaster)."
-  else
-    echo "postmaster: Not running"
-  fi
-  return "$returncode"
+  echo "postmaster: Not running"
+  return 1
 }
 
 status_gehttpd() {
+  daemon_name='gehttpd'
+  daemon_path="$gehttpd_root/gehttpd"
   if [ -s "$pidfile_gehttpd" ] ; then
-    pid_gehttpd=`cat "$pidfile_gehttpd"`
+    pid=`cat "$pidfile_gehttpd"`
     # not using 'gehttpd_init status' because it requires lynx install
-    ps -ef | grep "$pid_gehttpd" | grep -q gehttpd
-    returncode=$?
-  else
-    returncode=1
+    if [ -d "/proc/$pid" ] && [ "$(readlink "/proc/$pid/exe")" = "$daemon_path" ]; then
+      echo "$daemon_name: Running (PID $pid)."
+      return 0
+    fi
   fi
-  if [ "$returncode" -eq 0 ]; then
-    echo "gehttpd: Running (PID $pid_gehttpd)."
-  else
-    echo "gehttpd: Not running"
-  fi
-  return "$returncode"
+  echo "$daemon_name: Not running"
+  return 1
 }
 
 status() {


### PR DESCRIPTION
Implements #173 

**Verification steps:**

**for geserver:**

$ sudo /etc/init.d/geserver stop
...
$ sudo /etc/init.d/geserver status
postmaster: not running
gehttpd: not running
$ echo $?
1
$ sudo /etc/init.d/geserver start
...
$ sudo /etc/init.d/geserver status
postmaster: OK
gehttpd: OK
$ echo $?
0

**for gefusion:**

$ sudo /etc/init.d/gefusion stop
Shutting down Resource Provider... Not running
Shutting down System Manager... Not running
$ sudo /etc/init.d/gefusion status
gesystemmanager  not running
geresourceprovider  not running
$ echo $?
1
$ sudo /etc/init.d/gefusion start
Starting System Manager... Done
Starting Resource Provider... Done
$ sudo /etc/init.d/gefusion status
gesystemmanager  OK
geresourceprovider  OK
$ echo $?
0

**Comments**

wsgi:ge_* processes apparently are killed with gehttpd, thus apparently dont have or need pid files of their own--except when they arent killed.  This happened to me twice (parent process was killed but children werent) and I couldnt reproduce it.  If this is a known issue, maybe a "geserver cleanup" subcommand would be handy until it's resolved.

There is substantial repetition of paths and other info, eg in c++ and in bash.  This is clearly outside the scope of issue 173, but I tried to use already existing status-checking code to avoid worsening the DRY violations.  I think that's important enough that even where I couldnt use it, I pointed to it in a comment (implying that maybe the existing code could be improved to make it useful in the service status context).

Similarly /opt/google/gehttpd/bin/gehttpd_init has a status subcommand, but it requires lynx, which wasnt installed by following the instructions.  Thus I used ps.

Process IDs can be recycled so i grep for user or command as well.

Error codes seem to be 0 or 1, but they could be more descriptive, denoting exactly which processes are running and which arent.  Eg add 1 if proc A is not running, add 10 if proc B is missing (or similar in binary).