### PR TITLE
#882: Use `g++` from `devtoolset-2-toolchain` automatically on CentOS 6, if installed

### DIFF
--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -28,6 +28,15 @@ sys.path += ['scons']
 from khEnvironment import khEnvironment
 from khEnvironment import GetVersion
 
+# Add the OpenGEE Python libraries to the module search path:
+opengee_lib_path = os.path.join('lib', 'python')
+
+if opengee_lib_path not in sys.path:
+  sys.path.insert(1, opengee_lib_path)
+
+import opengee.c_compiler
+import opengee.version
+
 
 # Path to crosstool root directory.
 crosstool_path = '/usr/local/crosstool'
@@ -387,40 +396,6 @@ installdirs = {
     'htdocs': InstServerDir('gehttpd/htdocs'),
 }
 
-def get_cc_version(cc_path):
-  """Extracts the version number of a C/C++ compiler (like GCC) as a list of
-  strings."""
-
-  process = subprocess.Popen(
-    [cc_path, '--version'], stdout=subprocess.PIPE)
-  (stdout, stderr) = process.communicate()
-  match = re.search('[0-9][0-9.]*', stdout)
-  # If match is None we don't know the version.
-  if match is None:
-    return None
-  version = match.group().split('.')
-  return version
-
-def is_version_ge(version_components, comparand_components):
-  """Tests if a version number is greater than, or equal to another version
-  number.  Both version numbers are specified as lists of version components.
-  """
-
-  if version_components is None or comparand_components is None:
-    return False
-
-  for i in xrange(len(comparand_components)):
-    if i >= len(version_components):
-      version_component = 0
-    else:
-      version_component = int(version_components[i])
-    if int(comparand_components[i]) > version_component:
-      return False
-    if int(comparand_components[i]) < version_component:
-      return True
-
-  return True
-
 gee_version_number = GetVersion("version.txt", label)
 
 
@@ -480,8 +455,8 @@ env = khEnvironment(
 )
 
 # Check if the version of the default compiler is at least 4.8:
-version = get_cc_version(env['CXX'])
-if not is_version_ge(version, [4, 8]):
+version = opengee.c_compiler.get_cc_version(env['CXX'])
+if not opengee.version.is_version_ge(version, [4, 8]):
     # Check for GCC 4.8 from an alternative toolchain installation on RHEL 6:
     if cc_dir is None and os.path.isfile('/opt/rh/devtoolset-2/root/usr/bin/g++'):
         cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -34,7 +34,7 @@ import util
 
 def get_cc_version(cc_path):
   """Extracts the version number of a C/C++ compiler (like GCC) as a list of
-  strings."""
+  strings.  (Like ['5', '4', '0'].)"""
 
   process = subprocess.Popen(
     [cc_path, '--version'], stdout=subprocess.PIPE)
@@ -73,9 +73,10 @@ def path_prepend(value, new_path, if_present='skip', separator=':'):
   """Adds a component to a PATH variable, where paths are separated by
   `separator`.
 
-  if_present = What to do, if PATH already contains `new_path`.
-    'skip': leave PATH as is.
-    'move': move `new_path` to the beginning of PATH.
+    if_present = What to do, if PATH already contains `new_path`.
+      'skip': leave PATH as is.
+      'move': move `new_path` to the beginning of PATH.
+    separator = String that separates path components in the variable value.
   """
 
   # Check if the PATH variable already contains `new_path`:
@@ -111,6 +112,18 @@ def path_prepend(value, new_path, if_present='skip', separator=':'):
 def environ_var_path_prepend(
   var_name, new_path, if_present='skip', separator=':'
 ):
+  """Prepend a path component to a PATH-like environment variable (i.e., one
+  which contains paths separated by `separator`).
+
+    var_name = Name of the environment variable to add a path component to.
+  The variable is created, if it doesn't exist.
+    new_path = Path to add to the variable value.
+    if_present = What to do, if the variable already contains `new_path`.
+      'skip': Leave the variable value as is.
+      'move': Move `new_path` to the beginning of the variable value.
+    separator = String that separates path components in the variable value.
+  """
+
   try:
     value = os.environ[var_name]
   except KeyError:
@@ -125,7 +138,7 @@ def configure_c_compiler(os_dir):
   if not version:
     raise ValueError('Unable to determine g++ version!')
   if not is_version_ge(version, [4, 8]):
-    # Check for GCC 4.8 from an the devtoolchain installation on Red Hat 6:
+    # Check for GCC 4.8 from the devtoolset-2-toolchain package on Red Hat 6:
     cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
     if os.path.isfile('{0}/g++'.format(cc_dir)):
       environ_var_path_prepend('PATH', cc_dir, if_present='move')

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -214,6 +214,8 @@ def main(argv):
   if BuildLibrary(os_dir, argv[1].lower()=="windows"):
     print "Library built."
     RunTests()
+  else:
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -31,123 +31,37 @@ import subprocess
 import sys
 import util
 
+# Add the OpenGEE Python libraries to the module search path:
+opengee_lib_path = os.path.join(
+  os.path.dirname(os.path.realpath(__file__)),
+  '..', '..', '..', 'lib', 'python')
 
-def get_cc_version(cc_path):
-  """Extracts the version number of a C/C++ compiler (like GCC) as a list of
-  strings.  (Like ['5', '4', '0'].)"""
+if opengee_lib_path not in sys.path:
+  sys.path.insert(1, opengee_lib_path)
 
-  process = subprocess.Popen(
-    [cc_path, '--version'], stdout=subprocess.PIPE)
-  (stdout, _) = process.communicate()
-  match = re.search('[0-9][0-9.]*', stdout)
+import opengee.c_compiler
+import opengee.environ
+import opengee.version
 
-  # If match is None we don't know the version.
-  if match is None:
-    return None
 
-  version = match.group().split('.')
-
-  return version
-
-def is_version_ge(version_components, comparand_components):
-  """Tests if a version number is greater than, or equal to another version
-  number.  Both version numbers are specified as lists of version components.
-  """
-
-  if version_components is None or comparand_components is None:
-    return False
-
-  for i in xrange(len(comparand_components)):
-    if i >= len(version_components):
-      version_component = 0
-    else:
-      version_component = int(version_components[i])
-    if int(comparand_components[i]) > version_component:
-      return False
-    if int(comparand_components[i]) < version_component:
-      return True
-
-  return True
-
-def path_prepend(value, new_path, if_present='skip', separator=':'):
-  """Adds a component to a PATH variable, where paths are separated by
-  `separator`.
-
-    if_present = What to do, if PATH already contains `new_path`.
-      'skip': leave PATH as is.
-      'move': move `new_path` to the beginning of PATH.
-    separator = String that separates path components in the variable value.
-  """
-
-  # Check if the PATH variable already contains `new_path`:
-  if value == new_path:
-    return value
-  if value.startswith(new_path + separator):
-    if if_present == 'skip' or 'move':
-      return value
-    else:
-      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
-  if value.endswith(separator + new_path):
-    if if_present == 'skip':
-      return value
-    elif if_present == 'move':
-      return new_path + separator + value[ : -len(new_path) - 1]
-    else:
-      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
-  i = value.find(separator + new_path + separator)
-  if i >= 0:
-    if if_present == 'skip':
-      return value
-    elif if_present == 'move':
-      return new_path + separator + value[: i] + value[i + len(new_path) + 1:]
-    else:
-      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
-
-  # PATH doesn't contain `new_path`, prepend it:
-  if value == '':
-    return new_path
-
-  return new_path + separator + value
-
-def environ_var_path_prepend(
-  var_name, new_path, if_present='skip', separator=':'
-):
-  """Prepend a path component to a PATH-like environment variable (i.e., one
-  which contains paths separated by `separator`).
-
-    var_name = Name of the environment variable to add a path component to.
-  The variable is created, if it doesn't exist.
-    new_path = Path to add to the variable value.
-    if_present = What to do, if the variable already contains `new_path`.
-      'skip': Leave the variable value as is.
-      'move': Move `new_path` to the beginning of the variable value.
-    separator = String that separates path components in the variable value.
-  """
-
-  try:
-    value = os.environ[var_name]
-  except KeyError:
-    value = ''
-  os.environ[var_name] = path_prepend(
-    value, new_path, if_present=if_present, separator=separator)
 
 def configure_c_compiler(os_dir):
   if os_dir != 'Linux':
     return
-  version = get_cc_version('g++')
+  version = opengee.c_compiler.get_cc_version('g++')
   if not version:
     raise ValueError('Unable to determine g++ version!')
-  if not is_version_ge(version, [4, 8]):
+  if not opengee.version.is_version_ge(version, [4, 8]):
     # Check for GCC 4.8 from the devtoolset-2-toolchain package on Red Hat 6:
     cc_dir = '/opt/rh/devtoolset-2/root/usr/bin'
     if os.path.isfile('{0}/g++'.format(cc_dir)):
-      environ_var_path_prepend('PATH', cc_dir, if_present='move')
-      environ_var_path_prepend(
+      opengee.environ.env_prepend_path('PATH', cc_dir, if_present='move')
+      opengee.environ.env_prepend_path(
         'LIBRARY_PATH',
         '/opt/rh/devtoolset-2/root/usr/lib',
         if_present='move'
       )
-      environ_var_path_prepend(
+      opengee.environ.env_prepend_path(
         'LIBRARY_PATH',
         '/opt/rh/devtoolset-2/root/usr/lib64',
         if_present='move')

--- a/earth_enterprise/src/lib/python/opengee/__init__.py
+++ b/earth_enterprise/src/lib/python/opengee/__init__.py
@@ -1,0 +1,5 @@
+"""
+A collection of Python modules used by Open GEE during the build process.
+"""
+
+__all__ = ['c_compiler', 'environ', 'version']

--- a/earth_enterprise/src/lib/python/opengee/c_compiler.py
+++ b/earth_enterprise/src/lib/python/opengee/c_compiler.py
@@ -1,0 +1,24 @@
+import os
+import re
+import subprocess
+
+from . import version
+from . import environ
+
+
+def get_cc_version(cc_path):
+  """Extracts the version number of a C/C++ compiler (like GCC) as a list of
+  strings.  (Like ['5', '4', '0'].)"""
+
+  process = subprocess.Popen(
+    [cc_path, '--version'], stdout=subprocess.PIPE)
+  (stdout, _) = process.communicate()
+  match = re.search('[0-9][0-9.]*', stdout)
+
+  # If match is None we don't know the version.
+  if match is None:
+    return None
+
+  version = match.group().split('.')
+
+  return version

--- a/earth_enterprise/src/lib/python/opengee/environ.py
+++ b/earth_enterprise/src/lib/python/opengee/environ.py
@@ -1,0 +1,68 @@
+"""
+A module with functions for operating on environment variables.
+"""
+
+import os
+
+
+def prepend_path(value, new_path, if_present='skip', separator=os.pathsep):
+  """Adds a component to a PATH variable, where paths are separated by
+  `separator`.
+
+    if_present = What to do, if PATH already contains `new_path`.
+      'skip': leave PATH as is.
+      'move': move `new_path` to the beginning of PATH.
+    separator = String that separates path components in the variable value.
+  """
+
+  # Check if the PATH variable already contains `new_path`:
+  if value == new_path:
+    return value
+  if value.startswith(new_path + separator):
+    if if_present == 'skip' or 'move':
+      return value
+    else:
+      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
+  if value.endswith(separator + new_path):
+    if if_present == 'skip':
+      return value
+    elif if_present == 'move':
+      return new_path + separator + value[ : -len(new_path) - 1]
+    else:
+      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
+  i = value.find(separator + new_path + separator)
+  if i >= 0:
+    if if_present == 'skip':
+      return value
+    elif if_present == 'move':
+      return new_path + separator + value[: i] + value[i + len(new_path) + 1:]
+    else:
+      raise ValueError('Invalid if_present argument: {0}'.format(if_present))
+
+  # PATH doesn't contain `new_path`, prepend it:
+  if value == '':
+    return new_path
+
+  return new_path + separator + value
+
+def env_prepend_path(
+  var_name, new_path, if_present='skip', separator=':'
+):
+  """Prepend a path component to a PATH-like environment variable (i.e., one
+  which contains paths separated by `separator`).
+
+    var_name = Name of the environment variable to add a path component to.
+  The variable is created, if it doesn't exist.
+    new_path = Path to add to the variable value.
+    if_present = What to do, if the variable already contains `new_path`.
+      'skip': Leave the variable value as is.
+      'move': Move `new_path` to the beginning of the variable value.
+    separator = String that separates path components in the variable value.
+  """
+
+  try:
+    value = os.environ[var_name]
+  except KeyError:
+    value = ''
+  os.environ[var_name] = prepend_path(
+    value, new_path, if_present=if_present, separator=separator)

--- a/earth_enterprise/src/lib/python/opengee/version.py
+++ b/earth_enterprise/src/lib/python/opengee/version.py
@@ -1,0 +1,25 @@
+"""
+A module collecting functions for operating on versions.
+"""
+
+
+def is_version_ge(version_components, comparand_components):
+  """Tests if a version number is greater than, or equal to another version
+  number.  Both version numbers are specified as lists of version components.
+  None is trated as an unknown version, and comparisons with it test as False.
+  """
+
+  if version_components is None or comparand_components is None:
+    return False
+
+  for i in xrange(len(comparand_components)):
+    if i >= len(version_components):
+      version_component = 0
+    else:
+      version_component = int(version_components[i])
+    if int(comparand_components[i]) > version_component:
+      return False
+    if int(comparand_components[i]) < version_component:
+      return True
+
+  return True


### PR DESCRIPTION
Fixes #882 
* Added code to check if the g++ compiler version is high enough to
  `build_and_test.py`.

* Added code to use g++ from the devtoolset2 installation on Cent OS 6, if the
  default g++ compiler version is too low.