### PR TITLE
Disabling CA certificate authentication for the ge publish server to …

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
@@ -1,4 +1,6 @@
 import os
+# The line below prevents python 2.7.x+ versions from performing CA certificate verification for this application only.  CA checks fail due to nothing being found in the trust store.
+# A more permanent solution should be worked out to allow verification and remove this line
 os.environ['PYTHONHTTPSVERIFY'] = '0'
 
 from serve.publish.publish_app import application

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
@@ -1,1 +1,4 @@
+import os
+os.environ['PYTHONHTTPSVERIFY'] = '0'
+
 from serve.publish.publish_app import application


### PR DESCRIPTION
Addresses #817.  Temporary work around to avoid issues publishing via https admin console.

Tested on ubuntu 16, centos7, and RHEL7 by attempting to publish a database to any virtual host via the https admin console.