### PR TITLE
Changed SConscript in gtest to not build gtest if in release. 

### DIFF
--- a/earth_enterprise/src/third_party/gtest/SConscript
+++ b/earth_enterprise/src/third_party/gtest/SConscript
@@ -22,10 +22,12 @@ buildGtest = False
 
 # Check environment for libgtest.so
 conf = Configure(env)
-if not conf.CheckLib('gtest'):
-    buildGtest = True
-
 env = conf.Finish()
+
+# If building release, don't include gtest so scons won't add it as a dependency.
+if not env['release']:
+    if not conf.CheckLib('gtest'):
+        buildGtest = True
 
 # Build libgtest as a shared library. If we make gtest static it forces all
 # executables linked against it to link statically and that messes up the


### PR DESCRIPTION
This appears to remove the dependency from the rpms created. Only tested on CentOS 7. I was also able to build internal/release and build the rpms. rpms were tested on a different CentOS VM without gtest installed. Both /etc/init.d/geserver restart and /opt/google/bin/geserveradmin ran without failing to link gtest. I tried other approaches of removing gtest from libs in different ways but this seemed to work best.