### PR TITLE
Updated Readme to add 5.2.3 released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The application suite consists of three core components:
 
 ### Releases
 
+[Release 5.2.3](https://github.com/google/earthenterprise/releases/tag/5.2.3-4.final)
+* [Release Notes](http://www.opengee.org/geedocs/5.2.3/answer/7160003.html)
+* [Release Documentation](http://www.opengee.org/geedocs/5.2.3/)
+
 [Release 5.2.2](https://github.com/google/earthenterprise/releases/tag/5.2.2-2.final)
 * [Release Notes](http://www.opengee.org/geedocs/5.2.2/answer/7160002.html)
 * [Release Documentation](http://www.opengee.org/geedocs/5.2.2/)


### PR DESCRIPTION
Fixes #932 

Updated Readme to list 5.2.3 released version.

Verification steps:
- Verify that 5.2.3 is now listed as released version
- Verify the links