### PR TITLE
Update status of 5.2.3

### DIFF
--- a/docs/geedocs/index.html
+++ b/docs/geedocs/index.html
@@ -23,8 +23,8 @@ gtag('config', 'UA-108632131-2');
     <h2>Google Earth Enterprise  Documentation</h2>
     <p>Select a Google Earth Enterprise Open Source version to view the documentation</p>
     <h4><a href="5.2.4/index.html">5.2.4 (unstable)</a></h4>
-    <h4><a href="5.2.3/index.html">5.2.3 (unstable)</a></h4>
-    <h4><a href="5.2.2/index.html">5.2.2 (latest stable)</a></h4>
+    <h4><a href="5.2.3/index.html">5.2.3 (latest stable)</a></h4>
+    <h4><a href="5.2.2/index.html">5.2.2 (stable)</a></h4>
     <h4><a href="5.2.1/index.html">5.2.1 (stable)</a></h4>
     <h4><a href="5.2.0/index.html">5.2.0 (stable)</a></h4>
   </div>


### PR DESCRIPTION
Fixes #930 

Verification steps:

- In .../docs/geedocs/index.html verify that 5.2.3 is now listed as `latest stable` (instead of `unstable`).