### PR TITLE
Performance logging updates

### DIFF
--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -71,7 +71,7 @@ ValidOptions = set(
      'cc_dir',
      'coverage',
      'bundle_3rd_libs',  # Build with bundling 3rd party libs.
-     'log_performance',  # Add code to perform performancing loggging
+     'log_performance',  # Include code for performance logging
      ]);
 
 for argkey in ARGUMENTS:

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -436,8 +436,8 @@ env = khEnvironment(
     installdirs=installdirs,
     skia_rel_dir=skia_rel_dir,
     LINKFLAGS=extragccflags + linkflags,
-    CXXFLAGS=optflags + extragccflags + warnflags,
-    CCFLAGS=optflags + extragccflags + warnflags,
+    CXXFLAGS=optflags + extragccflags + warnflags + ["-DLOG_PERFORMANCE"],
+    CCFLAGS=optflags + extragccflags + warnflags + ["-DLOG_PERFORMANCE"],
     CPPFLAGS=cppflags,
     CPPPATH=[
              # generated 3rd party headers

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -436,8 +436,8 @@ env = khEnvironment(
     installdirs=installdirs,
     skia_rel_dir=skia_rel_dir,
     LINKFLAGS=extragccflags + linkflags,
-    CXXFLAGS=optflags + extragccflags + warnflags + ["-DLOG_PERFORMANCE"],
-    CCFLAGS=optflags + extragccflags + warnflags + ["-DLOG_PERFORMANCE"],
+    CXXFLAGS=optflags + extragccflags + warnflags,
+    CCFLAGS=optflags + extragccflags + warnflags,
     CPPFLAGS=cppflags,
     CPPPATH=[
              # generated 3rd party headers

--- a/earth_enterprise/src/common/khThread.cpp
+++ b/earth_enterprise/src/common/khThread.cpp
@@ -59,14 +59,12 @@ khMutex::khMutex(void) {
 }
 
 khMutex::~khMutex(void) {
-  BEGIN_PERF_LOGGING(timingLogger, "khMutex::~khMutex", "mutex");
 #ifndef NDEBUG
   int err = pthread_mutex_destroy(&mutex);
   assert(!err);
 #else
   pthread_mutex_destroy(&mutex);
 #endif
-  END_PERF_LOGGING(timingLogger);
 }
 
 khNoDestroyMutex::khNoDestroyMutex(void) {

--- a/earth_enterprise/src/common/packetfile/packetfilereaderpool.h
+++ b/earth_enterprise/src/common/packetfile/packetfilereaderpool.h
@@ -65,7 +65,8 @@ class PacketFileReaderToken {
  private:
   PacketFileReaderToken(uint32 pool_hash, uint32 packet_file_index)
       : pool_hash_(pool_hash),
-        packet_file_index_(packet_file_index) {}
+        packet_file_index_(packet_file_index) {
+  }
   friend class PacketFileReaderPool;
 
   uint32 pool_hash_;

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -60,14 +60,20 @@ plMutex::~plMutex(void) {
   (void) err; // Suppress unused variable 'err' warning.
 }
 
-void PerformanceLogger::generateFileName() {
-    time_t t = time(0);
-    tm date = *localtime(&t);
-    char buf[256];
-    if (timeFileName.size() == 0) {
-        strftime(buf, sizeof(buf), "time_stats.%m-%d-%Y-%H:%M:%S.csv", &date);
-        timeFileName = buf;
-    }
+// This function is only called while a lock is held
+void PerformanceLogger::generateFileNameAndWriteHeader() {
+  // Create a unique file name
+  time_t t = time(0);
+  tm date = *localtime(&t);
+  char buf[256];
+  if (timeFileName.size() == 0) {
+    strftime(buf, sizeof(buf), "time_stats.%m-%d-%Y-%H:%M:%S.csv", &date);
+    timeFileName = buf;
+  }
+
+  // Write the header for the CSV file
+  ofstream output_stream(timeFileName.c_str(), ios::app);
+  output_stream << "pid,tid,operation,object,startTime,endTime,duration,size" << endl;
 }
 
 // Log a profiling message

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -84,26 +84,11 @@ void PerformanceLogger::logTiming(
           << operation << ", "
           << object;
 
-  do_notify(message.str().c_str(), "timingfile.csv");
-}
-
-void PerformanceLogger::doNotify(std::string data, std::string fileName)
-{
-  {
-    khLockGuard lock(write_mutex);
-
-    { // Make sure we flush and close the output file before unlocking the mutex:
-      std::ofstream output_stream(fileName.c_str(), std::ios_base::app);
-
-      output_stream << data;
-    }
-  }
-}
-
+  do_notify(message.str(), "timingfile.csv");
 }
 
 // Thread safety wrapper for log output
-void PerformanceLogger::do_notify( const string& message, ostream& out ) {
+void PerformanceLogger::do_notify(const string & message, const string & fileName) {
 
   // Get the thread ID
   pthread_t tid = pthread_self();
@@ -118,5 +103,7 @@ void PerformanceLogger::do_notify( const string& message, ostream& out ) {
   }
 
 }
+
+} // namespace performance_logger
 
 #endif  // LOG_PERFORMANCE

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -98,7 +98,7 @@ void PerformanceLogger::do_notify(const string & message, const string & fileNam
     khLockGuard lock( write_mutex );
     { // Make sure we flush and close the output file before unlocking the mutex:
       std::ofstream output_stream(fileName.c_str(), std::ios_base::app);
-      output_stream << pid << ", " << tid << ", " << message;
+      output_stream << pid << ", " << tid << ", " << message << endl;
     }
   }
 

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -34,7 +34,6 @@ using namespace getime;
 namespace performance_logger {
 
 // make sure static members get initialized
-string PerformanceLogger::ioFileName = "";
 string PerformanceLogger::timeFileName = "";
 
 void plMutexBase::Lock(void) {
@@ -74,40 +73,15 @@ class plLockGuard {
     }
 };
 
-void PerformanceLogger::generateFileNames() {
+void PerformanceLogger::generateFileName() {
     // needs mutex lock
     time_t t = time(0);
     tm date = *localtime(&t);
     char buf[256];
-    if (!ioFileName.size()) {
-        strftime(buf, sizeof(buf), "io_stats.%m-%d-%Y-%H:%M:%S.csv", &date);
-        ioFileName = buf;
-    }
     if (!timeFileName.size()) {
         strftime(buf, sizeof(buf), "time_stats.%m-%d-%Y-%H:%M:%S.csv", &date);
         timeFileName = buf;
     }
-}
-
-void PerformanceLogger::logIO(
-        const string & operation,
-        const string & object,
-        const timespec startTime,
-        const timespec endTime,
-        const size_t size ) {
-        //const size_t requests) {
-    //output info
-    stringstream message;
-    const timespec duration = timespecDiff(endTime,startTime);
-    message.setf(ios_base::fixed, ios_base::floatfield);
-    message << operation << ','
-            << object    << ','
-            << startTime << ','
-            << endTime   << ','
-            << duration  << ','
-            << size;
-
-    do_notify(message.str(), ioFileName);
 }
 
 // Log a profiling message
@@ -138,7 +112,8 @@ void PerformanceLogger::do_notify(const string & message, const string & fileNam
 
   // Get the thread ID
   pthread_t tid = pthread_self();
-  pid_t pid = getpid();  // get the ID of the process
+  // get the ID of the process
+  pid_t pid = getpid();
 
   {  // atomic inner block
     plLockGuard lock( write_mutex );

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -50,7 +50,7 @@ void PerformanceLogger::logTiming(
           << operation << ", "
           << object;
 
-  doNotify(message.str().c_str(), "timingfile.csv");
+  notify(NFY_NOTICE, "%s\n", message.str().c_str());
 }
 
 // Thread safety wrapper for log output
@@ -58,12 +58,12 @@ void PerformanceLogger::do_notify( const string& message, ostream& out, khMutex&
 
   // Get the thread ID
   pthread_t tid = pthread_self();
-  pid_t pid = getppid();  // get the ID of the parent process
+  pid_t pid = getpid();  // get the ID of the process
 
   {  // atomic inner block
     khLockGuard lock( mutex );
     out << pid << ", " << tid << ", " << message;
-  };  // end inner block
+  }  // end inner block
 
 };  // end do_notify
 

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -30,7 +30,7 @@ using namespace getime;
 PerformanceLogger * const PerformanceLogger::_instance = new PerformanceLogger();
 
 // Log a profiling message
-void PerformanceLogger::log(
+void PerformanceLogger::logTiming(
     const string & operation,
     const string & object,
     const timespec startTime,
@@ -55,5 +55,5 @@ void PerformanceLogger::log(
     message << ", size: " << size;
   }
 
-  notify(NFY_NOTICE, "%s\n", message.str().c_str());
+  doNotify(message.str().c_str(), "timingfile.csv");
 }

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -73,7 +73,7 @@ void PerformanceLogger::generateFileNameAndWriteHeader() {
 
   // Write the header for the CSV file
   ofstream output_stream(timeFileName.c_str(), ios::app);
-  output_stream << "pid,tid,operation,object,startTime,endTime,duration,size" << endl;
+  output_stream << "pid,tid,operation,object,startTime_sec,endTime_sec,duration_sec,size" << endl;
 }
 
 // Log a profiling message

--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -75,7 +75,6 @@ class plLockGuard {
 };
 
 void PerformanceLogger::generateFileNames() {
-
     // needs mutex lock
     time_t t = time(0);
     tm date = *localtime(&t);
@@ -100,18 +99,13 @@ void PerformanceLogger::logIO(
     //output info
     stringstream message;
     const timespec duration = timespecDiff(endTime,startTime);
-    const pid_t tid = syscall(SYS_gettid);
-    //double throughput = (timespecToDouble(duration)*size) / 1024;
     message.setf(ios_base::fixed, ios_base::floatfield);
     message << operation << ','
             << object    << ','
             << startTime << ','
             << endTime   << ','
-            << tid       << ','
-            << size       << ','
-            << duration;
-
-    assert(ioFileName.size());
+            << duration  << ','
+            << size;
 
     do_notify(message.str(), ioFileName);
 }

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -34,37 +34,21 @@ namespace performance_logger {
 // khMutex class hierarchy, and we don't want to see log entries for logging
 // operations, so we have a non-instrumented implementation of the mutex
 // classes here. :P
-class khMutexBase {
- public:
-  pthread_mutex_t mutex;
+class plMutexBase {
+  public:
+    pthread_mutex_t mutex;
 
-  void lock(void) { Lock(); }
-  void Lock(void);
-  void unlock(void) { Unlock(); }
-  void Unlock(void);
-  bool trylock(void) { return TryLock(); }
-  bool TryLock(void);
+    void Lock(void);
+    void Unlock(void);
 };
 
 // Simple non-recursive, non-checking mutex
-class khMutex : public khMutexBase
+class plMutex : public plMutexBase
 {
- public:
-  khMutex(void);
-  ~khMutex(void);
+  public:
+    plMutex(void);
+    ~plMutex(void);
 };
-
-class khLockGuard {
-  khMutexBase &mutex;
- public:
-  khLockGuard(khMutexBase &mutex_) : mutex(mutex_) {
-    mutex.Lock();
-  }
-  ~khLockGuard(void) {
-    mutex.Unlock();
-  }
-};
-
 
 /*
  * Singleton class for logging event performance. This class is intended for
@@ -85,7 +69,7 @@ class PerformanceLogger {
         const timespec endTime,        // The end time of the operation
         const size_t size = 0);        // The size of the object, if applicable
   private:
-    khMutex write_mutex;
+    plMutex write_mutex;
 
     // Initialize member variables in constructor:
     PerformanceLogger()

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -22,8 +22,7 @@
 #include "common/khThread.h"  // defines khMutex
 
 
-// Ignore this code unless LOG_PERFORMANCE is set to 1
-#ifdef  LOG_PERFORMANCE
+#ifdef LOG_PERFORMANCE
 
 /*
  * Singleton class for logging event performance. This class is intended for
@@ -42,7 +41,7 @@ class PerformanceLogger {
   private:
     static PerformanceLogger * const _instance;
     PerformanceLogger() {}
-    void do_notify( const std::string&, std::ostream&, khMutex& );  // func decloration
+    void do_notify( const std::string&, std::ostream&, khMutex& );
 };
 
 /*
@@ -63,7 +62,7 @@ class BlockPerformanceLogger {
       startTime(getime::getMonotonicTime()),
       ended(false) {}
     void end() {
-     if (!ended) {
+      if (!ended) {
         ended = true;
         const timespec endTime = getime::getMonotonicTime();
         PerfLoggerCls::instance()
@@ -81,8 +80,6 @@ class BlockPerformanceLogger {
     bool ended;
 };
 
-#endif  // LOG_PERFORMANCE
-
 // Programmers should use the macros below to time code instead of using the
 // classes above directly. This makes it easy to use compile time flags to
 // exclude the time code.
@@ -92,8 +89,6 @@ class BlockPerformanceLogger {
 //
 // If you use multiple performance logging statements in the same scope you
 // must give each one a unique name.
-#ifdef LOG_PERFORMANCE
-
 #define BEGIN_PERF_LOGGING(name, op, ...) \
   BlockPerformanceLogger<PerformanceLogger> name(op, __VA_ARGS__)
 #define END_PERF_LOGGING(name) name.end()
@@ -103,8 +98,6 @@ class BlockPerformanceLogger {
 #define BEGIN_PERF_LOGGING( ... )
 #define END_PERF_LOGGING( ... )
 
-#endif  // LOG_PERFORMANCE = 1
-
-
+#endif  // LOG_PERFORMANCE
 
 #endif // PERFORMANCELOGGER_H

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -74,9 +74,9 @@ class PerformanceLogger {
     plMutex write_mutex;
     std::string timeFileName;
 
-    PerformanceLogger() : write_mutex() { generateFileName(); }
+    PerformanceLogger() : write_mutex() { generateFileNameAndWriteHeader(); }
     void do_notify(const std::string & message, const std::string & fileName);
-    void generateFileName();
+    void generateFileNameAndWriteHeader();
     
     // Disable copy (these functions should not be implemented)
     PerformanceLogger(const PerformanceLogger&);

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -15,12 +15,8 @@
 #ifndef PERFORMANCELOGGER_H
 #define PERFORMANCELOGGER_H
 
-#include <iostream>
-#include <assert.h>
 #include <pthread.h>
 #include <string>
-#include <sstream>
-#include <fstream>
 #include <time.h>
 
 #include "common/timeutils.h"
@@ -34,20 +30,14 @@ namespace performance_logger {
 // khMutex class hierarchy, and we don't want to see log entries for logging
 // operations, so we have a non-instrumented implementation of the mutex
 // classes here. :P
-class plMutexBase {
-  public:
-    pthread_mutex_t mutex;
-
-    void Lock(void);
-    void Unlock(void);
-};
-
-// Simple non-recursive, non-checking mutex
-class plMutex : public plMutexBase
-{
+class plMutex {
   public:
     plMutex(void);
     ~plMutex(void);
+    void Lock(void);
+    void Unlock(void);
+  private:
+    pthread_mutex_t mutex;
 };
 
 /*
@@ -92,8 +82,7 @@ class BlockPerformanceLogger {
       object(object),
       size(size),
       startTime(getime::getMonotonicTime()),
-      ended(false) { }
-    ~BlockPerformanceLogger() { end(); }
+      ended(false) {}
     void end() {
       if (!ended) {
         ended = true;
@@ -102,12 +91,14 @@ class BlockPerformanceLogger {
           .logTiming(operation, object, startTime, endTime, size);
       }
     }
+    ~BlockPerformanceLogger() {
+      end();
+    }
   private:
     const std::string operation;
     const std::string object;
     const size_t size;
     const timespec startTime;
-    static std::fstream timePrefFile;
     bool ended;
 };
 

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -101,4 +101,10 @@ class BlockPerformanceLogger {
   BlockPerformanceLogger<PerformanceLogger> name(op, __VA_ARGS__)
 #define END_PERF_LOGGING(name) name.end()
 
+#define BEGIN_IO_LOGGING() // fill in as needed
+#define BEGIN_IO_LOGGING() // fill in as needed
+#define BEGIN_THREAD_LOGGING() // fill in as needed
+#define BEGIN_THREAD_LOGGING() // fill in as needed
+
+
 #endif // PERFORMANCELOGGER_H

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -27,15 +27,29 @@
 class PerformanceLogger {
   public:
     static PerformanceLogger * const instance() { return _instance; }
-    void log(
+    void logTiming(
         const std::string & operation, // The operation being timed
         const std::string & object,    // The object that the operation is performed on
         const timespec startTime,      // The start time of the operation
         const timespec endTime,        // The end time of the operation
         const size_t size = 0);        // The size of the object, if applicable
+    void logIo(/* Add params as needed*/) {
+      // Format IO data
+      doNotify("", /* the formatted data */, "iofile.csv");
+    }
+    void logThread(/* Add params as needed*/) {
+      // Format thread data
+      doNotify("", /* the formatted data */, "threadfile.csv");
+    }
   private:
     static PerformanceLogger * const _instance;
     PerformanceLogger() {}
+    void doNotify(std::string data, std::string fileName) {
+      // Add thread ID to data
+      // Lock the mutex
+      // Write data to file
+      // unlock mutex
+    }
 };
 
 /*
@@ -60,7 +74,7 @@ class BlockPerformanceLogger {
         ended = true;
         const timespec endTime = getime::getMonotonicTime();
         PerfLoggerCls::instance()
-            ->log(operation, object, startTime, endTime, size);
+            ->logTiming(operation, object, startTime, endTime, size);
       }
     }
     ~BlockPerformanceLogger() {

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -23,7 +23,6 @@
 #include <time.h>
 
 #include "common/timeutils.h"
-#include "common/khThread.h"  // defines khMutex
 
 
 #ifdef LOG_PERFORMANCE
@@ -79,25 +78,21 @@ class PerformanceLogger {
       return _instance;
     }
 
-    // Initialize member variables in constructor:
-    PerformanceLogger()
-    : write_mutex()
-    {}
-
     void logTiming(
         const std::string & operation, // The operation being timed
         const std::string & object,    // The object that the operation is performed on
         const timespec startTime,      // The start time of the operation
         const timespec endTime,        // The end time of the operation
         const size_t size = 0);        // The size of the object, if applicable
-    // void logThread(/* Add params as needed*/) {
-    //   // Format thread data
-    //   doNotify("", /* the formatted data */, "threadfile.csv");
-    // }
   private:
     khMutex write_mutex;
-    PerformanceLogger() {}
-    void doNotify(std::string data, std::string fileName);
+
+    // Initialize member variables in constructor:
+    PerformanceLogger()
+    : write_mutex()
+    {}
+
+    void do_notify(const std::string & message, const std::string & fileName);
 };
 
 /*
@@ -135,7 +130,7 @@ class BlockPerformanceLogger {
     bool ended;
 };
 
-}
+} // namespace performance_logger
 
 // Programmers should use the macros below to time code instead of using the
 // classes above directly. This makes it easy to use compile time flags to

--- a/earth_enterprise/src/common/performancelogger_unittest.cpp
+++ b/earth_enterprise/src/common/performancelogger_unittest.cpp
@@ -63,7 +63,6 @@ class MockPerformanceLogger {
       size = 0;
     }
   private:
-    //static MockPerformanceLogger * const _instance;
     MockPerformanceLogger() {
       reset();
     }
@@ -156,5 +155,4 @@ TEST_F(BlockPerformanceLoggerTest, DeleteAfterEnd) {
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
-  return 0;
 }

--- a/earth_enterprise/src/common/performancelogger_unittest.cpp
+++ b/earth_enterprise/src/common/performancelogger_unittest.cpp
@@ -21,9 +21,10 @@
 using namespace std;
 using namespace testing;
 using namespace getime;
-using namespace performance_logger;
 
 #ifdef LOG_PERFORMANCE
+
+using namespace performance_logger;
 
 // Mock of the PerformanceLogger class
 class MockPerformanceLogger {

--- a/earth_enterprise/src/common/performancelogger_unittest.cpp
+++ b/earth_enterprise/src/common/performancelogger_unittest.cpp
@@ -35,7 +35,7 @@ class MockPerformanceLogger {
     size_t size;
 
     static MockPerformanceLogger * const instance() { return _instance; }
-    void log(
+    void logTiming(
         const string & operation,
         const string & object,
         const timespec startTime,

--- a/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
+++ b/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
@@ -273,9 +273,6 @@ void TerrainCombiner::CompressPacket(PacketInfo* packet) {
 }
 
 void TerrainCombiner::WritePacket(PacketInfo* packet) {
-  /* PERF NOTE: should IO Logging take precedence over PERF Logging,
-     or in PacketFileWriter::WriteAppendCRC ?
-  */
   std::string& compressed_buffer = packet->CompressedBuffer();
   BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_WritePacket", packet->EvenPath().AsString(),
                      compressed_buffer.size());
@@ -547,7 +544,6 @@ void TerrainCombiner::PacketWriteThread() {
         delete packet;
         packets_processed++;
         END_PERF_LOGGING(pwThread);
-        // how to handle exceptions?
       }
     }
   } catch(const khSimpleException &e) {

--- a/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
+++ b/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
@@ -40,11 +40,11 @@ namespace geterrain {
 // and a token is returned.  The number of packets is added to the total.
 PacketFileReaderToken CountedPacketFileReaderPool::Add(
     const std::string &packet_file_name) {
-  BEGIN_IO_LOGGING(openPacketFile,"CombineTerrain_OpenPacket","Open/add packet file to reader pool");
+  BEGIN_PERF_LOGGING(openPacketFile,"CombineTerrain_OpenPacket","Open/add packet file to reader pool");
   pool_packet_count_ += PacketIndexReader::NumPackets(
       PacketFile::IndexFilename(packet_file_name));
   PacketFileReaderToken retval = PacketFileReaderPool::Add(packet_file_name);
-  END_IO_LOGGING(openPacketFile);
+  END_PERF_LOGGING(openPacketFile);
   return retval;
 }
 
@@ -176,9 +176,9 @@ TerrainCombiner::~TerrainCombiner() {
 
 void TerrainCombiner::Close(size_t max_sort_buffer) {
   notify(NFY_DEBUG, "Closing TerrainCombiner");
-  BEGIN_IO_LOGGING(closeTC,"CombineTerrain_Close","Flush and Close TerrainCombiner file bundle");
+  BEGIN_PERF_LOGGING(closeTC,"CombineTerrain_Close","Flush and Close TerrainCombiner file bundle");
   writer_.Close(max_sort_buffer);
-  END_IO_LOGGING(closeTC);
+  END_PERF_LOGGING(closeTC);
 }
 
 // WriteCombinedTerrain - write a combined terrain packet for the
@@ -216,7 +216,7 @@ void TerrainCombiner::WriteCombinedTerrain(
   }
 
   END_PERF_LOGGING(calcReadSize);
-  BEGIN_IO_LOGGING(readPackets, "CombineTerrain_ReadPacket", even_path.AsString(), read_buffer_size);
+  BEGIN_PERF_LOGGING(readPackets, "CombineTerrain_ReadPacket", even_path.AsString(), read_buffer_size);
   
   // Create the new PacketInfo and initialize its raw buffer.
   PacketInfo* packet = new PacketInfo(even_path, providerid, progress_increment);
@@ -241,7 +241,7 @@ void TerrainCombiner::WriteCombinedTerrain(
   // The buffer in general shrinks because of removal of CRC bytes.
   read_buffer.resize(read_buffer_next);
 
-  END_IO_LOGGING(readPackets);
+  END_PERF_LOGGING(readPackets);
 
   // We add the packet to both the compress queue and the write queue for
   // processing by other threads that do compression and writing.
@@ -277,12 +277,12 @@ void TerrainCombiner::WritePacket(PacketInfo* packet) {
      or in PacketFileWriter::WriteAppendCRC ?
   */
   std::string& compressed_buffer = packet->CompressedBuffer();
-  BEGIN_IO_LOGGING(perfLog, "CombineTerrain_WritePacket", packet->EvenPath().AsString(),
+  BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_WritePacket", packet->EvenPath().AsString(),
                      compressed_buffer.size());
   writer_.WriteAppendCRC(packet->EvenPath(), &compressed_buffer[0],
                          compressed_buffer.size(), packet->ProviderId());
   progress_meter_.incrementDone(packet->ProgressIncrement());
-  END_IO_LOGGING(perfLog);
+  END_PERF_LOGGING(perfLog);
 }
 
 
@@ -542,11 +542,11 @@ void TerrainCombiner::PacketWriteThread() {
     PacketInfo* packet = NULL;
     while(PopWriteQueue(&packet)) {
       if (packet != NULL) {
-        BEGIN_IO_LOGGING(pwThread,"CombineTerrain_PacketWrite","Packet write thread");
+        BEGIN_PERF_LOGGING(pwThread,"CombineTerrain_PacketWrite","Packet write thread");
         WritePacket(packet);
         delete packet;
         packets_processed++;
-        END_IO_LOGGING(pwThread);
+        END_PERF_LOGGING(pwThread);
         // how to handle exceptions?
       }
     }

--- a/earth_enterprise/src/fusion/gecombineterrain/combineterrain.h
+++ b/earth_enterprise/src/fusion/gecombineterrain/combineterrain.h
@@ -37,7 +37,8 @@ class CountedPacketFileReaderPool : public PacketFileReaderPool {
   CountedPacketFileReaderPool(const std::string &pool_name,
                               geFilePool &file_pool)
       : PacketFileReaderPool(pool_name, file_pool),
-        pool_packet_count_(0) {}
+        pool_packet_count_(0) {
+  }
   ~CountedPacketFileReaderPool() {}
   virtual PacketFileReaderToken Add(const std::string &packet_file_name);
   inline const uint64 &pool_packet_count() const { return pool_packet_count_; }

--- a/earth_enterprise/src/fusion/gecombineterrain/gecombineterrain.cpp
+++ b/earth_enterprise/src/fusion/gecombineterrain/gecombineterrain.cpp
@@ -284,7 +284,6 @@ int main(int argc, char **argv) {
                static_cast<long long unsigned int>(physical_memory_size));
       }
 
-
       // Convert this read cache block size from kilobytes to bytes.
       read_cache_block_size *= 1024U;
 
@@ -327,9 +326,9 @@ int main(int argc, char **argv) {
     khDeleteGuard<TerrainMergeType> merger(
         TransferOwnership(new TerrainMergeType("Terrain Merger")));
 
-    // PERF NOTE: io to stderr, not file
     // Print the input file sizes for diagnostic log file info.
     std::vector<std::string> input_files;
+
     fprintf(stderr, "index version: %d\n", index_version);
     for (int i = argn; i < argc; ++i) {
       notify(NFY_INFO, "Opening terrain index: %s", argv[i]);
@@ -340,7 +339,6 @@ int main(int argc, char **argv) {
                                               argv[i])));
       input_files.push_back(argv[i]);
     }
-    // PERF NOTE: prints to stdout, not file
     khPrintFileSizes("Input File Sizes", input_files);
 
     merger->Start();
@@ -402,7 +400,6 @@ int main(int argc, char **argv) {
   // at the end, call dump all
   JOBSTATS_DUMPALL();
 
-  // PERF NOTE: prints to stdout not file
   // On successful completion, print the output file sizes.
   // The print occurs here to allow progress to go out of scope.
   khPrintFileSizes("Output File Sizes", output_files);


### PR DESCRIPTION
This combines the performance logging changes from PRs #707, #708, #709 and #723. It should be functionally the same as the previous PRs except for bug fixes - the purpose of this PR is just to merge them together and handle the merge conflicts.

Major changes compared to the original PRs:
* Combined IO logging and perf logging since they were logging the same data
* Removed logging from the khMutex destructor since it causes a static initialization order error
* Added a header to the output CSV file
* Added a lock to the creation of the PerformanceLogger singleton