### PR TITLE
Copy 5.2.2 release notes updates to 5.2.3 docs

### DIFF
--- a/docs/geedocs/5.2.3/answer/7160002.html
+++ b/docs/geedocs/5.2.3/answer/7160002.html
@@ -36,13 +36,18 @@ gtag('config', 'UA-108632131-2');
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
 <h2>Release notes: Open GEE 5.2.2</h2>
 
-<p>Open GEE 5.2.2 is currently in beta testing</p>
-
   <h5>
-    <p id="overview_5">New Features</p>
+    <p id="overview_5.2.2">New Features</p>
   </h5>
-    <p><strong>Example Feature</strong>. Example description</p>
-  <h5>
+  <p><strong>Ability to load a default globe, using Google Earth Enterprise Client, when connecting to the base URL path</strong>. This can be achieved through enhanced <code>geserveradmin</code> command
+    when publishing a database using the option <code>--setecdefault</code>. Example: <code>geserveradmin --publishdb /gevol/assets/Databases/SFMapDatabase.kmmdatabase/mapdb.kda/ver001/mapdb/ --targetpath http://myserver.org --setecdefault</code></p>  
+  <p><strong>geserver and gefusion services support status</strong>. geserver and gefusion now support returning the status of the services indicating whether they are running or not.</p>
+  <p><strong>Detailed profiling data for terrain processing</strong>. <code>gecombineterrain</code> operation can produce performance details if profiling is enabled. To turn on profiling use <code>log_performance=1</code> when building Open GEE. 
+   Ex. <code>scons -j8 release=1 log_performance=1 build</code>.
+   Executing <code>gecombineterrain</code> will, then, create a log file detailing timing of the execution. 
+   The file is named <code>time_stats.date_time_stamp.csv</code> (ex. <code>time_stats.03-26-2018-11:23:46.csv</code>) and stored in working directory of
+  <code>gecombineterrain</code> if run from terminal. If run from Fusion UI the .csv log file will be stored in <code>/gevol/published_dbs/stream_space/host-name</code> and <code>/gevol/assets/gee-database-name/Db.kdatabase/gedb.kda/</code></p>
+   <h5>
     <p id="supported_5.2.2">Supported Platforms</p>
   </h5>
   <p>The Open GEE 5.2.2 release is supported on 64-bit versions of the following operating systems:</p>
@@ -52,9 +57,42 @@ gtag('config', 'UA-108632131-2');
       <li>Ubuntu 14.04 LTS and 16.04 LTS</li>
     </ul>
     <p>Google Earth Enterprise 5.2.2 is compatible with Google Earth Enterprise Client (EC) version 7.1.5 and above.</p>
-<br/>
-  <p>If you're upgrading from GEE 5.1.3, you may have to reinstall the prerequisite libraries after uninstalling 5.1.3 but before installing 5.2.1.</p>
+  <p><p>To upgrade from Open GEE 5.2.0, do NOT uninstall it. We recommend that you upgrade Open GEE 5.2.0 by simply installing Open GEE 5.2.2. Installing Open GEE 5.2.2 on top of Open GEE 5.2.0 will ensure that your PostgreSQL databases are backed up and upgraded correctly to the new PostgreSQL version used by Open GEE 5.2.2.</p></p>
   <h5>
+    <h5>
+      <p id="resolved_issues_5.2.2">Resolved Issues</p>
+    </h5>
+    <div>
+      <table class="nice-table">
+        <tbody>
+          <tr>
+            <th>Number</th>
+            <th class="narrow">Description</th>
+            <th>Resolution</th>
+          </tr>
+          <tr>
+            <td>810</td>
+            <td>When GEE Server listen to specific ip address the returned default local virtual host is an ip address instead of the hostname</td>
+            <td>Resolved host name from ServerName in gehttpd.conf or FQDN.</td>
+          </tr>           
+          <tr>
+            <td>252</td>
+            <td>Google Earth Server fails to load Admin console when there is an invalid link to a published portable file</td>
+            <td>Added check to ensure files actually exist before continuing on to database object creation.</td>
+          </tr>           
+          <tr>
+            <td>660</td>
+            <td>Building OpenGee on Ubuntu 16.04 throws an error 'ImportError: No module named git:'</td>
+            <td>gitpython introduced dependency was documented in build instructions.</td>
+          </tr>
+          <tr>
+            <td>670</td>
+            <td>Diagnostics fails in current release_5.2.1</td>
+            <td>Fixed and temporary removed diagnostic link was restored.</td>
+          </tr>         
+        </tbody>
+      </table>  
+  <h5>            
   <h5>
     <p id="known_issues_5.2.2">Known Issues</p>
   </h5>
@@ -64,6 +102,311 @@ gtag('config', 'UA-108632131-2');
           <th>Number</th>
           <th class="narrow">Description</th>
           <th>Workaround</th>
+        </tr>
+        <tr>
+          <td>4</td>
+          <td>Google basemap fails to load in 2D Mercator Maps</td>
+          <td>Obtain a valid Google Maps API key and include it in <code>/opt/google/gehttpd/htdocs/maps/maps_google.html</code>.</td>
+        </tr>
+        <tr>
+          <td>8</td>
+          <td>Ensure GEE Portable Cutter Job Completes</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>9</td>
+          <td>Improve FileUnpacker Handling of Invalid Files</td>
+          <td>No current work around.</td>
+        </tr>				
+        <tr>
+          <td>20</td>
+          <td>Simplify build process for portable builds on MacOS</td>
+          <td>Building and running Portable Server on MacOS should be possible with minimal changes.</td>
+        </tr>		
+        <tr>
+          <td>34</td>
+          <td>Scons build creates temporary directories named “0” </td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>126</td>
+          <td>The Fusion installer creates a backup on the first run</td>
+          <td>No current work around. The created backup can be deleted.</td>
+        </tr>		
+        <tr>
+          <td>127</td>
+          <td>Incorrect error messages from Fusion installer</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>190</td>
+          <td>Hostname mismatch check in installers doesn't work as expected</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>193</td>
+          <td>Updated docs are not copied if the <code>/tmp/fusion_os_install</code> directory already exists</td>
+          <td>Delete <code>/tmp/fusion_os_install</code> at the beginning of the stage_install build process.</td>
+        </tr>		
+        <tr>
+          <td>200</td>
+          <td>stage_install fails on the tutorial files when <code>/home</code> and <code>/tmp</code> are on different file systems</td>
+          <td>Ensure that <code>/home</code> and <code>/tmp</code> are on the same file system or download the tutorial files to <code>/opt/google/share/tutorials/fusion/</code> after installing Fusion.</td>
+        </tr>
+        <tr>
+          <td>201</td>
+          <td>Some tiles are displayed incorrectly in the Enterprise Client when terrain is enabled</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>202</td>
+          <td>Icons are not displayed on vector layers in the Enterprise Client</td>
+          <td>No current work around. It is not clear if this is an error in GEE or in the Enterprise Client.</td>
+        </tr>
+        <tr>
+          <td>203</td>
+          <td>Some vector layer options are not saved</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>221</td>
+          <td>The asset manager may display that a job is "Queued" when in fact the job is "Blocked"</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>225</td>
+          <td>Fusion lets you create folder with space in the name</td>
+          <td>Avoid creating folder with space in their name.</td>
+        </tr>		
+        <tr>
+          <td>234</td>
+          <td>Geserver raises error executing apache_logs.pyc</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>254</td>
+          <td>Automasking fails for images stored with UTM projection</td>
+          <td>Use GDAL to convert the images to a different projection before ingesting them into Fusion.</td>
+        </tr>
+        <tr>
+          <td>269</td>
+          <td>gevectorimport doesn't crop features</td>
+          <td>Use GDAL/OGR to crop vector dataset before importing them using Fusion.</td>
+        </tr>		
+        <tr>
+          <td>295</td>
+          <td>Fix buffer overflows and leaks in unit tests</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>309</td>
+          <td>Check for the FusionConnection before new asset is populated</td>
+          <td>Make sure that gefusion service is started.</td>
+        </tr>		
+        <tr>
+          <td>320</td>
+          <td>The Portable Server web page uses obsolete REST calls</td>
+          <td>Do not use the buttons on the Portable Server web interface for adding remote servers or broadcasting to remote servers as these features are no longer supported.</td>
+        </tr>
+        <tr>
+          <td>326</td>
+          <td>Libraries may be loaded from the wrong directory</td>
+          <td>Delete any library versions that should not be loaded or use LD_LIBRARY_PATH to load libraries from <code>/opt/google/lib</code>.</td>
+        </tr>
+        <tr>
+          <td>340</td>
+          <td>GE Fusion Terrain is black</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>342</td>
+          <td>Fusion crashes when opening an unsupported file type</td>
+          <td>Re-open Fusion and avoid opening unsupported file types.</td>
+        </tr>
+        <tr>
+          <td>343</td>
+          <td>gefusion: File ->open->*.kiasset*,*.ktasset*,*.kip does not work</td>
+          <td>kip is not a supported format. Void opening files with .kip extension.</td>
+        </tr>		
+        <tr>
+          <td>380</td>
+          <td>Provider field in resource-view is blank</td>
+          <td>Open the individual resource to see the provider.</td>
+        </tr>
+        <tr>
+          <td>401</td>
+          <td>GEE commands are not in the path for sudo. </td>
+          <td>Specify the full path when running commands or add <code>/opt/google/bin</code> to the path for all users, including the super user.</td>
+        </tr>
+        <tr>
+          <td>402</td>
+          <td>Provider manager window locked to main window.</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>403</td>
+          <td>Missing Close button on system manager window in RHEL 7</td>
+          <td>Right-click the title bar and select Close.</td>
+        </tr>
+        <tr>
+          <td>404</td>
+          <td>Opaque polygons in preview.</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>405</td>
+          <td>Vector layer preview not cleared in some situations</td>
+          <td>Reset the preview window to the correct state by either clicking on it or previewing another vector layer.</td>
+        </tr>
+        <tr>
+          <td>407</td>
+          <td>Corrupt data warning when starting Fusion</td>
+          <td>No current work around but Fusion loads and runs correctly.</td>
+        </tr>
+        <tr>
+          <td>419</td>
+          <td>Fix Fusion Graphics Acceleration in Ubuntu 14 Docker Container Hosted on Ubuntu 16</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>437</td>
+          <td>Rebooting VM while it is building resources results in a corrupted XML</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>439</td>
+          <td>Uninstalling Fusion without stopping it results in unexpected error message</td>
+          <td>Ignore that error message.</td>
+        </tr>		
+        <tr>
+          <td>440</td>
+          <td>Fuzzy imagery in historical imagery tests.</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>442</td>
+          <td>Multiple database pushes after upgrade don't report a warning</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>444</td>
+          <td>Fusion installer does not upgrade the asset root on RHEL 7</td>
+          <td>Upgrade the asset root manually by running the command that is printed when you try to start the Fusion service.</td>
+        </tr>
+        <tr>
+          <td>445</td>
+          <td>Path to tutorial source volume in gee_test instructions is different from path used in installers</td>
+          <td>Use <code>/opt/google/share/tutorials</code>.</td>
+        </tr>		
+        <tr>
+          <td>448</td>
+          <td>Out of Memory issues</td>
+          <td>Use a system that has more than 4GB RAM.</td>
+        </tr>		
+        <tr>
+          <td>453</td>
+          <td>Improve `check_server_processes_running` detection for uninstall</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>456</td>
+          <td>Inconsistent behavior of vector layers after upgrade</td>
+          <td>No current work around.</td>
+        </tr>
+        <tr>
+          <td>460</td>
+          <td>Possibility of seg fault in QDateWrapper</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>474</td>
+          <td>Running gee_check on some supported platforms reports that the platform is not supported</td>
+          <td>You can ignore the failed test if using a supported platform (Ubuntu 14.04, Ubuntu 16.04, RHEL 7, and CentOS 7).</td>
+        </tr>
+        <tr>
+          <td>477</td>
+          <td>'service geserver stop/start/restart' doesn't work on Ubuntu 16.04 without a reboot</td>
+          <td>Reboot and try again.</td>
+        </tr>
+        <tr>
+          <td>487</td>
+          <td>gdal - python utilities do not recognize osgeo module</td>
+          <td>Install <code>python-gdal</code>.</td>
+        </tr>		
+        <tr>
+          <td>507</td>
+          <td>Volume host is reported unavailable if `hostname` doesn't match volume host</td>
+          <td>Set the host values in <code>/gevol/assets/.config/volumes.xml</code> to the FQDN and restart the Fusion service.</td>
+        </tr>		
+        <tr>
+          <td>535</td>
+          <td>DownloadTutorial.sh often is not staged properly for install</td>
+          <td>Copy <code>DownloadTutorial.sh</code> to <code>/tmp/fusion_os_install</code>.</td>
+        </tr>		
+        <tr>
+          <td>557</td>
+          <td>WMS service problem with 'width' &amp; 'height' &amp; 'bbox'</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>569</td>
+          <td>geserver service installation and uninstallation issues</td>
+          <td>Before uninstalling geserver verify if it's running or not.</td>
+        </tr>		
+        <tr>
+          <td>590</td>
+          <td>Maps API Javascript Files Not Found</td>
+          <td>No current work around.</td>
+        </tr>		
+        <tr>
+          <td>594</td>
+          <td>Save errors only reported for the first image</td>
+          <td>Close the form in question and try again.</td>
+        </tr>		
+        <tr>
+          <td>640</td>
+          <td>Save button disabled in 'Map Layer' creation dialog when an error encountered</td>
+          <td>Close the resource form and open it again to make the save option available again.</td>
+        </tr> 
+        <tr>
+          <td>651</td>
+          <td>Release executables and libraries depend on gtest</td>
+          <td>Follow current build instructions that requires <code>gtest</code> to be installed.</td>
+        </tr>
+	      <tr>
+          <td>669</td>
+          <td>Missing repo in RHEL 7 build instructions</td>
+          <td>Enable <code>rhel-7-server-optional-rpms</code> and <code>rhel-7-server-optional-source-rpms</code> repos.</td>
+        </tr>
+        <tr>
+          <td>682</td>
+          <td>Update geconfigurepublishroot to fully correct file permissions</td>
+          <td>Manually correct the file permissions.</td>
+        </tr>		
+        <tr>
+          <td>686</td>
+          <td>Scons fails to detect libpng library on CentOS 6</td>
+          <td>Ensure that a default <code>g++</code> compiler is installed.</td>
+        </tr>		
+        <tr>
+          <td>694</td>
+          <td>Search fails after transferring and publishing a database using disconnected send from the command line</td>
+          <td>Re-publish the database from the web interface.</td>
+        </tr>			
+        <tr>
+          <td>700</td>
+          <td>Add EL6/EL7 check to RPMs</td>
+          <td>Make sure that RPMS are installed on same EL version that they were produced for.</td>
+        </tr>	
+        <tr>
+          <td>731</td>
+          <td>Error in publish of SSL-enabled database</td>
+          <td>A temporary fix was added in this release. A more permanent fix will be done in OpenGEE 5.2.3.</td>
+        </tr>
+        <tr>
+          <td>825</td>
+          <td>Geserver fails to startup fully due to conflicting protobuf library</td>
+          <td>Run <code>pip uninstall protobuf</code> to uninstall the protobuf library installed by pip. </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This copies the documentation changes made on the release_5.2.2 branch into the 5.2.3 folder of documentation so that 5.2.3 docs are a strict superset of 5.2.2 docs. The only change is that the release notes for 5.2.2 were filled out.

You can see the updates here: https://tst-lsavoie.github.io/earthenterprise/geedocs/5.2.3/answer/7160002.html.