### PR TITLE
Resolve host name from ServerName or FQDN instead of using Listen command in gehttpd.con

### DIFF
--- a/earth_enterprise/src/server/wsgi/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/common/utils.py
@@ -216,6 +216,7 @@ def GetApacheSchemeHostPortFromListen():
     assert port
     if not scheme:
       scheme = "https" if port == "443" else "http"
+    host = None
     return (scheme, host, port)
 
   logging.error("Listen directive is not specified in gehttpd config.")


### PR DESCRIPTION
Fixes #810

When specific ip address is being listened to current logic of getting host name of the local virtual host use s that ip address instead of resolving from the machine. 

Verification Steps:
- Using sudo, edit opt/google/gehttpd/conf/gehttpd.conf (ex. `sudo nano /opt/google/gehttpd/conf/gehttpd.conf`) and change `Listen 80` to `Listen 127.0.0.1:80`

- Restart GEE Server: `sudo /etc/init.d/geserver restart`

- List  Virtual hosts: `/opt/google/bin/geserveradmin --listvhs`

- Verify the returned list
local, http://localhost/local_host
public, http://MyHostName/public_host
secure, http://MyHostName/secure_host

where MyHostName is the host name where GEE Server is installed and running.