### PR TITLE
 #877: Minimize asset root recursive `chown` during installation

### DIFF
--- a/docs/geedocs/5.2.3/answer/7160003.html
+++ b/docs/geedocs/5.2.3/answer/7160003.html
@@ -114,6 +114,14 @@ gtag('config', 'UA-108632131-2');
             <td>GE Server gets its URL from the client instead of itself</td>
             <td>Fixed code so that when you publish DB, GEServer's URL will be used and not the URL which we get from the Publish request message.</td>
           </tr>        
+          <tr>
+            <td>877</td>
+            <td>Fusion RPM install scripts to only <code>chown</code> the asset root when necessary</td>
+            <td>
+              Recursively <code>chown</code> only when the asset root directory has incorrect ownership on a Fusion master host.
+              This allows upgrading Fusion on machines where changing asset root ownership recursively would be very expensive.
+            </td>
+          </tr>        
         </tbody>
       </table>  
   <h5>            

--- a/earth_enterprise/rpms/opengee-fusion/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/post-install.sh
@@ -149,9 +149,10 @@ install_or_upgrade_asset_root()
     if [ ! -d "$ASSET_ROOT/.config" ]; then
         "$BASEINSTALLDIR_OPT/bin/geconfigureassetroot" --new --noprompt \
             --assetroot "$ASSET_ROOT" --srcvol "$SOURCE_VOLUME"
-        chown -R "$GEFUSIONUSER:$GEGROUP" "$ASSET_ROOT"
     else
-        # upgrade asset root -- if this is a master
+        # Upgrade the asset root, if this is a Fusion master host.
+        #   Fusion slaves access the same files over NFS, and they rely on the
+        # master to keep proper confguration and file permissions.
         if [ "$IS_SLAVE" = "false" ]; then
             OWNERSHIP=`find "$ASSET_ROOT" -maxdepth 0 -printf "%g:%u"`
             if [ "$OWNERSHIP" != "$GEGROUP:$GEFUSIONUSER" ] ; then
@@ -176,10 +177,10 @@ END
             # unless absolutely necessary
             "$BASEINSTALLDIR_OPT/bin/geconfigureassetroot" --fixmasterhost \
                 --noprompt  $NOCHOWN --assetroot $ASSET_ROOT
-            "$BASEINSTALLDIR_OPT/bin/geupgradeassetroot" --noprompt $NOCHOWN \
+            # If `geconfigureassetroot` already updated ownership, don't do it again:
+            "$BASEINSTALLDIR_OPT/bin/geupgradeassetroot" --noprompt --nochown \
                 --assetroot "$ASSET_ROOT"
-            chown -R "$GEFUSIONUSER:$GEGROUP" "$ASSET_ROOT"
-        fi  
+        fi
     fi
 }
 


### PR DESCRIPTION
* Only recursively `chown` when the asset root directory has incorrect ownership.
* Only `chown` on a Fusion master host.
* Only `chown` once.