### PR TITLE
Issue #720 RPM scriptlets should not ignore errors

### DIFF
--- a/earth_enterprise/rpms/opengee-common/post-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-common/post-uninstall.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 the Open GEE Contributors
+# Copyright 2018 the Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 #------------------------------------------------------------------------------
 # Directory locations:

--- a/earth_enterprise/rpms/opengee-common/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-common/pre-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 the Open GEE Contributors
+# Copyright 2018 the Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 #------------------------------------------------------------------------------
 check_group()

--- a/earth_enterprise/rpms/opengee-fusion/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-install.sh
@@ -191,6 +191,8 @@ final_assetroot_configuration()
     else
         "$BASEINSTALLDIR_OPT/bin/geselectassetroot" --assetroot "$ASSET_ROOT"
 
+        RET_VAL=0
+
         "$BASEINSTALLDIR_OPT/bin/geconfigureassetroot" --addvolume \
             "opt:$BASEINSTALLDIR_OPT/share/tutorials" --noprompt --nochown || RET_VAL=$?
         if [ "$RET_VAL" -eq "255" ]; then

--- a/earth_enterprise/rpms/opengee-fusion/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 # NOTE: requires xmllint from libxml2-utils
 
 set +x
+set -e
 
 #------------------------------------------------------------------------------
 # Definitions
@@ -191,8 +192,8 @@ final_assetroot_configuration()
         "$BASEINSTALLDIR_OPT/bin/geselectassetroot" --assetroot "$ASSET_ROOT"
 
         "$BASEINSTALLDIR_OPT/bin/geconfigureassetroot" --addvolume \
-            "opt:$BASEINSTALLDIR_OPT/share/tutorials" --noprompt --nochown
-        if [ $? -eq 255 ]; then
+            "opt:$BASEINSTALLDIR_OPT/share/tutorials" --noprompt --nochown || RET_VAL=$?
+        if [ "$RET_VAL" -eq "255" ]; then
             cat <<END
 The geconfigureassetroot utility has failed while attempting
 to add the volume 'opt:$BASEINSTALLDIR_OPT/share/tutorials'.

--- a/earth_enterprise/rpms/opengee-fusion/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-install.sh
@@ -205,7 +205,8 @@ END
 
 final_fusion_service_configuration()
 {
-    chcon -t texrel_shlib_t "$BASEINSTALLDIR_OPT"/lib/*so*
+    chcon -t texrel_shlib_t "$BASEINSTALLDIR_OPT"/lib/*so* ||
+      echo "Warning: chcon labeling failed. SELinux is probably not enabled"
 
     service gefusion start
 }

--- a/earth_enterprise/rpms/opengee-fusion/post-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-uninstall.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set +x
+set -e
 
 remove_users_and_groups()
 {

--- a/earth_enterprise/rpms/opengee-fusion/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/pre-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 set +x
+set -e
+
 NEW_INSTALL=false
 if [ "$1" = "1" ] ; then
     NEW_INSTALL=true

--- a/earth_enterprise/rpms/opengee-fusion/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/pre-install.sh
@@ -27,6 +27,17 @@ fi
 #-----------------------------------------------------------------
 main_preinstall()
 {
+    # Check to see if opengee executables work and error out if not
+    RET_VAL=0
+    ERROUT=`$BASEINSTALLDIR_OPT/bin/geserveradmin 2>&1` || RET_VAL=$?
+
+    if [ "$RET_VAL" -eq "127" ]; then
+      echo "$ERROUT"
+      echo "It appears that not all library dependencies have been installed."
+      echo "This is likely to be a missing MrSID library."
+      return 127
+    fi
+
     if [ -f /etc/init.d/gefusion ]; then
         service gefusion stop
     fi

--- a/earth_enterprise/rpms/opengee-fusion/pre-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-fusion/pre-uninstall.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 #-----------------------------------------------------------------
 # Main Function

--- a/earth_enterprise/rpms/opengee-server/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/post-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 umask 002
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/rpms/opengee-server/post-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-server/post-uninstall.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 #-----------------------------------------------------------------
 # Main Functions

--- a/earth_enterprise/rpms/opengee-server/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/pre-install.sh
@@ -27,6 +27,18 @@ fi
 #-----------------------------------------------------------------
 main_preinstall()
 {
+
+    # Check to see if opengee executables work and error out if not
+    RET_VAL=0
+    ERROUT=`$BASEINSTALLDIR_OPT/bin/geserveradmin 2>&1` || RET_VAL=$?
+
+    if [ "$RET_VAL" -eq "127" ]; then
+      echo "$ERROUT"
+      echo "It appears that not all library dependencies have been installed."
+      echo "This is likely to be a missing MrSID library."
+      return 127
+    fi
+
     # needed both for rpm state change and upgrading non-rpm install
     if [ -f /etc/init.d/geserver ]; then
         service geserver stop

--- a/earth_enterprise/rpms/opengee-server/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/pre-install.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 NEW_INSTALL=false
 if [ "$1" = "1" ] ; then

--- a/earth_enterprise/rpms/opengee-server/pre-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-server/pre-uninstall.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2017 The Open GEE Contributors
+# Copyright 2018 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set +x
+set -e
 
 #-----------------------------------------------------------------
 # Main Function

--- a/earth_enterprise/rpms/shared/install-utils.sh.template
+++ b/earth_enterprise/rpms/shared/install-utils.sh.template
@@ -90,10 +90,10 @@ load_systemrc_config()
         VALUE=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/assetroot/text()")
         [ -z "$VALUE" ] || ASSET_ROOT="$VALUE"
 
-        VALUE=$(xml_file_get_node_text "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+        VALUE=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
         [ -z "$VALUE" ] || GEFUSIONUSER="$VALUE"
 
-        VALUE=$(xml_file_get_node_text "$SYSTEMRC" "//Systemrc/userGroupname/text()")
+        VALUE=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
         [ -z "$VALUE" ] || GEGROUP="$VALUE"
     fi
 }


### PR DESCRIPTION
Implements #720 

* Added '-e' flag to scriptlets to return errors that occur to RPM installer
* Updated a few places that were causing errors incorrectly
* Added explicit checks to make sure that the executables work in preinstall scriptlets

**Verification Steps**
1. Install Open GEE RPMs built without MrSID support
1. Build and publish a basic database (without changing the default asset root and publish root)
1. Create RPMs with MrSID support from the [new branch](https://github.com/tst-ccamp/earthenterprise/tree/720-rpm-error-handling)
1. On test server, remove or disable MrSID library, e.g. `sudo mv /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482/ /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482.moved` if it's already installed
1. Install new opengee-common rpm using yum
1. Attempt to install opengee-server and opengee-fusion rpms using yum
1. Both should fail to install with an error similar to: 
    ```
    /opt/google/bin/geserveradmin: error while loading shared libraries: libltidsdk.so: cannot open shared 
    object file: No such file or directory
    It appears that not all library dependencies have been installed.
    This is likely to be a missing MrSID library.
    error: %pre(opengee-server-0:5.2.1.0.alpha.201803082212-1.el7.x86_64) scriptlet failed, exit status 127
    Error in PREIN scriptlet in rpm package opengee-server-5.2.1.0.alpha.201803082212-1.el7.x86_64
    opengee-server-5.2.1.0.alpha.201803072058.g3c4815d-1.el7.x86_64 was supposed to be removed but is not!
    ```
1. Install/restore the MrSID library, e.g. `sudo mv /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482.moved/ /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482`
1. Attempt to install opengee-server and opengee-fusion rpms using yum
1. This time the rpms should install successfully (but there may be warnings printed out)
1. Verify that the published database from before is still published