### PR TITLE
PR - #835: Fix for server_url issue in GEE web services

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager.py
@@ -114,6 +114,7 @@ class PublishManager(object):
       raise exceptions.PublishServeException(
           "Couldn't get self-referential server URL.")
     logger.debug("PublishManager init: server URL %s", server_url)
+    os.environ["GESERVER_URL"] = server_url
     self.__ResetPublishManager(server_url)
 
   def HandlePingRequest(self, request, response):
@@ -154,9 +155,8 @@ class PublishManager(object):
       response: response object.
     """
     logger.debug("HandleResetRequest...")
-    request_url = request.GetParameter(constants.ORIGIN_REQUEST_HOST)
-    assert request_url
-    self.__ResetPublishManager(request_url)
+    geserver_url = os.environ.get("GESERVER_URL")
+    self.__ResetPublishManager(geserver_url)
     http_io.ResponseWriter.AddBodyElement(
         response, constants.HDR_STATUS_CODE, constants.STATUS_SUCCESS)
 
@@ -224,10 +224,9 @@ class PublishManager(object):
 
     try:
       # Register FusionDb/Portable for serving in Fdb module.
-      request_url = request.GetParameter(constants.ORIGIN_REQUEST_HOST)
-      assert request_url
+      geserver_url = os.environ.get("GESERVER_URL")
       self._mod_fdb_serve_handler.RegisterDatabaseForServing(
-          request_url,
+          geserver_url,
           publish_def.target_path,
           publish_def.db_type,
           target_gedb_path)
@@ -250,7 +249,7 @@ class PublishManager(object):
     except Exception:
       self._publish_helper.DoUnpublish(publish_def.target_path)
       self._mod_fdb_serve_handler.UnregisterDatabaseForServing(
-          request_url, publish_def.target_path)
+          geserver_url, publish_def.target_path)
       raise
 
   def HandleUnpublishRequest(self, request, response):
@@ -280,20 +279,19 @@ class PublishManager(object):
           "Not valid target path %s (path format is /sub_path1[/sub_path2]." %
           target_path)
 
-    request_url = request.GetParameter(constants.ORIGIN_REQUEST_HOST)
-    assert request_url
+    geserver_url = os.environ.get("GESERVER_URL")
 
     try:
       self._publish_helper.HandleUnpublishRequest(norm_target_path)
     except Exception:
       # Unregister FusionDb/Portable for serving in Fdb module.
       self._mod_fdb_serve_handler.UnregisterDatabaseForServing(
-          request_url, norm_target_path)
+          geserver_url, norm_target_path)
       raise
     else:
       # Unregister FusionDb/Portable for serving in Fdb module.
       self._mod_fdb_serve_handler.UnregisterDatabaseForServing(
-          request_url, norm_target_path)
+          geserver_url, norm_target_path)
       http_io.ResponseWriter.AddBodyElement(response,
                                             constants.HDR_STATUS_CODE,
                                             constants.STATUS_SUCCESS)


### PR DESCRIPTION
Fixes #835 

server_url that was initialized by init is stored in
 os.environ["GESERVER_URL"] = server_url
Used the above, whenever we need to send message back instead of using
request_url from request message.