### PR TITLE
fix(fusion): Check for NULL return from NewPYRTexture in NewTextureFromPath (#342)

### DIFF
--- a/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
+++ b/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
@@ -261,11 +261,15 @@ gstTextureGuard gstTextureManager::NewTextureFromPath(
       std::string str = path;
       str += "/" + kHeaderXmlFile;
       gstTextureGuard texture = NewPYRTexture(str, std::string());
-      *is_mercator_imagery = texture->IsMercatorImagery();
+      if (texture) {
+        *is_mercator_imagery = texture->IsMercatorImagery();
+      }
       return texture;
     } else if (base.endsWith(".xml")) {
       gstTextureGuard texture = NewPYRTexture(path, std::string());
-      *is_mercator_imagery = texture->IsMercatorImagery();
+      if (texture) {
+        *is_mercator_imagery = texture->IsMercatorImagery();
+      }
       return texture;
     }
   }


### PR DESCRIPTION
Check for NULL return from NewPYRTexture in NewTextureFromPath.
Reproduction steps:  The tutorial fies can be used to reproduce the crash.  In the Fusion UI, click the "Open File in Preview" button on the toolbar.  Open the file from the tutorial at /gevol/assets/Resources/Terrain/SFTerrain.ktasset/product.kta/ver001/preview.png.aux.xml.  Before the fix, gefusion would crash.  After the fix, the UI reports "File has unknown problems" and gefusion does not crash.
Tested fix on Ubuntu 16.04.
Fixes #342