### PR TITLE
Opgee794 custom version labels

### DIFF
--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -73,9 +73,10 @@ built_version_file = env.Command(version_file, [ ],
                       [env.EmitVersion(version_file, backup_file)])
 env.AlwaysBuild(built_version_file)
 
+label = ARGUMENTS.get('label', '')
 long_version_file = File('gee_long_version.txt').abspath
 built_long_version_file = env.Command(long_version_file, [ ],
-                      [env.EmitLongVersion(long_version_file, backup_file)])
+                      [env.EmitLongVersion(long_version_file, backup_file, label)])
 env.AlwaysBuild(built_long_version_file)
 env.install('root', long_version_file)
 

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -72,6 +72,7 @@ ValidOptions = set(
      'coverage',
      'bundle_3rd_libs',  # Build with bundling 3rd party libs.
      'log_performance',  # Include code for performance logging
+     'label',            # Value to combine with version strings.
      ]);
 
 for argkey in ARGUMENTS:
@@ -97,6 +98,7 @@ coverage = ARGUMENTS.get('coverage', 0)
 bundle_3rd_libs = int(ARGUMENTS.get('bundle_3rd_libs', 0))
 cc_dir = ARGUMENTS.get('cc_dir', None)
 log_performance = int( ARGUMENTS.get( 'log_performance', 0 ) )
+label = ARGUMENTS.get('label', '')
 
 # make some directory variables used by other parts of the build system
 top_dir = Dir('#').abspath
@@ -414,7 +416,7 @@ def is_version_ge(version_components, comparand_components):
 
   return True
 
-gee_version_number = GetVersion("version.txt")
+gee_version_number = GetVersion("version.txt", label)
 
 
 # create the environment that controls the builds

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -223,37 +223,43 @@ def EmitVersionStrfunc(target, backupFile):
   return 'EmitVersion(%s, %s)' % (target, backupFile)
   
   
-def EmitLongVersionFunc(target, backupFile):
+def EmitLongVersionFunc(target, backupFile, label):
   """Emit version information to the target file."""
 
-  versionStr = GetLongVersion(backupFile)
+  versionStr = GetLongVersion(backupFile, label)
 
   with open(target, 'w') as fp:
     fp.write(versionStr)
 
 
-def EmitLongVersionStrfunc(target, backupFile):
-  return 'EmitLongVersion(%s, %s)' % (target, backupFile)
+def EmitLongVersionStrfunc(target, backupFile, label):
+  return 'EmitLongVersion(%s, %s, %s)' % (target, backupFile, label)
   
 
-def GetLongVersion(backupFile):
+def GetLongVersion(backupFile, label=''):
   """Create a detailed version string based on the state of
      the software, as it exists in the repository."""
-  
+ 
   if CheckGitAvailable():
-    return GitGeneratedLongVersion()
+    ret = GitGeneratedLongVersion()
 
   # Without git, must use the backup file to create a string.
-  base = ReadBackupVersionFile(backupFile)
-  date = datetime.utcnow().strftime("%Y%m%d%H%M")
-  
-  return '-'.join([base, date])
+  else:
+    base = ReadBackupVersionFile(backupFile)
+    date = datetime.utcnow().strftime("%Y%m%d%H%M")
+    ret = '-'.join([base, date])
+
+  # Append the label, if there is one.
+  if len(label):
+    ret = '-'.join([ret, label])
+
+  return ret
 
 
-def GetVersion(backupFile):
+def GetVersion(backupFile, label=''):
   """As getLongVersion(), but only return the leading *.*.* value."""
 
-  raw = GetLongVersion(backupFile)
+  raw = GetLongVersion(backupFile, label)
   final = raw.split("-")[0]
 
   return final

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -251,7 +251,7 @@ def GetLongVersion(backupFile, label=''):
 
   # Append the label, if there is one.
   if len(label):
-    ret = '-'.join([ret, label])
+    ret = '.'.join([ret, label])
 
   return ret
 


### PR DESCRIPTION
Implements #794 

A new "label" argument can be passed in to scons, which will then be appended to the appropriate version strings, making it easier to differentiate e.g. dev from release rpms.

For example:
scons -j8 release=1 label=testing stage_install
...

Affected results: rpm names/versions, GEE splash screen version information.

Scenarios to test:
- On a tagged branch: opengee-common-5.2.2.2.beta.testing-1.el6_x86_64.rpm
- On a non-tagged commit: opengee-common-5.2.2.2.beta.201804061530.g4ddd3a0.testing-1.el6_x86_64.rpm
- Dirty state: opengee-common-5.2.2.2.beta.201804061530.testing-1.el6_x86_64.rpm
- Leaving out a label yields the same results as before this change.