### PR TITLE
879 - Fixing OpenGEE 5.2.3 release notes

### DIFF
--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -47,7 +47,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
-    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles<code></p>
+    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code></p>
     <p><strong>Debian package for opengee-common for Ubuntu 16</strong>. It is now possible to produce Debian package for libraries and utilities common to Fusion and Server for Ubuntu 16.</p>    
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>

--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -42,12 +42,12 @@ gtag('config', 'UA-108632131-2');
     <p id="overview_5.2.3">New Features</p>
   </h5>
     <p><strong>C++11 support</strong>. With release 5.2.3 Open GEE C++ code now supports and defaults to compiling using the <code>-std=gnu++11</code> compile flag.  This default can be overridden and the C++ code can be compiled using the <code>-std=gnu++98</code> flag instead.  However, Open GEE 5.2.3 will be the last release to support compiling C++ code using the <code>-std=gnu++98</code> flag.  The subsequent releases after Open GEE 5.2.3 will require the use of the <code>-std=gnu++11</code> flag when compiling C++ code.</p>
-    <p><strong>Remove TCP/IP connections to PostgreSQL</strong>. With release 5.2.3 Open GEE code will now connect to PostgreSQL exclusively using Unix domain sockets. This will make it easier to secure PostgreSQL for security sensitive installations </p>
+    <p><strong>Remove TCP/IP connections to PostgreSQL</strong>. With release 5.2.3 Open GEE code will now connect to PostgreSQL exclusively using Unix domain sockets. This will make it easier to secure PostgreSQL for security sensitive installations.</p>
     <p><strong>Volume deletion</strong>. <code>geconfigureassetroot</code> now supports the option <code>--removevolume</code> for volume deletion.</p>
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
-    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code></p> 
+    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code>.</p> 
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -47,8 +47,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
-    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code></p>
-    <p><strong>Debian package for opengee-common for Ubuntu 16</strong>. It is now possible to produce Debian package for libraries and utilities common to Fusion and Server for Ubuntu 16.</p>    
+    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code></p> 
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -47,6 +47,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
+    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles<code></p>
     <p><strong>Debian package for opengee-common for Ubuntu 16</strong>. It is now possible to produce Debian package for libraries and utilities common to Fusion and Server for Ubuntu 16.</p>    
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>

--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -47,7 +47,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
-    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles<code></p>
+    <p><strong>Maps API Javascript Files</strong>. Maps API Javascript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles<code></p>
     <p><strong>Debian package for opengee-common for Ubuntu 16</strong>. It is now possible to produce Debian package for libraries and utilities common to Fusion and Server for Ubuntu 16.</p>    
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>

--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -36,7 +36,7 @@ gtag('config', 'UA-108632131-2');
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
 <h2>Release notes: Open GEE 5.2.3</h2>
 
-<p>Open GEE 5.2.3 is currently in development</p>
+<p>Open GEE 5.2.3 is currently in beta testing</p>
 
   <h5>
     <p id="overview_5.2.3">New Features</p>
@@ -47,6 +47,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>Performance tuning for gecombineterrain</strong>. <code>gecombineterrain</code> now supports the option <code>--numCompressThreads</code> which allows configuration of the threads used for operation.  If not specified <code>gecombineterrain</code> defaults this option to match the number of available CPUs.</p>
     <p><strong>Package name customization at build time</strong>. Scons build now accepts a custom label argument which is appended to the version in RPM file names.</p>
     <p><strong>Rewrite KML URLs</strong>. Users can rewrite the URLs for KML resorces included in databases at publish time.</p>
+    <p><strong>Debian package for opengee-common for Ubuntu 16</strong>. It is now possible to produce Debian package for libraries and utilities common to Fusion and Server for Ubuntu 16.</p>    
   <h5>
     <p id="supported_5.2.3">Supported Platforms</p>
   </h5>
@@ -86,6 +87,11 @@ gtag('config', 'UA-108632131-2');
             <td>Scons scripts ensure gcc version 4.8+ is installed before continuing with builds</td>
           </tr>
           <tr>
+            <td>342</td>
+            <td>Fusion UI crashes when opening non supported type of file</td>
+            <td>Added check to kiasset, ktasset, xml file load to handle invalid files</td>
+          </tr>          
+          <tr>
             <td>535</td>
             <td>DownloadTutorial.sh often is not staged properly for install</td>
             <td>Tutorial download script is now included in the Fusion RPM</td>
@@ -101,11 +107,6 @@ gtag('config', 'UA-108632131-2');
             <td>Temporary fix from 5.2.2 was found to be the best solution</td>
           </tr>
           <tr>
-            <td>762</td>
-            <td>Package libraries and utilities common to Fusion and Server for Ubuntu 16</td>
-            <td>opengee-common deb packages can be created for Ubuntu 16</td>
-          </tr>
-          <tr>
             <td>806</td>
             <td>gecombineterrain defaulted to only 1 cpu to process data and ignored arguments</td>
             <td>Added --numCompressThreads option to accept the number of threads to use.  Default value is the number of CPUs available.  Deprecated --numcpus option</td>
@@ -119,11 +120,6 @@ gtag('config', 'UA-108632131-2');
             <td>835</td>
             <td>GE Server gets its URL from the client instead of itself</td>
             <td>Fixed code so that when you publish DB, GEServer's URL will be used and not the URL which we get from the Publish request message</td>
-          </tr>
-          <tr>
-            <td>342</td>
-            <td>Fusion UI crashes when opening non supported type of file</td>
-            <td>Added check to kiasset, ktasset, xml file load to handle invalid files</td>
           </tr>	  
         </tbody>
       </table>  


### PR DESCRIPTION
Fix #879 and finish fixing #590 by documenting the fix in release notes

- Moved `Package libraries and utilities common to Fusion and Server for Ubuntu 16` from list of fixed bugs to list of new features.
- Ensured that fixed issues are ordered  in ascending fashion.
- Documented Map API JS Files addition (#590)
- Updated status of 5.2.3 from `in development` to `in beta testing`.


