### PR TITLE
Issue 337: Checks GCC version and exits build if version < 4.8.0

### DIFF
--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -479,21 +479,22 @@ env = khEnvironment(
     python_major_version=python_major_version
 )
 
-# Check for GCC from an alternative toolchain installation on RHEL 6:
-if cc_dir is None and os.path.isfile('/opt/rh/devtoolset-2/root/usr/bin/g++'):
-    cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
-    rpathlink_dirs += [
+# Check if the version of the default compiler is at least 4.8:
+version = get_cc_version(env['CXX'])
+if not is_version_ge(version, [4, 8]):
+    # Check for GCC 4.8 from an alternative toolchain installation on RHEL 6:
+    if cc_dir is None and os.path.isfile('/opt/rh/devtoolset-2/root/usr/bin/g++'):
+        cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
+        rpathlink_dirs += [
           '/opt/rh/devtoolset-2/root/usr/lib64',
           '/opt/rh/devtoolset-2/root/usr/lib']
-
-# Check that GCC is version 4.8 or greater
-version = get_cc_version(env['CXX'])
-if version == None:
-    print "Unable to determine gcc version, minimum required version is 4.8"
-elif not is_version_ge(version, [4, 8]):
-    print ("GCC version " + '.'.join(version) + 
-           " detected. Minimum required version is 4.8")
-    Exit(1)
+    else:
+        if version == None:
+            print "Unable to determine GCC version, minimum required is 4.8"
+        else:
+            print ("GCC version " + '.'.join(version) + 
+                   " detected. Minimum required version is 4.8")
+            Exit(1)
 
 if cc_dir:
     env['CXX'] = cc_dir + '/g++'

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -479,14 +479,21 @@ env = khEnvironment(
     python_major_version=python_major_version
 )
 
-# Check for GCC 4.8 from an alternative toolchain installation on RHEL 6:
+# Check for GCC from an alternative toolchain installation on RHEL 6:
 if cc_dir is None and os.path.isfile('/opt/rh/devtoolset-2/root/usr/bin/g++'):
-    # Check if the version of the default compiler is, at least 4.8:
-    if not is_version_ge(get_cc_version(env['CXX']), [4, 8]):
-        cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
-        rpathlink_dirs += [
+    cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
+    rpathlink_dirs += [
           '/opt/rh/devtoolset-2/root/usr/lib64',
           '/opt/rh/devtoolset-2/root/usr/lib']
+
+# Check that GCC is version 4.8 or greater
+version = get_cc_version(env['CXX'])
+if version == None:
+    print "Unable to determine gcc version, minimum required version is 4.8"
+elif not is_version_ge(version, [4, 8]):
+    print ("GCC version " + '.'.join(version) + 
+           " detected. Minimum required version is 4.8")
+    Exit(1)
 
 if cc_dir:
     env['CXX'] = cc_dir + '/g++'


### PR DESCRIPTION
Makes sure that GCC is at least version 4.8.0.  If the script cannot determine the version it emits a warning but continues.