### PR TITLE
Release notes and doc changes for Open GEE 5.2.1

### DIFF
--- a/docs/geedocs/5.2.1/answer/2987876.html
+++ b/docs/geedocs/5.2.1/answer/2987876.html
@@ -12,8 +12,8 @@
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a></h1>
 <h2>Legal notices</h2>
 
-<p>Copyright &copy; 2008-2017 Google, Inc.<br/>
-Copyright &copy; 2017 Open GEE Contributors<br/>
+<p>Copyright &copy; 2008-2018 Google, Inc.<br/>
+Copyright &copy; 2018 Open GEE Contributors<br/>
 All rights reserved.</p>
 <p>
   Google, Google Earth, and Keyhole are trademarks or registered trademarks of Google, Inc. in the United States and
@@ -62,5 +62,5 @@ All rights reserved.</p>
 <li>Skia</li>
 <li>Tornado</li>
 </ul>
-<div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p> <p class="copyright">&copy;2015 Google; &copy;2017 Open GEE Contributors</p></div>
+<div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p> <p class="copyright">&copy;2015 Google; &copy;2018 Open GEE Contributors</p></div>
 </div></body> </html>

--- a/docs/geedocs/5.2.1/answer/2987876.html
+++ b/docs/geedocs/5.2.1/answer/2987876.html
@@ -12,7 +12,7 @@
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a></h1>
 <h2>Legal notices</h2>
 
-<p>Copyright &copy; 2008-2018 Google, Inc.<br/>
+<p>Copyright &copy; 2008-2017 Google, Inc.<br/>
 Copyright &copy; 2018 Open GEE Contributors<br/>
 All rights reserved.</p>
 <p>

--- a/docs/geedocs/5.2.1/answer/2987876.html
+++ b/docs/geedocs/5.2.1/answer/2987876.html
@@ -13,7 +13,7 @@
 <h2>Legal notices</h2>
 
 <p>Copyright &copy; 2008-2017 Google, Inc.<br/>
-Copyright &copy; 2018 Open GEE Contributors<br/>
+Copyright &copy; 2017-2018 Open GEE Contributors<br/>
 All rights reserved.</p>
 <p>
   Google, Google Earth, and Keyhole are trademarks or registered trademarks of Google, Inc. in the United States and

--- a/docs/geedocs/5.2.1/answer/2987876.html
+++ b/docs/geedocs/5.2.1/answer/2987876.html
@@ -32,7 +32,7 @@ All rights reserved.</p>
   Open Google Earth Enterprise utilizes the following products as integrated components, linked libraries, or
   optional modules. No usage rights, expressed or implied, are provided for said products independent of Open Google 
   Earth Enterprise, unless otherwise stated in the product documentation. All trademarks are the property of their
-  respective owners. Each product is released under their own respective license. License information is available
+  respective owners. Each product is released under its own respective license. License information is available
   under the
   <a href="https://github.com/google/earthenterprise/tree/master/earth_enterprise/third_party">third_party directory</a>
   of the repository.

--- a/docs/geedocs/5.2.1/answer/2987876.html
+++ b/docs/geedocs/5.2.1/answer/2987876.html
@@ -62,5 +62,5 @@ All rights reserved.</p>
 <li>Skia</li>
 <li>Tornado</li>
 </ul>
-<div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p> <p class="copyright">&copy;2015 Google; &copy;2018 Open GEE Contributors</p></div>
+<div class="footer"><p class="BackToTop"><a href="#top_of_file">Back to top</a> <hr /></p> <p class="copyright">&copy;2015 Google; &copy;2017-2018 Open GEE Contributors</p></div>
 </div></body> </html>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -33,22 +33,22 @@ gtag('config', 'UA-108632131-2');
 <p><img src="../art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
 <h2>Release notes: Open GEE 5.2.1</h2>
-<p>Open GEE 5.2.1 is an incremental release of <a href="../answer/7160000.html">Open GEE 5.2.0</a>. It contains new features, several bug fixes in Fusion and GEE Server, and updates to third-party libraries.</p>
+<p>Open GEE 5.2.1 is a comprehensive update of <a href="../answer/7160000.html">Open GEE 5.2.0</a>. It contains new features, several bug fixes in Fusion and GEE Server, and updates to third-party libraries.</p>
   <h5>
     <p id="overview_5_2_1">New Features</p>
   </h5> 
-    <p><strong>MrSID support</strong>. At build time open GEE 5.2.1 now checks for MrSID libraries and if found, Fusion will be built with MrSID raster format support.</p>
-    <p><strong>RPM Installers</strong>. For RedHat and Centos, RPM can now be built to enable easier installation.
-	For Ubuntu platform, installer scripts continue to be the supported way to install Open GEE.</p>
-    <p><strong>JPEG2000 performance boost</strong>. New used version of OpenJpeg2000 library has considerable performance increase.</p>
-    <p><strong>Controlling quality of terrain</strong>. Command line tool "gepackgen" producing packets does now accept a decimation value. In general reducing the decimation value for terrain produces higher quality and better looking terrain.</p>		
-    <p><strong>Testing scripts enhanced</strong>. <code>publish_tutorial.sh</code> and <code>publish_historical.sh</code> scripts do now publish the pushed databases.</p>
-    <p><strong>Detailed version info</strong>. Version number displayed in user interface shows detailed info indicating whether the product is an official release or a development build.</p>
-	<p><strong>Continuous Integration</strong>. Travis CI is used for continuous integration. Every time a commit is made to Open GEE a continuous build is run to validate the committed changes.</p>
+    <p><strong>MrSID support</strong>. At build time, open GEE checks for MrSID libraries and, if found, Fusion will be built with MrSID raster format support.</p>
+    <p><strong>RPM Installers</strong>. For RedHat and CentOS, RPMs can now be built to enable easier installation.
+	For Ubuntu, the installer scripts continue to be the supported way to install Open GEE.</p>
+    <p><strong>JPEG2000 performance boost</strong>. Updated version of OpenJpeg2000 library has considerable performance increase.</p>
+    <p><strong>Controlling quality of terrain</strong>. Command-line tool gepackgen producing packets now accepts a decimation value. In general, reducing the decimation value for terrain produces higher quality and better looking terrain.</p>		
+    <p><strong>Testing scripts enhanced</strong>. <code>publish_tutorial.sh</code> and <code>publish_historical.sh</code> scripts now publish the pushed databases.</p>
+    <p><strong>Detailed version info</strong>. Version number displayed in user interface shows detailed information indicating an official release or a development build.</p>
+	<p><strong>Continuous Integration</strong>. Travis CI is used for continuous integration. On every new commit to Open GEE a build is executed to validate the committed changes.</p>
   <h5>
     <p id="supported_5.2.1">Supported Platforms</p>
   </h5>
-  <p>The Open GEE 5.2.1 release is supported on 64-bit versions of the following operating systems:</p>
+  <p>Open GEE 5.2.1 is supported on 64-bit versions of the following operating systems:</p>
     <ul>
       <li>Red Hat Enterprise Linux version 6.x and 7.x, including the most recent security patches</li>
       <li>CentOS 6.x and 7.x</li>
@@ -59,7 +59,7 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="library_updates_5.2.1">New and Updated Libraries</p>
   </h5>
-    Open GEE 5.2.1 includes extensive library changes.  This list may be incomplete.
+    Open GEE 5.2.1 includes many library updates. Major updates include:
     <table class="nice-table">
       <tbody>
         <tr>
@@ -85,7 +85,7 @@ gtag('config', 'UA-108632131-2');
       </tbody>
     </table>
 
-  <p>To upgrade from Open GEE 5.2.0, Do NOT uninstall it. We recommend that you upgrade Open GEE 5.2.0 by simply installing Open GEE 5.2.1. Installing Open GEE 5.2.1 on top of Open GEE 5.2.0 will ensure that your PostgreSQL databases are backed up and upgraded correctly to the new PostgreSQL version used by Open GEE 5.2.1.</p>
+  <p>To upgrade from Open GEE 5.2.0, do NOT uninstall it. We recommend that you upgrade Open GEE 5.2.0 by simply installing Open GEE 5.2.1. Installing Open GEE 5.2.1 on top of Open GEE 5.2.0 will ensure that your PostgreSQL databases are backed-up and upgraded correctly to the new PostgreSQL version used by Open GEE 5.2.1.</p>
   <h5>
   <h5>
     <p id="known_issues_5.2.1">Known Issues</p>
@@ -124,12 +124,12 @@ gtag('config', 'UA-108632131-2');
         </tr>		
         <tr>
           <td>126</td>
-          <td>The fusion installer creates a backup on the first run</td>
+          <td>The Fusion installer creates a backup on the first run</td>
           <td>No current work around. The created backup can be deleted.</td>
         </tr>		
         <tr>
           <td>127</td>
-          <td>Incorrect error messages from fusion installer</td>
+          <td>Incorrect error messages from Fusion installer</td>
           <td>No current work around.</td>
         </tr>		
         <tr>
@@ -149,7 +149,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>201</td>
-          <td>Some tiles are displayed incorrectly in the enterprise client when terrain is enabled</td>
+          <td>Some tiles are displayed incorrectly in the Enterprise Client when terrain is enabled</td>
           <td>No current work around.</td>
         </tr>		
         <tr>
@@ -215,7 +215,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>342</td>
           <td>Fusion crashes when opening an unsupported file type</td>
-          <td>Re-open fusion and avoid opening unsupported file types.</td>
+          <td>Re-open Fusion and avoid opening unsupported file types.</td>
         </tr>
         <tr>
           <td>343</td>
@@ -254,7 +254,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>407</td>
-          <td>Corrupt data warning when starting fusion</td>
+          <td>Corrupt data warning when starting Fusion</td>
           <td>No current work around but Fusion loads and runs correctly.</td>
         </tr>
         <tr>
@@ -269,7 +269,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>439</td>
-          <td>Uninstalling fusion without stopping it results in unexpected error message</td>
+          <td>Uninstalling Fusion without stopping it results in unexpected error message</td>
           <td>Ignore that error message.</td>
         </tr>		
         <tr>
@@ -285,7 +285,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>444</td>
           <td>Fusion installer does not upgrade the asset root on RHEL 7</td>
-          <td>Upgrade the asset root manually by running the command that is printed when you try to start the fusion service.</td>
+          <td>Upgrade the asset root manually by running the command that is printed when you try to start the Fusion service.</td>
         </tr>
         <tr>
           <td>445</td>
@@ -330,7 +330,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>507</td>
           <td>Volume host is reported unavailable if `hostname` doesn't match volume host</td>
-          <td>Set the host values in <code>/gevol/assets/.config/volumes.xml</code> to the FQDN and restart the fusion service.</td>
+          <td>Set the host values in <code>/gevol/assets/.config/volumes.xml</code> to the FQDN and restart the Fusion service.</td>
         </tr>		
         <tr>
           <td>535</td>
@@ -478,7 +478,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>671</td>
-          <td>Documentation link on server admin page is broken in release_5.2.1</td>
+          <td>Documentation link on Server admin page is broken in release_5.2.1</td>
           <td>Fixed links</td>
         </tr>		
         <tr>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -139,7 +139,7 @@ gtag('config', 'UA-108632131-2');
         </tr>		
         <tr>
           <td>193</td>
-          <td>Updated docs are not copied if the /tmp/fusion_os_install directory already exists</td>
+          <td>Updated docs are not copied if the <code>/tmp/fusion_os_install</code> directory already exists</td>
           <td>Delete <code>/tmp/fusion_os_install</code> at the beginning of the stage_install build process.</td>
         </tr>		
         <tr>
@@ -230,7 +230,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>401</td>
           <td>GEE commands are not in the path for sudo. </td>
-          <td>Specify the full path when running commands or add /opt/google/bin to the path for all users, including the super user.</td>
+          <td>Specify the full path when running commands or add <code>/opt/google/bin</code> to the path for all users, including the super user.</td>
         </tr>
         <tr>
           <td>402</td>
@@ -295,7 +295,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>448</td>
           <td>Investigate Out of Memory issues</td>
-          <td>Use a system that have more than 4GB RAM.</td>
+          <td>Use a system that has more than 4GB RAM.</td>
         </tr>		
         <tr>
           <td>453</td>
@@ -339,7 +339,7 @@ gtag('config', 'UA-108632131-2');
         </tr>		
         <tr>
           <td>557</td>
-          <td>Wms service problem with 'width' &amp; 'height' &amp; 'bbox'</td>
+          <td>WMS service problem with 'width' &amp; 'height' &amp; 'bbox'</td>
           <td>No current work around.</td>
         </tr>		
         <tr>
@@ -367,11 +367,11 @@ gtag('config', 'UA-108632131-2');
           <td>Release executables and libraries depend on gtest</td>
           <td>Follow current build instructions that requires <code>gtest</code> to be installed.</td>
         </tr>
-	<tr>
+	      <tr>
           <td>669</td>
           <td>Missing repo in RHEL 7 build instructions</td>
           <td>Enable <code>rhel-7-server-optional-rpms</code> and <code>rhel-7-server-optional-source-rpms</code> repos.</td>
-        </tr
+        </tr>
         <tr>
           <td>682</td>
           <td>Update geconfigurepublishroot to fully correct file permissions</td>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -366,7 +366,12 @@ gtag('config', 'UA-108632131-2');
           <td>651</td>
           <td>Release executables and libraries depend on gtest</td>
           <td>Follow current build instructions that requires <code>gtest</code> to be installed.</td>
-        </tr>		
+        </tr>
+	<tr>
+          <td>669</td>
+          <td>Missing repo in RHEL 7 build instructions</td>
+          <td>Enable <code>rhel-7-server-optional-rpms</code> and <code>rhel-7-server-optional-source-rpms</code> repos.</td>
+        </tr
         <tr>
           <td>682</td>
           <td>Update geconfigurepublishroot to fully correct file permissions</td>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -478,8 +478,8 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>671</td>
-          <td>Running gerewritedbroot with the proper parameters results in a usage message</td>
-          <td>initialized variable in gerewritedbroot</td>
+          <td>Documentation link on server admin page is broken in release_5.2.1</td>
+          <td>Fixed links</td>
         </tr>		
         <tr>
           <td>677, 685</td>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -37,7 +37,7 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5_2_1">New Features</p>
   </h5> 
-    <p><strong>MrSID support</strong>. At build time, open GEE checks for MrSID libraries and, if found, Fusion will be built with MrSID raster format support.</p>
+    <p><strong>MrSID support</strong>. At build time, Open GEE checks for MrSID libraries and, if found, Fusion will be built with MrSID raster format support.</p>
     <p><strong>RPM Installers</strong>. For RedHat and CentOS, RPMs can now be built to enable easier installation.
 	For Ubuntu, the installer scripts continue to be the supported way to install Open GEE.</p>
     <p><strong>JPEG2000 performance boost</strong>. Updated version of OpenJpeg2000 library has considerable performance increase.</p>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -155,7 +155,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>202</td>
           <td>Icons are not displayed on vector layers in the Enterprise Client</td>
-          <td>No current work around.  It is not clear if this is an error in GEE or in the Enterprise Client.</td>
+          <td>No current work around. It is not clear if this is an error in GEE or in the Enterprise Client.</td>
         </tr>
         <tr>
           <td>203</td>
@@ -170,7 +170,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>225</td>
           <td>Fusion lets you create folder with space in the name</td>
-          <td>Avoid creating folder with space in their name</td>
+          <td>Avoid creating folder with space in their name.</td>
         </tr>		
         <tr>
           <td>234</td>
@@ -260,7 +260,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>419</td>
           <td>Fix Fusion Graphics Acceleration in Ubuntu 14 Docker Container Hosted on Ubuntu 16</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>		
         <tr>
           <td>437</td>
@@ -320,7 +320,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>477</td>
           <td>'service geserver stop/start/restart' doesn't work on Ubuntu 16.04 without a reboot</td>
-          <td>Reboot and try again</td>
+          <td>Reboot and try again.</td>
         </tr>
         <tr>
           <td>487</td>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -37,7 +37,7 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5_2_1">New Features</p>
   </h5> 
-    <p><strong>MrSID support</strong>. Open GEE 5.2.1 build checks for MrSID libraries and if found, Fusion will be built with MrSID raster format support.</p>
+    <p><strong>MrSID support</strong>. At build time open GEE 5.2.1 now checks for MrSID libraries and if found, Fusion will be built with MrSID raster format support.</p>
     <p><strong>RPM Installers</strong>. For RedHat and Centos, RPM can now be built to enable easier installation.
 	For Ubuntu platform, installer scripts continue to be the supported way to install Open GEE.</p>
     <p><strong>JPEG2000 performance boost</strong>. New used version of OpenJpeg2000 library has considerable performance increase.</p>
@@ -339,7 +339,7 @@ gtag('config', 'UA-108632131-2');
         </tr>		
         <tr>
           <td>557</td>
-          <td>Wms service problem with 'width' & 'height' & 'bbox'</td>
+          <td>Wms service problem with 'width' &amp; 'height' &amp; 'bbox'</td>
           <td>No current work around.</td>
         </tr>		
         <tr>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -501,7 +501,7 @@ gtag('config', 'UA-108632131-2');
     
     <hr />
     </p>
-    <p class="copyright">&copy;2018 Open GEE Contributors</p>
+    <p class="copyright">&copy;2017-2018 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/5.2.1/answer/7160001.html
+++ b/docs/geedocs/5.2.1/answer/7160001.html
@@ -33,7 +33,18 @@ gtag('config', 'UA-108632131-2');
 <p><img src="../art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
 <h2>Release notes: Open GEE 5.2.1</h2>
-<p>Open GEE 5.2.1 is actively under development</p>
+<p>Open GEE 5.2.1 is an incremental release of <a href="../answer/7160000.html">Open GEE 5.2.0</a>. It contains new features, several bug fixes in Fusion and GEE Server, and updates to third-party libraries.</p>
+  <h5>
+    <p id="overview_5_2_1">New Features</p>
+  </h5> 
+    <p><strong>MrSID support</strong>. Open GEE 5.2.1 build checks for MrSID libraries and if found, Fusion will be built with MrSID raster format support.</p>
+    <p><strong>RPM Installers</strong>. For RedHat and Centos, RPM can now be built to enable easier installation.
+	For Ubuntu platform, installer scripts continue to be the supported way to install Open GEE.</p>
+    <p><strong>JPEG2000 performance boost</strong>. New used version of OpenJpeg2000 library has considerable performance increase.</p>
+    <p><strong>Controlling quality of terrain</strong>. Command line tool "gepackgen" producing packets does now accept a decimation value. In general reducing the decimation value for terrain produces higher quality and better looking terrain.</p>		
+    <p><strong>Testing scripts enhanced</strong>. <code>publish_tutorial.sh</code> and <code>publish_historical.sh</code> scripts do now publish the pushed databases.</p>
+    <p><strong>Detailed version info</strong>. Version number displayed in user interface shows detailed info indicating whether the product is an official release or a development build.</p>
+	<p><strong>Continuous Integration</strong>. Travis CI is used for continuous integration. Every time a commit is made to Open GEE a continuous build is run to validate the committed changes.</p>
   <h5>
     <p id="supported_5.2.1">Supported Platforms</p>
   </h5>
@@ -44,11 +55,40 @@ gtag('config', 'UA-108632131-2');
       <li>Ubuntu 14.04 LTS and 16.04 LTS</li>
     </ul>
     <p>Google Earth Enterprise 5.2.1 is compatible with Google Earth Enterprise Client (EC) version 7.1.5 and above.</p>
-<br/>
-  <p>If you're upgrading from GEE 5.1.3, you may have to reinstall the prerequisite libraries after uninstalling 5.1.3 but before installing 5.2.1.</p>
+
+  <h5>
+    <p id="library_updates_5.2.1">New and Updated Libraries</p>
+  </h5>
+    Open GEE 5.2.1 includes extensive library changes.  This list may be incomplete.
+    <table class="nice-table">
+      <tbody>
+        <tr>
+          <th>Library</th>
+          <th>Version</th>
+          <th>New or Updated</th>
+        </tr>
+        <tr>
+          <td>OpenJPEG</td>
+          <td>2.3.0</td>
+          <td>Updated</td>
+        </tr>
+        <tr>
+          <td>PostgreSQL</td>
+          <td>9.6.5</td>
+          <td>Updated</td>
+        </tr>
+        <tr>
+          <td>PostGIS</td>
+          <td>2.3.4</td>
+          <td>Updated</td>
+        </tr>		
+      </tbody>
+    </table>
+
+  <p>To upgrade from Open GEE 5.2.0, Do NOT uninstall it. We recommend that you upgrade Open GEE 5.2.0 by simply installing Open GEE 5.2.1. Installing Open GEE 5.2.1 on top of Open GEE 5.2.0 will ensure that your PostgreSQL databases are backed up and upgraded correctly to the new PostgreSQL version used by Open GEE 5.2.1.</p>
   <h5>
   <h5>
-    <p id="known_issues_5.2.0">Known Issues</p>
+    <p id="known_issues_5.2.1">Known Issues</p>
   </h5>
     <table class="nice-table">
       <tbody>
@@ -58,25 +98,60 @@ gtag('config', 'UA-108632131-2');
           <th>Workaround</th>
         </tr>
         <tr>
-          <td>2</td>
-          <td>MrSID imagery is not supported</td>
-          <td>MrSID support can be added by purchasing a proprietary GDAL plugin that supports MrSID and modifying the build process to include the plugin.</td>
-        </tr>
-        <tr>
           <td>4</td>
           <td>Google basemap fails to load in 2D Mercator Maps</td>
           <td>Obtain a valid Google Maps API key and include it in <code>/opt/google/gehttpd/htdocs/maps/maps_google.html</code>.</td>
         </tr>
         <tr>
-          <td>6</td>
-          <td>The Portable UI reports an error any time a cut is canceled, even if the cancel was successful</td>
-          <td>Ignore the misleading error message.</td>
-        </tr>
+          <td>8</td>
+          <td>Ensure GEE Portable Cutter Job Completes</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>9</td>
+          <td>Improve FileUnpacker Handling of Invalid Files</td>
+          <td>No current work around.</td>
+        </tr>				
+        <tr>
+          <td>20</td>
+          <td>Simplify build process for portable builds on MacOS</td>
+          <td>Building and running Portable Server on MacOS should be possible with minimal changes.</td>
+        </tr>		
+        <tr>
+          <td>34</td>
+          <td>Scons build creates temporary directories named “0” </td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>126</td>
+          <td>The fusion installer creates a backup on the first run</td>
+          <td>No current work around. The created backup can be deleted.</td>
+        </tr>		
+        <tr>
+          <td>127</td>
+          <td>Incorrect error messages from fusion installer</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>190</td>
+          <td>Hostname mismatch check in installers doesn't work as expected</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>193</td>
+          <td>Updated docs are not copied if the /tmp/fusion_os_install directory already exists</td>
+          <td>Delete <code>/tmp/fusion_os_install</code> at the beginning of the stage_install build process.</td>
+        </tr>		
         <tr>
           <td>200</td>
           <td>stage_install fails on the tutorial files when <code>/home</code> and <code>/tmp</code> are on different file systems</td>
           <td>Ensure that <code>/home</code> and <code>/tmp</code> are on the same file system or download the tutorial files to <code>/opt/google/share/tutorials/fusion/</code> after installing Fusion.</td>
         </tr>
+        <tr>
+          <td>201</td>
+          <td>Some tiles are displayed incorrectly in the enterprise client when terrain is enabled</td>
+          <td>No current work around.</td>
+        </tr>		
         <tr>
           <td>202</td>
           <td>Icons are not displayed on vector layers in the Enterprise Client</td>
@@ -85,13 +160,43 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>203</td>
           <td>Some vector layer options are not saved</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
+        <tr>
+          <td>221</td>
+          <td>The asset manager may display that a job is "Queued" when in fact the job is "Blocked"</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>225</td>
+          <td>Fusion lets you create folder with space in the name</td>
+          <td>Avoid creating folder with space in their name</td>
+        </tr>		
+        <tr>
+          <td>234</td>
+          <td>Geserver raises error executing apache_logs.pyc</td>
+          <td>No current work around.</td>
+        </tr>		
         <tr>
           <td>254</td>
           <td>Automasking fails for images stored with UTM projection</td>
           <td>Use GDAL to convert the images to a different projection before ingesting them into Fusion.</td>
         </tr>
+        <tr>
+          <td>269</td>
+          <td>gevectorimport doesn't crop features</td>
+          <td>Use GDAL/OGR to crop vector dataset before importing them using Fusion.</td>
+        </tr>		
+        <tr>
+          <td>295</td>
+          <td>Fix buffer overflows and leaks in unit tests</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>309</td>
+          <td>Check for the FusionConnection before new asset is populated</td>
+          <td>Make sure that gefusion service is started.</td>
+        </tr>		
         <tr>
           <td>320</td>
           <td>The Portable Server web page uses obsolete REST calls</td>
@@ -103,19 +208,9 @@ gtag('config', 'UA-108632131-2');
           <td>Delete any library versions that should not be loaded or use LD_LIBRARY_PATH to load libraries from <code>/opt/google/lib</code>.</td>
         </tr>
         <tr>
-          <td>333</td>
-          <td>Portable Server is not supported on MacOS</td>
-          <td>Building and running Portable Server on MacOS should be possible with minimal changes.</td>
-        </tr>
-        <tr>
-          <td>335, 359</td>
-          <td>If there is an error while saving a resource, the resource cannot be saved again even if the error is resolved</td>
-          <td>Close the resource form and open it again to make the save option available again.</td>
-        </tr>
-        <tr>
           <td>340</td>
           <td>GE Fusion Terrain is black</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
         <tr>
           <td>342</td>
@@ -123,39 +218,39 @@ gtag('config', 'UA-108632131-2');
           <td>Re-open fusion and avoid opening unsupported file types.</td>
         </tr>
         <tr>
-          <td>375</td>
-          <td>Invalid version of psycopg2 on Ubuntu 16.04</td>
-          <td>On Ubuntu 16.04 switch to 'python-psycopg2' instead of 'python2.7-psycopg2'.</td>
-        </tr>
+          <td>343</td>
+          <td>gefusion: File ->open->kiasset,ktasset,kip does not work</td>
+          <td>kip is not a supported format. Void opening files with .kip extension.</td>
+        </tr>		
         <tr>
           <td>380</td>
           <td>Provider field in resource-view is blank</td>
-          <td>Open the individual resource to see the provider</td>
+          <td>Open the individual resource to see the provider.</td>
         </tr>
         <tr>
           <td>401</td>
           <td>GEE commands are not in the path for sudo. </td>
-          <td>Specify the full path when running commands or add /opt/google/bin to the path for all users, including the super user</td>
+          <td>Specify the full path when running commands or add /opt/google/bin to the path for all users, including the super user.</td>
         </tr>
         <tr>
           <td>402</td>
           <td>Provider manager window locked to main window.</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
         <tr>
           <td>403</td>
           <td>Missing close button on system manager window in RHEL 7</td>
-          <td>Right click the title bar and select close</td>
+          <td>Right click the title bar and select close.</td>
         </tr>
         <tr>
           <td>404</td>
           <td>Opaque polygons in preview.</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
         <tr>
           <td>405</td>
           <td>Vector layer preview not cleared in some situations</td>
-          <td>Reset the preview window to the correct state by either clicking on it or previewing another vector layer</td>
+          <td>Reset the preview window to the correct state by either clicking on it or previewing another vector layer.</td>
         </tr>
         <tr>
           <td>407</td>
@@ -163,58 +258,245 @@ gtag('config', 'UA-108632131-2');
           <td>No current work around but Fusion loads and runs correctly.</td>
         </tr>
         <tr>
-          <td>423</td>
-          <td>Slower JPEG2000 performance than 5.1.3</td>
-          <td>Use Geotiff or other image formats.</td>
-        </tr>
+          <td>419</td>
+          <td>Fix Fusion Graphics Acceleration in Ubuntu 14 Docker Container Hosted on Ubuntu 16</td>
+          <td>No current work around</td>
+        </tr>		
         <tr>
           <td>437</td>
           <td>Rebooting VM while it is building resources results in a corrupted XML</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
+        <tr>
+          <td>439</td>
+          <td>Uninstalling fusion without stopping it results in unexpected error message</td>
+          <td>Ignore that error message.</td>
+        </tr>		
         <tr>
           <td>440</td>
           <td>Fuzzy imagery in historical imagery tests.</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
+        <tr>
+          <td>442</td>
+          <td>Multiple database pushes after upgrade don't report a warning</td>
+          <td>No current work around.</td>
+        </tr>		
         <tr>
           <td>444</td>
           <td>Fusion installer does not upgrade the asset root on RHEL 7</td>
-          <td>Upgrade the asset root manually by running the command that is printed when you try to start the fusion service</td>
+          <td>Upgrade the asset root manually by running the command that is printed when you try to start the fusion service.</td>
         </tr>
+        <tr>
+          <td>445</td>
+          <td>Path to tutorial source volume in gee_test instructions is different from path used in installers</td>
+          <td>Use <code>/opt/google/share/tutorials</code>.</td>
+        </tr>		
+        <tr>
+          <td>448</td>
+          <td>Investigate Out of Memory issues</td>
+          <td>Use a system that have more than 4GB RAM.</td>
+        </tr>		
         <tr>
           <td>453</td>
           <td>Improve `check_server_processes_running` detection for uninstall</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
         <tr>
           <td>456</td>
           <td>Inconsistent behavior of vector layers after upgrade</td>
-          <td>No current work around</td>
+          <td>No current work around.</td>
         </tr>
+        <tr>
+          <td>460</td>
+          <td>Possibility of seg fault in QDateWrapper</td>
+          <td>No current work around.</td>
+        </tr>		
         <tr>
           <td>474</td>
           <td>Running gee_check on some supported platforms reports that the platform is not supported</td>
           <td>You can ignore the failed test if using a supported platform (Ubuntu 14.04, Ubuntu 16.04, RHEL 7, and CentOS 7).</td>
         </tr>
         <tr>
-          <td>476</td>
-          <td>Support building on CentOS6 with Python2.6</td>
-          <td>No current work around</td>
-        </tr>
-        <tr>
           <td>477</td>
           <td>'service geserver stop/start/restart' doesn't work on Ubuntu 16.04 without a reboot</td>
           <td>Reboot and try again</td>
         </tr>
+        <tr>
+          <td>487</td>
+          <td>gdal - python utilities do not recognize osgeo module</td>
+          <td>Install <code>python-gdal</code>.</td>
+        </tr>		
+        <tr>
+          <td>507</td>
+          <td>Volume host is reported unavailable if `hostname` doesn't match volume host</td>
+          <td>Set the host values in <code>/gevol/assets/.config/volumes.xml</code> to the FQDN and restart the fusion service.</td>
+        </tr>		
+        <tr>
+          <td>535</td>
+          <td>DownloadTutorial.sh often is not staged properly for install</td>
+          <td>Copy <code>DownloadTutorial.sh</code> to <code>/tmp/fusion_os_install</code>.</td>
+        </tr>		
+        <tr>
+          <td>557</td>
+          <td>Wms service problem with 'width' & 'height' & 'bbox'</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>569</td>
+          <td>geserver service installation and uninstallation issues</td>
+          <td>Before uninstalling geserver verify if its running or not.</td>
+        </tr>		
+        <tr>
+          <td>590</td>
+          <td>Maps API Javascript Files Not Found</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>594</td>
+          <td>Save errors only reported for the first image</td>
+          <td>Close the form in question and try again.</td>
+        </tr>		
+        <tr>
+          <td>640</td>
+          <td>Save button disabled in 'Map Layer' creation dialog when an error encountered</td>
+          <td>Close the resource form and open it again to make the save option available again.</td>
+        </tr> 
+        <tr>
+          <td>651</td>
+          <td>Release executables and libraries depend on gtest</td>
+          <td>Follow current build instructions that requires <code>gtest</code> to be installed.</td>
+        </tr>		
+        <tr>
+          <td>682</td>
+          <td>Update geconfigurepublishroot to fully correct file permissions</td>
+          <td>Correct manually the file permissions.</td>
+        </tr>		
+        <tr>
+          <td>686</td>
+          <td>Scons fails to detect libpng library on CentOS 6</td>
+          <td>Ensure that a default <code>g++</code> compiler is installed.</td>
+        </tr>		
+        <tr>
+          <td>694</td>
+          <td>Search fails after transferring and publishing a database using disconnected send from the command line</td>
+          <td>Re-publish the database from the web interface.</td>
+        </tr>			
+        <tr>
+          <td>700</td>
+          <td>Add EL6/EL7 check to RPMs</td>
+          <td>Make sure that RPMS are installed on same EL version that they were produced for.</td>
+        </tr>		
+		
       </tbody>
     </table>
+  <h5>
+    <p id="resolved_issues_5.2.1">Resolved Issues</p>
+  </h5>
+  <div>
+    <table class="nice-table">
+      <tbody>
+        <tr>
+          <th>Number</th>
+          <th class="narrow">Description</th>
+          <th>Resolution</th>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>MrSID imagery is not supported</td>
+          <td>Build script now check for MrSID libraries and if found, Fusion will be built with MrSID format support</td>
+        </tr>
+        <tr>
+          <td>6</td>
+          <td>The Portable UI reports an error any time a cut is canceled, even if the cancel was successful</td>
+          <td>Fixed concurrency issue</td>
+        </tr>
+        <tr>
+          <td>247</td>
+          <td>Default Imagery and Terrain file filters ignore files with the ".tiff" extension</td>
+          <td>Added ".tiff" to list of supported format extensions</td>
+        </tr>
+        <tr>
+          <td>321, 335, 359</td>
+          <td>If there is an error while saving a resource, the resource cannot be saved again even if the error is resolved</td>
+          <td>Fixed out-of-sync errors</td>
+        </tr>
+        <tr>
+          <td>355</td>
+          <td>Package gtest under CentOS/RHEL 6</td>
+          <td>instructions for building OpenGEE under CentOS 6 were updated and build scripts modified to detect and use "devtoolset-2-toolchain"</td>
+        </tr>		
+        <tr>
+          <td>375</td>
+          <td>Invalid version of psycopg2 on Ubuntu 16.04</td>
+          <td>Added PYTHONPATH to Apache environment, so it gets passed on to CGI scripts like Cutter</td>
+        </tr>
+        <tr>
+          <td>423</td>
+          <td>Slower JPEG2000 performance than 5.1.3</td>
+          <td>Upgraded to new version of OpenJpeg: 2.3.0. This new version has multiple performance improvements.</td>
+        </tr>
+        <tr>
+          <td>476</td>
+          <td>Support building on CentOS6 with Python2.6</td>
+          <td>Added support for Python 2.6 for CentOS6.</td>
+        </tr>		
+        <tr>
+          <td>515</td>
+          <td>gepolymaskgen segfaults with specific inputs</td>
+          <td>Fixed out of bounds error in box filter</td>
+        </tr>
+        <tr>
+          <td>524</td>
+          <td>Globe Database Fails to Publish if a Snippet is selected</td>
+          <td>Fixed spelling mistake</td>
+        </tr>
+        <tr>
+          <td>624</td>
+          <td>File permissions incorrect in /opt/google if root has a restrictive umask</td>
+          <td>Fixed permissions</td>
+        </tr>
+        <tr>
+          <td>634</td>
+          <td>Duplicate resources in imagery projects</td>
+          <td>Passed "re_init" flag down through prefill</td>
+        </tr>		
+        <tr>
+          <td>658</td>
+          <td>Fix Perl Interpreter Paths in Built Scripts</td>
+          <td>Added initscripts as a dependency for opengee-server and updated find-requires and requiresCommands capabilities of RPM</td>
+        </tr>
+        <tr>
+          <td>666</td>
+          <td>Running gerewritedbroot with the proper parameters results in a usage message</td>
+          <td>initialized variable in gerewritedbroot</td>
+        </tr>
+        <tr>
+          <td>671</td>
+          <td>Running gerewritedbroot with the proper parameters results in a usage message</td>
+          <td>initialized variable in gerewritedbroot</td>
+        </tr>		
+        <tr>
+          <td>677, 685</td>
+          <td>Trying to disassemble or assemble a portable globe or map GLC fails on RedHat 6</td>
+          <td>Used a python 2.6 compatible function instead of python 2.7.</td>
+        </tr>
+        <tr>
+          <td>680</td>
+          <td>Restoring a DB dump from earlier versions of GEE that does not have a search enabled will fail</td>
+          <td>Moved logic to add postgres extension when restoring/upgrading earlier in the process</td>
+        </tr>		
+
+
+      </tbody>
+    </table>
+
   <div class="footer">
     <p class="BackToTop"><a href="#top_of_file">Back to top</a>
     
     <hr />
     </p>
-    <p class="copyright">&copy;2017 Open GEE Contributors</p>
+    <p class="copyright">&copy;2018 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/5.2.1/index.html
+++ b/docs/geedocs/5.2.1/index.html
@@ -41,7 +41,7 @@ gtag('config', 'UA-108632131-2');
   <div class="footer">
     <hr />
     <p class="copyright">&copy;2017 Google</p>
-    <p class="copyright">&copy;2018 Open GEE Contributors</p>    
+    <p class="copyright">&copy;2017-2018 Open GEE Contributors</p>    
   </div>
 </div>
 </body>

--- a/docs/geedocs/5.2.1/index.html
+++ b/docs/geedocs/5.2.1/index.html
@@ -41,6 +41,7 @@ gtag('config', 'UA-108632131-2');
   <div class="footer">
     <hr />
     <p class="copyright">&copy;2017 Google</p>
+    <p class="copyright">&copy;2018 Open GEE Contributors</p>    
   </div>
 </div>
 </body>

--- a/docs/geedocs/index.html
+++ b/docs/geedocs/index.html
@@ -2,9 +2,17 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<title>Google Earth Enterprise Documentation</title>
+<title>Google Earth Enterprise Documentation 5.2.1</title>
 <link rel="stylesheet" href="css/styles.css" type="text/css" media="all" />
 <link rel="stylesheet" href="css/containers.css" type="text/css" media="all" />
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-108632131-2"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'UA-108632131-2');
+</script>
 </head>
 
 <body>
@@ -12,14 +20,27 @@
   <div class="sidebar1"> </div>
   <div class="content"> <a name="top_of_file"></a>
     <p><img src="art/common/googlelogo_color_260x88dp.png" width="130" height="44" alt="Google logo" /></p>
-    <h2>Google Earth Enterprise  Documentation</h2>
-    <p>Select a Google Earth Enterprise Open Source version to view the documentation</p>
-    <h4><a href="5.2.1/index.html">5.2.1 (unstable)</a></h4>
-    <h4><a href="5.2.0/index.html">5.2.0 (stable)</a></h4>
+    <h2>Google Earth Enterprise Documentation</h2>
+    <p>This documentation contains legacy information that may not apply to the
+       Google Earth Enterprise Open Source version. This bundle is also 
+       available in the GEE Server 5.2.1 installation package.</p>
+    <h4><a href="answer/2995465.html">Get started</a></h4>
+    <h4><a href="answer/4412440.html">Fusion tutorial</a></h4>
+    <h4><a href="answer/3468016.html">Install Google Earth Enterprise</a></h4>
+    <h4><a href="answer/3481464.html">Fusion administration</a></h4>
+    <h4><a href="answer/6153619.html">Fusion resources and projects</a></h4>
+    <h4><a href="answer/3468004.html">GEE Server administration</a></h4>
+    <h4><a href="answer/173056.html">GEE Server configuration and security</a></h4>
+    <h4><a href="answer/6006981.html">Google Earth Enterprise client</a></h4>
+    <h4><a href="answer/4580164.html">Portable</a></h4>
+    <h4><a href="answer/6014171.html">Developers</a></h4>
+    <h4><a href="answer/6121524.html">Troubleshooting and error messages</a></h4>
+    <h4><a href="answer/7160001.html">Release notes</a></h4>
+    <h4><a href="answer/2987876.html">Legal notices</a></h4>
   </div>
   <div class="footer">
     <hr />
-    <p class="copyright">&copy;2017 Google</p>
+    <p class="copyright">&copy;2018 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/index.html
+++ b/docs/geedocs/index.html
@@ -41,7 +41,7 @@ gtag('config', 'UA-108632131-2');
   <div class="footer">
     <hr />
     <p class="copyright">&copy;2017 Google</p>
-    <p class="copyright">&copy;2018 Open GEE Contributors</p>
+    <p class="copyright">&copy;2017-2018 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/index.html
+++ b/docs/geedocs/index.html
@@ -40,6 +40,7 @@ gtag('config', 'UA-108632131-2');
   </div>
   <div class="footer">
     <hr />
+    <p class="copyright">&copy;2017 Google</p>
     <p class="copyright">&copy;2018 Open GEE Contributors</p>
   </div>
 </div>


### PR DESCRIPTION
Work for #358 

- Release notes list new features, fixed bugs and known issues for Open GEE 5.2.1
- Documentation was updated to to use for root index document same one as one used for Open GEE 5.2.1