### PR TITLE
Increased the AssetCacheSize and VersionCacheSize to 128k

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
+++ b/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
@@ -23,8 +23,8 @@ class MiscConfigStorage {
   // help work around the delayed NFS visibility problem.
   uint        NFSVisibilityDelay = uint(0);
 
-  uint        AssetCacheSize = uint(32000);
-  uint        VersionCacheSize = uint(32000);
+  uint        AssetCacheSize = uint(128000);
+  uint        VersionCacheSize = uint(128000);
 
   bool        GenerateProductPreviews = true;
   


### PR DESCRIPTION
Currently a static value (128k) -- would be great if this were configurable based on some calculated analysis of current system resources. 