### PR TITLE
590: Fixing page title for v360, v310 API usage examples

### DIFF
--- a/earth_enterprise/src/maps/example_local_v310.html
+++ b/earth_enterprise/src/maps/example_local_v310.html
@@ -11,7 +11,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <title>Fusion Maps API v390 - Hello World Example</title>
+    <title>Fusion Maps API v310 - Hello World Example</title>
 
     <script type="text/javascript">
         var gmap;

--- a/earth_enterprise/src/maps/example_local_v360.html
+++ b/earth_enterprise/src/maps/example_local_v360.html
@@ -11,7 +11,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <title>Fusion Maps API v390 - Hello World Example</title>
+    <title>Fusion Maps API v360 - Hello World Example</title>
 
     <script type="text/javascript">
         var gmap;


### PR DESCRIPTION
During testing, I noticed the page titles for alternate API versions all read "v390" -- code was correctly loading each version, but page title was wrong.