### PR TITLE
fix(server): Make disk space test optional

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/disk_space_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/disk_space_test.py
@@ -17,6 +17,7 @@
 
 import os
 import xml.etree.ElementTree as ET
+from geecheck_tests import common
 
 # Need to use unittest2 for Python 2.6.
 try:
@@ -69,6 +70,7 @@ def getFsFreespace(pathname):
 
 class TestDiskSpace(unittest.TestCase):
 
+    @unittest.skipUnless(common.IsFusionInstalled(), 'Fusion is not installed')
     def testAdequateDiskSpace(self):
       """Check that the remaining disk space is at least 20%."""
       self.assertLessEqual(20, getDiskInfo())


### PR DESCRIPTION
In cases where fusion is not present, the test for adequate disk space
doesn't make sense and will fail. In these cases, skip the test.

This addresses #861