### PR TITLE
#225: Added check to reject directory names with spaces or special characters.

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1629,6 +1629,16 @@ void AssetManager::NewFolder(const QString& folder_name) {
   if (!ok || text.isEmpty())
     return;
 
+  if (text.contains(QRegExp("[\\W+]"))) {
+      QMessageBox::warning(this, "Warning",
+                           tr("Invalid directory name: \n") +
+                           text + QString("\n\n") +
+                           tr("Please use only letters, numbers and "
+                              "underscores."),
+                           tr("OK"), 0, 0, 1);
+      return;
+  }
+
   QListViewItem* item;
 
   if (folder_name.isEmpty()) {


### PR DESCRIPTION
- This fix prevents the Fusion->Asset Manager->ASSET_ROOT->New Subfolder dialog from creating directories with spaces or special characters.
- To test, use New Subfolder dialog in Fusion->Asset Manager in ASSET_ROOT window.
- Tested on CentOS 7
- Fixes #225
- Note: May need to check all UI dialogs for consistency.