### PR TITLE
Performance improvements for profiling

### DIFF
--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -110,9 +110,19 @@ void PerformanceLogger::do_notify(const string & message) {
   {  // atomic inner block
     plLockGuard lock( write_mutex );
     {
-      timeFile << pid << ',' << tid << ',' << message << endl;
+      if (buffer.size() + message.size() > BUF_SIZE) {
+        flushBuffer();
+      }
+      stringstream newLine;
+      newLine << pid << ',' << tid << ',' << message << endl;
+      buffer.append(newLine.str());
     }
   }
+}
+
+void PerformanceLogger::flushBuffer() {
+  timeFile << buffer;
+  buffer.clear();
 }
 
 } // namespace performance_logger

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -15,6 +15,7 @@
 #ifndef PERFORMANCELOGGER_H
 #define PERFORMANCELOGGER_H
 
+#include <fstream>
 #include <pthread.h>
 #include <string>
 #include <time.h>
@@ -73,10 +74,11 @@ class PerformanceLogger {
     static plMutex instance_mutex;
     plMutex write_mutex;
     std::string timeFileName;
+    std::ofstream timeFile;
 
-    PerformanceLogger() : write_mutex() { generateFileNameAndWriteHeader(); }
-    void do_notify(const std::string & message, const std::string & fileName);
-    void generateFileNameAndWriteHeader();
+    PerformanceLogger() : write_mutex() { initializeFile(); }
+    void do_notify(const std::string & message);
+    void initializeFile();
     
     // Disable copy (these functions should not be implemented)
     PerformanceLogger(const PerformanceLogger&);

--- a/earth_enterprise/src/common/performancelogger.h
+++ b/earth_enterprise/src/common/performancelogger.h
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <pthread.h>
+#include <sstream>
 #include <string>
 #include <time.h>
 
@@ -71,15 +72,22 @@ class PerformanceLogger {
         const timespec endTime,        // The end time of the operation
         const size_t size = 0);        // The size of the object, if applicable
   private:
+    static const int BUF_SIZE = 64 * 1024;
     static plMutex instance_mutex;
     plMutex write_mutex;
     std::string timeFileName;
     std::ofstream timeFile;
+    std::string buffer;
 
-    PerformanceLogger() : write_mutex() { initializeFile(); }
+    PerformanceLogger() : buffer(BUF_SIZE, '\0') {
+      buffer.clear();
+      initializeFile();
+    }
+    ~PerformanceLogger() { flushBuffer(); }
     void do_notify(const std::string & message);
+    void flushBuffer();
     void initializeFile();
-    
+
     // Disable copy (these functions should not be implemented)
     PerformanceLogger(const PerformanceLogger&);
     void operator=(const PerformanceLogger&);


### PR DESCRIPTION
This PR reduces the overhead of profiling by:
- Opening and closing the file once
- Batching updates and writing 64 KB to the file at a time

The resulting output file has fewer lines that an output file that is run with the old code; however, this is because there are more operations on condition variables (i.e., there are more calls to khCondVar::broadcast_all, khCondVar::signal_one, and khCondVar:wait), so the actual operations being performed are the same.

Sample command line for testing (you will have to change this based where your data is):
```
sudo /opt/google/bin/gecombineterrain --indexversion 7 --numcpus 4 --output /gevol/assets/Databases/CA_POIs.kdatabase/terrain.kta/ver002/terrain.pack/ /gevol/assets/Projects/Terrain/worldtopo.ktproject/geindex.kta/ver004/worldtopo-v4.geindex
```