### PR TITLE
Fix no portables 765

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -1213,16 +1213,19 @@ class PublishManagerHelper(stream_manager.StreamManager):
     root = constants.CUTTER_GLOBES_PATH
     for name in os.listdir(root):
       # Ignore globes that are registered.
-      if (name not in registered_portable_set) and (os.path.isfile(name)):
-        db_info = basic_types.DbInfo()
-        db_info.name = name
-        db_info.type = db_info.name[-3:]
-        # Ignore files that are not Portables, eg .README
-        if serve_utils.IsPortable(db_info.type):
-          serve_utils.GlxDetails(db_info)
-          if db_info.size > GLOBE_SIZE_THRESHOLD:
-            globes_list.append(db_info)
-
+      if name not in registered_portable_set:
+        if os.path.isfile(os.path.join(path, name)):
+          db_info = basic_types.DbInfo()
+          db_info.name = name
+          db_info.type = db_info.name[-3:]
+          # Ignore files that are not Portables, eg .README
+          if serve_utils.IsPortable(db_info.type):
+            serve_utils.GlxDetails(db_info)
+            if db_info.size > GLOBE_SIZE_THRESHOLD:
+              globes_list.append(db_info)
+        else:
+          logger.warn( "%s is not a valid file and is being ignored." % os.path.join(path,name) )
+          
     return globes_list
 
   def _CreateVsConfig(self, vs_name, vs_url):

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -1214,7 +1214,7 @@ class PublishManagerHelper(stream_manager.StreamManager):
     for name in os.listdir(root):
       # Ignore globes that are registered.
       if name not in registered_portable_set:
-        if os.path.isfile(os.path.join(path, name)):
+        if os.path.isfile(os.path.join(root, name)):
           db_info = basic_types.DbInfo()
           db_info.name = name
           db_info.type = db_info.name[-3:]
@@ -1224,7 +1224,7 @@ class PublishManagerHelper(stream_manager.StreamManager):
             if db_info.size > GLOBE_SIZE_THRESHOLD:
               globes_list.append(db_info)
         else:
-          logger.warn( "%s is not a valid file and is being ignored." % os.path.join(path,name) )
+          logger.warn( "%s is not a valid file and is being ignored." % os.path.join(root,name) )
           
     return globes_list
 

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -1225,7 +1225,7 @@ class PublishManagerHelper(stream_manager.StreamManager):
               globes_list.append(db_info)
         else:
           logger.warn( "%s is not a valid file and is being ignored." % os.path.join(root,name) )
-          
+
     return globes_list
 
   def _CreateVsConfig(self, vs_name, vs_url):


### PR DESCRIPTION
Fixes issue #765.  Needed to check that portable files actually exist using the full path instead of just the filename.

Tested that #252 is still also fixed as well. Tested on CentOS 7
Test steps:

1. Create, push, and publish a database using fusion and geserver (to see that links don't break display)
2. Create an invalid symlink in /etc/google/gehttpd/htdocs/cutter/globes
3. Place a portable globe in /etc/google/gehttpd/htdocs/cutter/globes
4. Log in to the server admin page
5. Pushed DB from step 1 is visible
6. Clicking manage portables brings up a window containing the portable globe
7. Add another file into the portable globes file
8. Refresh the portable globes display and ensure the new globe appears
9. Opened /opt/google/gehttpd/logs/gestream_publisher.out and verified there is a warning related to the invalid symlink created in step 2.