### PR TITLE
 #836: Add PIL as a dependency to the Server RPM.

### DIFF
--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -487,6 +487,8 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     // `initscripts` package:
     requires('initscripts')
     requires('python-unittest2')
+    // The WMS Service requires PIL, which is not automatically detected:
+    requires('python-imaging')
 
     requiresCommands(
         packageSharedCommands +


### PR DESCRIPTION
* Add `python-imaging` as a dependency of the Server RPM. It's necessary for publishing maps over WMS, and is not automatically detected by `rpm-find-requires`.

Fixes #836.