### PR TITLE
Issue #720 Temporary fix for RPM install error on a "clean" server

### DIFF
--- a/earth_enterprise/rpms/opengee-fusion/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-install.sh
@@ -17,7 +17,6 @@
 # NOTE: requires xmllint from libxml2-utils
 
 set +x
-set -e
 
 #------------------------------------------------------------------------------
 # Definitions

--- a/earth_enterprise/rpms/opengee-fusion/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/pre-install.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set +x
-set -e
 
 NEW_INSTALL=false
 if [ "$1" = "1" ] ; then
@@ -27,6 +26,9 @@ fi
 #-----------------------------------------------------------------
 main_preinstall()
 {
+   # Report errors to RPM installer
+    set -e
+
     # Check to see if opengee executables work and error out if not
     RET_VAL=0
     ERROUT=`$BASEINSTALLDIR_OPT/bin/geserveradmin 2>&1` || RET_VAL=$?
@@ -37,6 +39,9 @@ main_preinstall()
       echo "This is likely to be a missing MrSID library."
       return 127
     fi
+
+    # Stop reporting errors to RPM installer
+    set +e
 
     if [ -f /etc/init.d/gefusion ]; then
         service gefusion stop

--- a/earth_enterprise/rpms/opengee-server/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/post-install.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set +x
-set -e
 umask 002
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/rpms/opengee-server/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/pre-install.sh
@@ -27,6 +27,8 @@ fi
 #-----------------------------------------------------------------
 main_preinstall()
 {
+     # Report errors to RPM installer
+    set -e
 
     # Check to see if opengee executables work and error out if not
     RET_VAL=0
@@ -38,6 +40,9 @@ main_preinstall()
       echo "This is likely to be a missing MrSID library."
       return 127
     fi
+
+    # Stop reporting errors to RPM installer
+    set +e
 
     # needed both for rpm state change and upgrading non-rpm install
     if [ -f /etc/init.d/geserver ]; then


### PR DESCRIPTION
Fixes issues found testing #720

* Removed the 'set -e' setting for the entire pre/post install scriptlets
* Instead they are focussed around just checking to make sure that the
  GEE executables work before proceeding

**Verification Steps**

***Clean Install***
1. On a server that has previously not had Open GEE installed:
1. Verify that /gevol does not exist
1. Install RPMs built using this branch
1. Verify no obvious errors with the RPM itself
1. Verify that the Fusion and GE Services are working by executing
    ```
    $ sudo service geserver restart
    $ sudo service gefusion restart
    $ getop
    ```
1. Bring up the Earth Server Admin Console to make sure it's running (You may have to configure firewall settings)

***Upgrade***

Note: if installing on the same server as used above, be sure to uninstall opengee RPMs before continuing below

1. Install Open GEE RPMs built without MrSID support
1. Build and publish a basic database (without changing the default asset root and publish root)
1. Create RPMs with MrSID support from the [new branch](https://github.com/tst-ccamp/earthenterprise/tree/720-rpm-error-handling)
1. On test server, remove or disable MrSID library, e.g. `sudo mv /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482/ /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482.moved` if it's already installed
1. Install new opengee-common rpm using yum
1. Attempt to install opengee-server and opengee-fusion rpms using yum
1. Both should fail to install with an error similar to: 
    ```
    /opt/google/bin/geserveradmin: error while loading shared libraries: libltidsdk.so: cannot open shared 
    object file: No such file or directory
    It appears that not all library dependencies have been installed.
    This is likely to be a missing MrSID library.
    error: %pre(opengee-server-0:5.2.1.0.alpha.201803082212-1.el7.x86_64) scriptlet failed, exit status 127
    Error in PREIN scriptlet in rpm package opengee-server-5.2.1.0.alpha.201803082212-1.el7.x86_64
    opengee-server-5.2.1.0.alpha.201803072058.g3c4815d-1.el7.x86_64 was supposed to be removed but is not!
    ```
1. Install/restore the MrSID library, e.g. `sudo mv /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482.moved/ /opt/MrSID_DSDK-9.5.4.4703-rhel6.x86-64.gcc482`
1. Attempt to install opengee-server and opengee-fusion rpms using yum
1. This time the rpms should install successfully (but there may be warnings printed out)
1. Verify that the published database from before is still published