### PR TITLE
Add --setecdefault documentation; fix typo

### DIFF
--- a/docs/geedocs/5.2.1/answer/3481558.html
+++ b/docs/geedocs/5.2.1/answer/3481558.html
@@ -416,7 +416,7 @@ geserveradmin --garbagecollect
 </table>
 <h4><a name="geserveradmin_pdb"></a>Publish database</h4>
 <pre>
-<code><b>--publishdb</b> <i>db_name</i> <b>--targetpath</b> <i>target_path</i> [<b>--vhname</b> <i>vh_name</i>]</code></pre>
+<code><b>--publishdb</b> <i>db_name</i> <b>--targetpath</b> <i>target_path</i> [<b>--vhname</b> <i>vh_name</i>] [<b>--setecdefault</b>]</code></pre>
 <p>Publish the specified database on the specified target path. If the virtual host name is omitted, it publishes to the default virtual host: "public".</p>
 <table class="nice-table">
   <tbody>
@@ -436,6 +436,11 @@ geserveradmin --garbagecollect
 <code><b>--vhname</b> <i>vh_name</i></code></pre></td>
       <td>Optional</td>
       <td>Specify the name of the virtual host. If the virtual host name is omitted, it publishes to the default virtual host: "public".</td>
+    </tr>
+    <tr>
+      <td><pre><code><b>--setecdefault</b> </code></pre></td>
+      <td>Optional</td>
+      <td>Publish this database as the default one for the Earth Client to connect to if no database or virtual host is specified upon initial connection.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/geedocs/5.2.1/answer/3481558.html
+++ b/docs/geedocs/5.2.1/answer/3481558.html
@@ -565,5 +565,6 @@ geserveradmin --garbagecollect
 <p><i>Optional</i>. Perform the upgrade without prompting the user for any input. This option requires that some commands have arguments specified on the command line.</p>
 <p> </p>
 </p>
+<p class="copyright">&copy;2018 Google, Open GEE Contributors</p>
 </body>
 </html>

--- a/docs/geedocs/5.2.1/answer/6034724.html
+++ b/docs/geedocs/5.2.1/answer/6034724.html
@@ -161,6 +161,9 @@ Removing a database does not <em>delete</em> it. Remove reverses the <em>push</e
 <li>Publish the database to GEE Server using <code>geserveradmin --publishdb db_name --targetpath target_path</code>. For example:
 <p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org</code></p>
 </li>
+<li>Publish the database to GEE Server, specifying a default globe for GEEC, using <code>geserveradmin --publishdb db_name --targetpath target_path --setcedefault</code>. For example:
+<p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org --setcedefault</code></p>
+</li>
 <p>For more information about the <code>geserveradmin</code> command options, see the <a href="../answer/3481558.html">Command Reference</a>.
 
 

--- a/docs/geedocs/5.2.1/answer/6034724.html
+++ b/docs/geedocs/5.2.1/answer/6034724.html
@@ -161,8 +161,8 @@ Removing a database does not <em>delete</em> it. Remove reverses the <em>push</e
 <li>Publish the database to GEE Server using <code>geserveradmin --publishdb db_name --targetpath target_path</code>. For example:
 <p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org</code></p>
 </li>
-<li>Publish the database to GEE Server, specifying it as the default globe for GEEC, using <code>geserveradmin --publishdb db_name --targetpath target_path --setcedefault</code>. For example:
-<p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org --setcedefault</code></p>
+<li>Publish the database to GEE Server, specifying it as the default globe for GEEC, using <code>geserveradmin --publishdb db_name --targetpath target_path --setecdefault</code>. For example:
+<p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org --setecdefault</code></p>
 </li>
 <p>For more information about the <code>geserveradmin</code> command options, see the <a href="../answer/3481558.html">Command Reference</a>.
 

--- a/docs/geedocs/5.2.1/answer/6034724.html
+++ b/docs/geedocs/5.2.1/answer/6034724.html
@@ -161,11 +161,12 @@ Removing a database does not <em>delete</em> it. Remove reverses the <em>push</e
 <li>Publish the database to GEE Server using <code>geserveradmin --publishdb db_name --targetpath target_path</code>. For example:
 <p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org</code></p>
 </li>
-<li>Publish the database to GEE Server, specifying a default globe for GEEC, using <code>geserveradmin --publishdb db_name --targetpath target_path --setcedefault</code>. For example:
+<li>Publish the database to GEE Server, specifying it as the default globe for GEEC, using <code>geserveradmin --publishdb db_name --targetpath target_path --setcedefault</code>. For example:
 <p><code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org --setcedefault</code></p>
 </li>
 <p>For more information about the <code>geserveradmin</code> command options, see the <a href="../answer/3481558.html">Command Reference</a>.
 
 
-</p></ol><div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p> <p class="copyright">&copy;2015 Google</p></div>
+</p></ol><div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p>
+<p class="copyright">&copy;2018 Google, Open GEE Contributors</p></div>
 </div></body> </html>

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -96,7 +96,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
     "   [--setecdefault]         Publish this database as the default one for\n"
     "                            the Earth Client to connect to if no database\n"
     "                            or virtual host is specified upon initial\n"
-    "                            connection." 
+    "                            connection.\n" 
     " --unpublish <target_path>  Unpublish the DB served from the specified\n"
     "                            target path.\n"
     " --republishdb <db_name>    Publish a registered DB on the specified\n"


### PR DESCRIPTION
Add "--setecdefault" documentation to webpages.  Fix small typo in geserveradmin --help.

Original issue: https://github.com/google/earthenterprise/issues/699