### PR TITLE
Correct two issues blocking windows portable builds

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/Windows/build_lib
@@ -1,6 +1,6 @@
 copy /Y ..\shared\* .
 copy /Y ..\Windows\khTypes.h .
 swig -python -c++ glc_unpacker.i
-g++ -std=gnu++11 -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
-g++ -std=gnu++11 -c glc_unpacker_wrap.cxx -I{exec_prefix}\include
-g++ -std=gnu++11 -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L{exec_prefix}\libs -lpython27
+g++ -std=gnu++11 {special_defs} -c glc_unpacker.cpp portable_glc_reader.cpp file_unpacker.cpp file_package.cpp packetbundle.cpp packetbundle_finder.cpp
+g++ -std=gnu++11 {special_defs} -D_hypot=hypot -c glc_unpacker_wrap.cxx -I{exec_prefix}\include
+g++ -std=gnu++11 {special_defs} -static-libgcc -static-libstdc++ -shared glc_unpacker_wrap.o glc_unpacker.o portable_glc_reader.o file_unpacker.o file_package.o packetbundle.o packetbundle_finder.o -o _glc_unpacker.pyd -L{exec_prefix}\libs -lpython27

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -83,7 +83,7 @@ def BuildLibrary(os_dir, ignore_results):
   if os_dir == "Windows":
     # The logic below fixes a method used by the swig c++ wrapper. Mingw python headers
     # should detect and fix this but for some reason they aren't working with mingw64
-    pythonCLib = "libpython" + sys.version + ".a"
+    pythonCLib = "libpython{0}.{1}.a".format(sys.version_info[0], sys.version_info[1])
     pathToLib = os.path.join(sys.exec_prefix, "libs", pythonCLib)
     archData = platform.architecture(pathToLib)
     if archData[0] == "64bit":

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/build_and_test.py
@@ -83,8 +83,11 @@ def BuildLibrary(os_dir, ignore_results):
   if os_dir == "Windows":
     # The logic below fixes a method used by the swig c++ wrapper. Mingw python headers
     # should detect and fix this but for some reason they aren't working with mingw64
-    pythonCLib = "libpython{0}.{1}.a".format(sys.version_info[0], sys.version_info[1])
+    pythonCLib = "libpython{0}{1}.a".format(sys.version_info[0], sys.version_info[1])
     pathToLib = os.path.join(sys.exec_prefix, "libs", pythonCLib)
+    if not os.path.isfile(pathToLib):
+      print "ERROR: {0} was not found.  It is needed for linking".format(pathToLib)
+      return False
     archData = platform.architecture(pathToLib)
     if archData[0] == "64bit":
       specialDefs = "-DMS_WIN64"


### PR DESCRIPTION
Fixes issue #976 

The definition of the hypot macro is a workaround for an upstream python bug which has not been resolved yet.  The other mingw define fixes a linkage issue in the swig c++ wrapper when compiling under mingw64.  Verified portable compile works as expected for win64, win32 and centos7.

Note for testing: currently need to obtain a copy of version.txt to work around #973 