### PR TITLE
#735: Add Linux thread IDs to the gecombineterrain performance log.

### DIFF
--- a/earth_enterprise/src/common/performancelogger.cpp
+++ b/earth_enterprise/src/common/performancelogger.cpp
@@ -30,7 +30,6 @@ using namespace getime;
 
 #ifdef LOG_PERFORMANCE
 
-#include <sys/syscall.h>
 #include <sys/types.h>
 
 

--- a/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
+++ b/earth_enterprise/src/fusion/gecombineterrain/combineterrain.cpp
@@ -418,7 +418,7 @@ void TerrainCombiner::MarkPacketReadyForWrite(PacketInfo* packet) {
 }
 
 bool TerrainCombiner::PopCompressQueue(PacketInfo** packet_out) {
-  BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_Pop", "CompressQueue");
+  BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_CompressQueue_Pop", "CompressQueue");
   *packet_out = NULL;
   bool wake_reader = false;
   {
@@ -492,7 +492,7 @@ void TerrainCombiner::PacketCompressThread() {
 }
 
 bool TerrainCombiner::PopWriteQueue(PacketInfo** packet_out) {
-  BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_Pop", "WriteQueue");
+  BEGIN_PERF_LOGGING(perfLog, "CombineTerrain_WriteQueue_Pop", "WriteQueue");
   *packet_out = NULL;
   bool wake_reader = false;
   {


### PR DESCRIPTION
* Renamed the `tid` column to `pthread_id` in the `gecombineterrain` performance log.
* Added a `tid` column containing the Linux thread ID (as returned by the `gettid` `syscall`).

Fixes #735.