### PR TITLE
#936: Add progress log messages to `gesystemmanager`.

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -270,6 +270,10 @@ void RasterProjectAssetImplD::AddInsets(
   for (std::vector<RasterProjectModifyRequest::Item>::const_iterator item =
          items.begin();
        item != items.end(); ++item) {
+    
+    notify(NFY_PROGRESS, "Raster project::AddInsets: Finding position to add inset %lu of %lu.",
+      item - items.begin(), items.size());
+
     // error if there's anything I already have
     if (have.find(item->dataAsset) != have.end()) {
       throw khException(kh::tr("Project already has inset '%1'")
@@ -315,6 +319,8 @@ void RasterProjectAssetImplD::AddInsets(
   }
 
   SyncInputRefs();
+
+  notify(NFY_PROGRESS, "Raster project::AddInsets: Complete.");
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -270,10 +270,6 @@ void RasterProjectAssetImplD::AddInsets(
   for (std::vector<RasterProjectModifyRequest::Item>::const_iterator item =
          items.begin();
        item != items.end(); ++item) {
-    
-    notify(NFY_PROGRESS, "Raster project::AddInsets: Finding position to add inset %lu of %lu.",
-      item - items.begin(), items.size());
-
     // error if there's anything I already have
     if (have.find(item->dataAsset) != have.end()) {
       throw khException(kh::tr("Project already has inset '%1'")
@@ -319,8 +315,6 @@ void RasterProjectAssetImplD::AddInsets(
   }
 
   SyncInputRefs();
-
-  notify(NFY_PROGRESS, "Raster project::AddInsets: Complete.");
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetD.cpp
@@ -74,7 +74,9 @@ AssetImplD::InputsUpToDate(const AssetVersion &version,
 void
 AssetImplD::UpdateInputs(std::vector<AssetVersion> &inputvers) const
 {
-  inputvers.reserve(inputs.size());
+  std::size_t inputs_count = inputs.size();
+
+  inputvers.reserve(inputs_count);
   for (std::vector<std::string>::const_iterator i = inputs.begin();
        i != inputs.end(); ++i) {
     AssetVersionRef verref(*i);
@@ -85,8 +87,11 @@ AssetImplD::UpdateInputs(std::vector<AssetVersion> &inputvers) const
       AssetD asset(verref.AssetRef());
       bool needed = false;
       inputvers.push_back(asset->Update(needed));
+      notify(NFY_PROGRESS, "Updating asset input %lu (of %lu input%s).",
+        i - inputs.begin(), inputs_count, inputs_count == 1 ? "" : "s");
     } else {
       inputvers.push_back(AssetVersion(verref));
     }
   }
+  notify(NFY_PROGRESS, "Updating asset inputs complete.");
 }


### PR DESCRIPTION
* Added progress log messages to the loop that updates input resources.

* Added progress log messages to the loop that iterates over imagery inset
  assets.

Fixes #936.