### PR TITLE
Issue #821: Fusion Maps API infinite loop

### DIFF
--- a/earth_enterprise/src/maps/api/bootstrap.js
+++ b/earth_enterprise/src/maps/api/bootstrap.js
@@ -32,6 +32,7 @@ google.maps = google.maps || {};
 
   var loadScriptTime = (new Date).getTime();
 
+  getScript(GEE_BASE_URL + '/js/jquery.js');
   getScript(GEE_BASE_URL + GEE_API_PATH + '/main.js');
   getScript(GEE_BASE_URL + GEE_API_PATH + '/../fusion_map_obj_v3.js');
 

--- a/earth_enterprise/src/maps/api/fusion_maps_v3.js
+++ b/earth_enterprise/src/maps/api/fusion_maps_v3.js
@@ -233,8 +233,6 @@ function doInitMap(geeMapOpts, showSearch, showGlobesList) {
 
   // Need to resize after search tabs are filled in.
   geeResizeDivs();  // Resize the map to fill the screen.
-
-  geeInitView(geeShowPolygon);
 }
 
 /**
@@ -500,55 +498,4 @@ function geeLayerIconUrl(glmId, serverUrl, layer) {
         '/query?request=Icon&icon_path=' + layer.icon;
   }
   return serverUrl + '/query?request=Icon&icon_path=' + layer.icon;
-}
-
-function geeShowPolygon(polygonKml) {
-  var coordinates = geePolygonCoordinates(polygonKml, google.maps.LatLng);
-  geeMapCutPolygon = geeDrawPolygon(coordinates, '#FF0000', '#FF00FF');
-
-  var bounds = geePolygonBounds(coordinates);
-  latDiff = bounds.north - bounds.south;
-  lngDiff = bounds.east - bounds.west;
-  if (latDiff > lngDiff) {
-    maxDist = latDiff;
-  } else {
-    maxDist = lngDiff;
-  }
-
-  zoomLevel = Math.floor(Math.log(360 / maxDist) / Math.log(2)) + 2;
-  geePanTo((bounds.south + bounds.north) / 2,
-           (bounds.west + bounds.east) / 2, zoomLevel);
-
-  setTimeout('geeClearPolygon(geeMapCutPolygon)', geePolygonDisplayTime);
-}
-
-/**
- * Draw the polygon.
- * @param {array of google.maps.LatLng} coordinates Coordinates of the polygon.
- * @param {string} stroke_color Color of polygon border.
- * @param {string} fill_color Color of polygon interior.
- * @return {google.maps.Polygon} polygon that was drawn on map.
- */
-function geeDrawPolygon(coordinates, stroke_color, fill_color) {
-  var polygon = new google.maps.Polygon({
-          paths: coordinates,
-          strokeColor: stroke_color,
-          strokeOpacity: 1.0,
-          strokeWeight: 1,
-          fillColor: fill_color,
-          fillOpacity: 0.4
-        });
-
-  // Draw the new polygon.
-  polygon.setMap(geeMap.map);
-  return polygon;
-}
-
-/**
- * Clear polygon.
- * @param {google.maps.Polygon} polygon Polygon that was drawn on map.
- */
-function geeClearPolygon(polygon) {
-  // Clear the given polygon.
-  polygon.setMap(null);
 }

--- a/earth_enterprise/src/maps/api/fusion_utils.js
+++ b/earth_enterprise/src/maps/api/fusion_utils.js
@@ -652,18 +652,6 @@ function getLatLngZoomParameter() {
 }
 
 /**
- * Initializes view based on internal polygon.
- * Queries the server for the polygon, using the function to show
- * the polygon as the SUCCESS callback.
- *
- * @param {function} showPolygon Function to show polygon in returned kml.
- */
-function geeInitView(showPolygon) {
-  url = GEE_SERVER_URL + 'earth/polygon.kml';
-  jQuery.get(url, showPolygon);
-}
-
-/**
  * Gets the value of a specified parameter in the current page's URL.
  * @param {string}
  *           param  URL parameter to extract.


### PR DESCRIPTION
Fixes #821

Fixes an infinite loop in the fusion maps API when calling geeInitMap. The function tries to load a polygon that does not exist, resulting in a NaN that causes an infinite loop.

Also updates some of the bootstrap files to load jQuery, which is required for the latest version of the Google Maps API.