### PR TITLE
docs(publish): Make the changes for geserver certificate validation permanent

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_app.wsgi
@@ -1,6 +1,6 @@
 import os
-# The line below prevents python 2.7.x+ versions from performing CA certificate verification for this application only.  CA checks fail due to nothing being found in the trust store.
-# A more permanent solution should be worked out to allow verification and remove this line
+# The line below prevents python 2.7.x+ versions from performing CA certificate verification for this application only.
+#  CA checks will fail due to self connections being made to 'localhost' instead of the hostname in the certificate
 os.environ['PYTHONHTTPSVERIFY'] = '0'
 
 from serve.publish.publish_app import application


### PR DESCRIPTION
Since the publish server now establishes connections to itself via localhost, CA certificate verification is not possible or really necessary.  Removing the temporary comments.