### PR TITLE
SConstruct: replace deprecated build_dir with variant_dir

### DIFF
--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -50,9 +50,19 @@ for root, dirs, files in os.walk('..'):
       # If we find one tar file that seems OK, assume all are OK
       break
 
+cache_dir = ARGUMENTS.get('cache_dir', 0)
+if cache_dir:
+  CacheDir(cache_dir)
+
 # list of dirs to try to build (if present)
-dirs = ['third_party', 'google', 'keyhole', 'common', 'fusion', 'server',
-        'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+if os.path.isfile('.treat_third_part_as_sdk'):
+  # this is useful if you want to share pre-built 3rd party builds
+  dirs = ['google', 'keyhole', 'common', 'fusion', 'server',
+          'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+else:
+  dirs = ['third_party', 'google', 'keyhole', 'common', 'fusion', 'server',
+          'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+
 
 # get the build date
 build_date = time.localtime(time.time())

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -516,6 +516,7 @@ env['LRELEASE'] = qtdir+'/bin/lrelease'
 env['KHIDL'] = File('#common/khxml/khidl.pl')
 
 env.PhonyTargets(build_dir = 'BUILD_DIR=' + builddir)
+env.SConsignFile(os.path.join(builddir, 'scons-signatures'))
 SConscript('SConscript', variant_dir=builddir, duplicate=0)
 
 env.Clean('cleanall', [[exportdir+"/"+x for x in os.listdir(exportdir) if x != "third_party"]])

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -86,7 +86,7 @@ ValidOptions = set(
      'log_performance',  # Include code for performance logging
      'cpp_standard',     # The standard of CPP that will be used.  Default is C++11
      'label',            # Value to combine with version strings.
-     'build_folder'      # where to put the build output and intermediate files 
+     'build_folder'      # where to put the build output and intermediate files
      ]);
 
 for argkey in ARGUMENTS:
@@ -136,7 +136,6 @@ if not native_cc and not os.path.isdir(compatibility_dir):
   print "ERROR: %s doesn't exist.\nPlease run %s/../rpms/build_scripts/update_ghardy.sh" % (compatibility_dir, top_dir)
   Exit(1)
 
-
 if release:
   builddir = 'REL-'
 elif optimize:
@@ -153,7 +152,7 @@ if native_cc:
   builddir = 'NATIVE-' + builddir
 
 # setup export directories
-exportdir = os.path.join(build_folder, builddir) 
+exportdir = os.path.join(build_folder, builddir)
 exportdirs = {
     'root': exportdir+'/',
     'lib': exportdir+'/lib/',
@@ -469,7 +468,7 @@ if not opengee.version.is_version_ge(version, [4, 8]):
         if version == None:
             print "Unable to determine GCC version, minimum required is 4.8"
         else:
-            print ("GCC version " + '.'.join(version) + 
+            print ("GCC version " + '.'.join(version) +
                    " detected. Minimum required version is 4.8")
             Exit(1)
 
@@ -508,6 +507,7 @@ env['LRELEASE'] = qtdir+'/bin/lrelease'
 
 env['KHIDL'] = File('#common/khxml/khidl.pl')
 
-SConscript('SConscript', build_dir=exportdir, duplicate=0)
+env.PhonyTargets(build_dir = 'BUILD_DIR=' + builddir)
+SConscript('SConscript', variant_dir=builddir, duplicate=0)
 
 env.Clean('cleanall', [[exportdir+"/"+x for x in os.listdir(exportdir) if x != "third_party"]])

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -86,7 +86,8 @@ ValidOptions = set(
      'log_performance',  # Include code for performance logging
      'cpp_standard',     # The standard of CPP that will be used.  Default is C++11
      'label',            # Value to combine with version strings.
-     'build_folder'      # where to put the build output and intermediate files
+     'build_folder',     # where to put the build output and intermediate files
+     'cache_dir'         # use a cache dir to speed up build
      ]);
 
 for argkey in ARGUMENTS:
@@ -516,7 +517,6 @@ env['LRELEASE'] = qtdir+'/bin/lrelease'
 env['KHIDL'] = File('#common/khxml/khidl.pl')
 
 env.PhonyTargets(build_dir = 'BUILD_DIR=' + builddir)
-env.SConsignFile(os.path.join(builddir, 'scons-signatures'))
 SConscript('SConscript', variant_dir=builddir, duplicate=0)
 
 env.Clean('cleanall', [[exportdir+"/"+x for x in os.listdir(exportdir) if x != "third_party"]])

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -113,7 +113,7 @@ bundle_3rd_libs = int(ARGUMENTS.get('bundle_3rd_libs', 0))
 cc_dir = ARGUMENTS.get('cc_dir', None)
 log_performance = int( ARGUMENTS.get( 'log_performance', 0 ) )
 cpp_standard = ARGUMENTS.get('cpp_standard', 'gnu++11')
-build_folder = ARGUMENTS.get('build_folder', Dir('#/.').abspath)
+build_folder = ARGUMENTS.get('build_folder', 0)
 label = ARGUMENTS.get('label', '')
 
 # make some directory variables used by other parts of the build system
@@ -136,6 +136,7 @@ if not native_cc and not os.path.isdir(compatibility_dir):
   print "ERROR: %s doesn't exist.\nPlease run %s/../rpms/build_scripts/update_ghardy.sh" % (compatibility_dir, top_dir)
   Exit(1)
 
+
 if release:
   builddir = 'REL-'
 elif optimize:
@@ -151,8 +152,15 @@ builddir += march
 if native_cc:
   builddir = 'NATIVE-' + builddir
 
+if build_folder:
+  builddir = build_folder
+
 # setup export directories
-exportdir = os.path.join(build_folder, builddir)
+if os.path.isabs(builddir):
+  exportdir = builddir
+else:
+  exportdir = Dir('#/%s' % builddir).abspath
+
 exportdirs = {
     'root': exportdir+'/',
     'lib': exportdir+'/lib/',
@@ -434,10 +442,10 @@ env = khEnvironment(
     CPPFLAGS=cppflags,
     CPPPATH=[
              # generated 3rd party headers
-             Dir(exportdir + '/include'),
-             Dir(exportdir),  # generated headers
+             Dir(builddir + '/include'),
+             Dir(builddir),  # generated headers
              Dir('.'),
-             Dir(exportdir+'/common'),
+             Dir(builddir + '/common'),
              Dir('common'),
              Dir('common/khmisc'),
              src_keyhole_abs_dir],


### PR DESCRIPTION
Renaming deprecated build_dir to variant_dir in earthenterprise/earth_enterprise/src/SConstruct