### PR TITLE
#498 Add 'removevolume' option to geconfigureassetroot

### DIFF
--- a/docs/geedocs/5.2.2/answer/3481558.html
+++ b/docs/geedocs/5.2.2/answer/3481558.html
@@ -90,7 +90,7 @@
   <p><i>Default</i>. Uses normal imagery for the project.</p>
   <h2><a name="63542"></a>geconfigureassetroot</h2>
   <pre>
-<code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--removevolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>
+<code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>
   <h3>Purpose</h3>
   <p>To add volume definitions or edit existing volume definitions.</p>
   <div class="tip">You must run this command as root. Except for the <b>--listvolumes</b> command, you must stop the fusion service before using this command and then start it again after you are done.</div>
@@ -133,11 +133,8 @@ geconfigureassetroot --editvolumes</code></pre>
 <code><b>--fixmasterhost</b> [--assetroot <i>path</i>]</code></pre>
 <p><i>Optional</i>. Change the <i>assetroot host</i> entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)</p>
 <pre>
-<code><b>--addvolume</b> <i>volume_name:path</i></code></pre>
-<p><i>Optional</i>. Add a volume with the given name and directory path.</p>
-<pre>
-<code><b>--removevolume</b> <i>volume_name</i></code></pre>
-<p><i>Optional</i>. Remove volume with the given name.</p>
+<code><b>--addvolume</b> <i>volume_name:path</i>]</code></pre>
+<p><i>Optional</i>. Change the <i>assetroot host</i> entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)</p>
 <h2><a name="geconfigurepublishroot"></a>geconfigurepublishroot</h2>
 <pre>
 <code>geconfigurepublishroot [--path=<em>path</em>] [--allow_symlinks] [--noprompt]</code></pre>

--- a/docs/geedocs/5.2.2/answer/3481558.html
+++ b/docs/geedocs/5.2.2/answer/3481558.html
@@ -90,7 +90,7 @@
   <p><i>Default</i>. Uses normal imagery for the project.</p>
   <h2><a name="63542"></a>geconfigureassetroot</h2>
   <pre>
-<code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>
+<code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--removevolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>
   <h3>Purpose</h3>
   <p>To add volume definitions or edit existing volume definitions.</p>
   <div class="tip">You must run this command as root. Except for the <b>--listvolumes</b> command, you must stop the fusion service before using this command and then start it again after you are done.</div>
@@ -133,8 +133,11 @@ geconfigureassetroot --editvolumes</code></pre>
 <code><b>--fixmasterhost</b> [--assetroot <i>path</i>]</code></pre>
 <p><i>Optional</i>. Change the <i>assetroot host</i> entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)</p>
 <pre>
-<code><b>--addvolume</b> <i>volume_name:path</i>]</code></pre>
-<p><i>Optional</i>. Change the <i>assetroot host</i> entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)</p>
+<code><b>--addvolume</b> <i>volume_name:path</i></code></pre>
+<p><i>Optional</i>. Add a volume with the given name and directory path.</p>
+<pre>
+<code><b>--removevolume</b> <i>volume_name</i></code></pre>
+<p><i>Optional</i>. Remove volume with the given name.</p>
 <h2><a name="geconfigurepublishroot"></a>geconfigurepublishroot</h2>
 <pre>
 <code>geconfigurepublishroot [--path=<em>path</em>] [--allow_symlinks] [--noprompt]</code></pre>

--- a/earth_enterprise/src/common/khstl.h
+++ b/earth_enterprise/src/common/khstl.h
@@ -371,7 +371,20 @@ makeset(const T &e1, const T &e2, const T &e3, const T &e4, const T &e5, const T
   tmp.insert(e6);
   return tmp;
 }
-
+template <class T>
+std::set<T>
+makeset(const T &e1, const T &e2, const T &e3, const T &e4, const T &e5, const T &e6, const T &e7)
+{
+  std::set<T> tmp;
+  tmp.insert(e1);
+  tmp.insert(e2);
+  tmp.insert(e3);
+  tmp.insert(e4);
+  tmp.insert(e5);
+  tmp.insert(e6);
+  tmp.insert(e7);
+  return tmp;
+}
 
 template <class Key, class Value>
 std::map<Key, Value>


### PR DESCRIPTION
This is my first attempt at fixing bug #498 , as a coding assignment. A couple of notes:
- Documentation also needs to be updated to account for "removevolume", but when looking at  earthenterprise/docs/geedocs/5.2.0/answer/3481558.html, I found this:
============
--fixmasterhost [--assetroot path]

Optional. Change the assetroot host entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)

--addvolume volume_name:path]

Optional. Change the assetroot host entry to match the current host name. (This command corrects cases where a host name is changed after installing and configuring Google Earth Enterprise Fusion.)
============

The above two entries are identical, does it mean that "addvolume" also needs to be properly documented? Or is that document not being actively maintained?

- There is a typo that I found and fixed ("unrecognized parameters")

- With C++11, some code can be simplified--for example, you wouldn't need a "makeset" with multiple versions for different number of template arguments. However, this would require updating the build system. There are other improvements that could be made. However, in general, I tried to maintain consistency with the current style of geconfigureassetroot.cpp and only fix the issue referenced in the bug.

