### PR TITLE
Fixed bug #685: globe disassembly produces empty directory (#719)

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/utils.py
@@ -331,8 +331,11 @@ def RunCmd(os_cmd):
     p = subprocess.Popen(os_cmd, shell=False,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
-    results = p.communicate()[0]
-    err_data = p.communicate()[1]
+    # capture stdout/stderr into memory variables
+    # NOTE: communicate() can only be called one time
+    # per call of Popen as after the first call
+    # stdout/stderr pipe handles are closed
+    results, err_data = p.communicate()
     return_code = p.returncode
     if return_code != 0:
       results = "{0} (return code {1})".format(err_data, return_code)


### PR DESCRIPTION
* Fixed bug where communicate() was called multiple times for a single popen call.  Should only call this once to get the stdout and stderr in a single return.  The first call closes the pipes so the second call always fails.  Also added and clened up logging so finding errors is a bit easier next time

* ensure that the return from utils.RunCmd() is a non-empty list

* return None object instead of a null logger if GetLogger is called before log file name is set.

* removed gratuitous checking of return type from code we own and know will not return anything but a list.

* Remove unnecessary check for empty list