### PR TITLE
Updated earth_enterprise/rpms/build.gradle to output Debian package for common libraries

### DIFF
--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -403,35 +403,19 @@ if (project.hasProperty('buildOpenGee')) {
 }
 
 task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
-    packageName = 'opengee-common'
-    release = "1.${rpmPlatformString}"
+    packageName = openGeeCommonRpm.packageName
+    release = openGeeCommonRpm.release
     version = openGeeVersion
-    user = 'root'
-    permissionGroup = 'root'
-    packageGroup = 'Application/Productivity'
-    summary = 'Third-party libraries bundled with Open GEE'
+    user = openGeeCommonRpm.user
+    permissionGroup = openGeeCommonRpm.permissionGroup
+    packageGroup = 'misc'
+    summary = openGeeCommonRpm.summary
     // The package build failed when packageDescription was copied here from openGeeCommonRpm, so it is omitted for now
-    license =
-        'ASL 2.0 and ' +
-        'BSD and ' +
-        'GPLv2+ and ' +
-        'Psycopg2 GPL 3+ and ' +
-        'LGPLv2 and ' +
-        'MIT and ' +
-        'MPLv1.1 and ' +
-        'PSF 2 and ' +
-        'Python Imaging Library 1.1.7 and ' +
-        'mgrs 1.1.0 and mm 1.4.2 and ' +
-        'OpenLDAP and ' +
-        'OpenSSL and ' +
-        'Skia 5.1.2'
+    license = openGeeCommonRpm.license
+    priority = 'optional'
 
     setArch('amd64')	// if this is not specified, the architecture is x86_64, and dpkg won't install without the --force-architecture flag
 
-    requires('alien')
-    requires('autoconf')
-    requires('automake')
-    requires('doxygen')
     requires('flex')
     requires('freeglut3-dev')
     requires('gettext')
@@ -447,9 +431,6 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
     requires('python-psycopg2')
     requires('python-setuptools')
     requires('python2.7')
-    requires('python-git')
-    requires('shunit2')
-    requires('swig')
 
     // Prefix variable definitions to all install scripts:
     installUtils = file('build/shared/install-utils.sh')

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -79,16 +79,6 @@ def gee_long_version_txt = "${src_dir}${native_dir()}/gee_long_version.txt"
 
 def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
 
-def osId = org.opengee.os.Platform.osId
-
-def packageDep
-
-if (osId == "ubuntu") {
-    packageDep = "openGeeDebs"
-} else {
-    packageDep = "openGeeRpms"
-}
-
 def stagedInstall_path =
     project.hasProperty('stageInstallPath') ?
         project.stageInstallPath :
@@ -712,7 +702,7 @@ task openGeeRpms(
 task openGeeDebs(
     dependsOn: ['openGeeServerDeb', 'openGeeFusionDeb', 'openGeeCommonDeb'])
 
-task osPackage(dependsOn: packageDep)
+task osPackage(dependsOn: org.opengee.os.Platform.osId == 'ubuntu' ? openGeeDebs : openGeeRpms)
 
 // Mostly for documentation purposes.  You need to comment out the rest of the
 // Gradle file to run this task:

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -409,8 +409,7 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
     user = openGeeCommonRpm.user
     permissionGroup = openGeeCommonRpm.permissionGroup
     packageGroup = 'misc'
-    summary = openGeeCommonRpm.summary
-    // The package build failed when packageDescription was copied here from openGeeCommonRpm, so it is omitted for now
+    formatPackageDescription(openGeeCommonRpm.summary + '\n' + openGeeCommonRpm.packageDescription)
     license = openGeeCommonRpm.license
     priority = 'optional'
 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2017 the Open GEE Contributors
+// Copyright 2017, 2018 the Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -416,7 +416,7 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
     setArch('amd64')	// if this is not specified, the architecture is x86_64, and dpkg won't install without the --force-architecture flag
 
     requires('flex')
-    requires('freeglut3-dev')
+    requires('freeglut3')
     requires('gettext')
     requires('libc6')
     requires('libfreetype6')

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -79,6 +79,16 @@ def gee_long_version_txt = "${src_dir}${native_dir()}/gee_long_version.txt"
 
 def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
 
+def osId = org.opengee.os.Platform.osId
+
+def packageDep
+
+if (osId == "ubuntu") {
+    packageDep = "openGeeDebs"
+} else {
+    packageDep = "openGeeRpms"
+}
+
 def stagedInstall_path =
     project.hasProperty('stageInstallPath') ?
         project.stageInstallPath :
@@ -702,7 +712,7 @@ task openGeeRpms(
 task openGeeDebs(
     dependsOn: ['openGeeServerDeb', 'openGeeFusionDeb', 'openGeeCommonDeb'])
 
-task osPackage(dependsOn: ['openGeeRpms', 'openGeeDebs'])
+task osPackage(dependsOn: packageDep)
 
 // Mostly for documentation purposes.  You need to comment out the rest of the
 // Gradle file to run this task:

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -402,16 +402,84 @@ if (project.hasProperty('buildOpenGee')) {
     openGeeCommonRpm.dependsOn stageOpenGeeInstall
 }
 
-
-task openGeeCommonDeb (type: Deb) {
+task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
     packageName = 'opengee-common'
+    release = "1.${rpmPlatformString}"
+    version = openGeeVersion
+    user = 'root'
+    permissionGroup = 'root'
+    packageGroup = 'Application/Productivity'
+    summary = 'Third-party libraries bundled with Open GEE'
+    // The package build failed when packageDescription was copied here from openGeeCommonRpm, so it is omitted for now
+    license =
+        'ASL 2.0 and ' +
+        'BSD and ' +
+        'GPLv2+ and ' +
+        'Psycopg2 GPL 3+ and ' +
+        'LGPLv2 and ' +
+        'MIT and ' +
+        'MPLv1.1 and ' +
+        'PSF 2 and ' +
+        'Python Imaging Library 1.1.7 and ' +
+        'mgrs 1.1.0 and mm 1.4.2 and ' +
+        'OpenLDAP and ' +
+        'OpenSSL and ' +
+        'Skia 5.1.2'
 
-    from(stagedInstallDir_common) {
+    setArch('amd64')	// if this is not specified, the architecture is x86_64, and dpkg won't install without the --force-architecture flag
+
+    requires('alien')
+    requires('autoconf')
+    requires('automake')
+    requires('doxygen')
+    requires('flex')
+    requires('freeglut3-dev')
+    requires('gettext')
+    requires('libc6')
+    requires('libfreetype6')
+    requires('libperl4-corelibs-perl')
+    requires('libpng12-0')
+    requires('libstdc++6')
+    requires('libtool')
+    requires('libxml2-utils')
+    requires('openssl')
+    requires('python-imaging')
+    requires('python-psycopg2')
+    requires('python-setuptools')
+    requires('python2.7')
+    requires('python-git')
+    requires('shunit2')
+    requires('swig')
+
+    // Prefix variable definitions to all install scripts:
+    installUtils = file('build/shared/install-utils.sh')
+
+    preInstall = file('opengee-common/pre-install.sh')
+    postUninstall = file('opengee-common/post-uninstall.sh')
+
+    from (file('build/shared/gevars.sh')) {
+        into new File(packageInstallRootDir, 'etc/init.d')
+    }
+
+    from (stagedInstallDir_common_opt) {
+        into new File(packageInstallRootDir, 'opt')
+    }
+
+    from (stagedInstallDir_common_user_magic) {
         into packageInstallRootDir
     }
+
     from(stagedInstallDir_manual) {
         into packageInstallRootDir
     }
+
+    from(file('opengee-common/install')) {
+        into packageInstallRootDir
+    }
+}
+
+if (project.hasProperty('buildOpenGee')) {
+    openGeeCommonDeb.dependsOn stageOpenGeeInstall
 }
 
 task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {

--- a/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
+++ b/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
@@ -97,18 +97,23 @@ class GeeDeb extends com.netflix.gradle.plugins.deb.Deb {
         findRequires(packageInputFiles).each { requires(it) }
     }
 
-    protected void formatPackageDescription(String descrip){
-        packageDescription = ''
-        List lines = descrip.split( '\n' )
-        lines.eachWithIndex{ item, index ->
-            if(0 == index)
-                packageDescription = item
-            else{
-                if(item.trim() == '')
-                    packageDescription = packageDescription + '\n .'
-                else
-                    packageDescription = packageDescription + '\n ' + item
+    // Formats a multi-line description to be compatible with a Debian build
+    void formatPackageDescription(String descrip){
+        def formattedDescription = ''
+        descrip.eachLine{ line ->
+            if (line.trim() == '') {
+                if (formattedDescription != '') {
+                    formattedDescription += '\n .'
+                }
+            } else {
+                if (formattedDescription == '') {
+                    formattedDescription += line.trim()
+                } else {
+                    formattedDescription += '\n ' + line.trim()
+                }
             }
         }
+
+        packageDescription = formattedDescription
     }
 }

--- a/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
+++ b/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
@@ -1,3 +1,17 @@
+// Copyright 2017, 2018 the Open GEE Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import com.netflix.gradle.plugins.deb.Deb
 import org.opengee.shell.GeeCommandLine
 

--- a/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
+++ b/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
@@ -82,4 +82,19 @@ class GeeDeb extends com.netflix.gradle.plugins.deb.Deb {
 
         findRequires(packageInputFiles).each { requires(it) }
     }
+
+    protected void formatPackageDescription(String descrip){
+        packageDescription = ''
+        List lines = descrip.split( '\n' )
+        lines.eachWithIndex{ item, index ->
+            if(0 == index)
+                packageDescription = item
+            else{
+                if(item.trim() == '')
+                    packageDescription = packageDescription + '\n .'
+                else
+                    packageDescription = packageDescription + '\n ' + item
+            }
+        }
+    }
 }


### PR DESCRIPTION
Updated the openGeeCommonDeb task in build.gradle to install common files and specify dependencies.

Tested the build and installation of the resulting opengee-common***.deb package on Ubuntu 16.04.
Installed using sudo dpkg -i opengee-common***.deb. Installed dependencies with sudo apt-get -f install.

For me, the install of dependencies was hit-and-miss, but I believe that this was due to some issues I was having with my virtual machine. In the instances where it did not install the dependencies, apt-get would not allow me to install anything at all (using sudo apt-get install <package>).

The list of dependencies was compiled from the list in BUILD_Ubuntu.md and needs a follow-on task to clean up the list.

Fixes #762