### PR TITLE
WIP - Fixes issue #622 - Returns proper JSON for Map 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ earth_enterprise/tutorial/FusionTutorial/KML
 /*.files
 /*.includes
 
+# CLion project files.
+.idea/
+cmake-build*/

--- a/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
@@ -316,7 +316,7 @@ std::string JsonUtils::JsonObject(
     if (iter != field_map.begin()) {
       buffer << ",\n";  // Note: IE6 doesn't like trailing commas.
     }
-    buffer << iter->first << " : " << iter->second;
+    buffer << Quoted(iter->first) << " : " << iter->second;
   }
   buffer << "\n}\n";
   return buffer.str();


### PR DESCRIPTION
This pull request fixes issue #622. It fixes it by simply quoting the Key when serializing the data.

This approach still allows the returned value (JSON) to be used as valid JavaScript.


**Notes**

- In order to activate this change, the map has to be unpublished, then republished which triggers the writing and reading of the JSON object. 
- Previous discussion of another approach can be found at #907 

@tst-ppenev, @tst-rwildes, @tst-dsugar, @tst-ccamp any thoughts about possible issues to test for with this? Unit Tests are passing, and the basic functionality is working on my end.
