### PR TITLE
Document changes that fixed issue #958

### DIFF
--- a/docs/geedocs/5.2.4/answer/7160004.html
+++ b/docs/geedocs/5.2.4/answer/7160004.html
@@ -45,7 +45,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>C++98 no longer supported</strong>. As of 5.2.4 C++11 syntax can be used and building open GEE using C++98 standard will no longer be supported</p>
     <p><strong>Added "Save and Build" file menu option</strong>. As of 5.2.4 the Fusion UI will include an additional file menu option that allows users to save and build assets with one click, instead of clicking the save option and then the build option immediately after.</p>
     <p><strong>Added build parameter to redirect the build output</strong>. Build output can now be optionally directed to a folder of your choosing instead of the current hard coded defaults. See earth_enterprise/BUILD.md in source code for more details.</p>
-    <p><strong>Added experimental build cache folder parameter to the build</strong>. Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommened except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
+    <p><strong>Added experimental build cache folder parameter to the build</strong>. Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommended except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
   <h5>
     <p id="supported_5.2.4">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/5.2.4/answer/7160004.html
+++ b/docs/geedocs/5.2.4/answer/7160004.html
@@ -44,6 +44,8 @@ gtag('config', 'UA-108632131-2');
   </h5>
     <p><strong>C++98 no longer supported</strong>. As of 5.2.4 C++11 syntax can be used and building open GEE using C++98 standard will no longer be supported</p>
     <p><strong>Added "Save and Build" file menu option</strong>. As of 5.2.4 the Fusion UI will include an additional file menu option that allows users to save and build assets with one click, instead of clicking the save option and then the build option immediately after.</p>
+    <p><strong>Added build parameter to redirect the build output</strong>Build output can now be optionally directed to a folder of your choosing instead of the current hard coded defaults. See earth_enterprise/BUILD.md in source code for more details.</p>
+    <p><strong>Added experimental build cache folder parameter to the build</strong>Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommend except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
   <h5>
     <p id="supported_5.2.4">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/5.2.4/answer/7160004.html
+++ b/docs/geedocs/5.2.4/answer/7160004.html
@@ -45,7 +45,7 @@ gtag('config', 'UA-108632131-2');
     <p><strong>C++98 no longer supported</strong>. As of 5.2.4 C++11 syntax can be used and building open GEE using C++98 standard will no longer be supported</p>
     <p><strong>Added "Save and Build" file menu option</strong>. As of 5.2.4 the Fusion UI will include an additional file menu option that allows users to save and build assets with one click, instead of clicking the save option and then the build option immediately after.</p>
     <p><strong>Added build parameter to redirect the build output</strong>. Build output can now be optionally directed to a folder of your choosing instead of the current hard coded defaults. See earth_enterprise/BUILD.md in source code for more details.</p>
-    <p><strong>Added experimental build cache folder parameter to the build</strong>. Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommended except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
+    <p><strong>Added experimental build cache folder parameter to the build</strong>. Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommended except for giving feedback and/or helping to address issues with Open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
   <h5>
     <p id="supported_5.2.4">Supported Platforms</p>
   </h5>

--- a/docs/geedocs/5.2.4/answer/7160004.html
+++ b/docs/geedocs/5.2.4/answer/7160004.html
@@ -44,8 +44,8 @@ gtag('config', 'UA-108632131-2');
   </h5>
     <p><strong>C++98 no longer supported</strong>. As of 5.2.4 C++11 syntax can be used and building open GEE using C++98 standard will no longer be supported</p>
     <p><strong>Added "Save and Build" file menu option</strong>. As of 5.2.4 the Fusion UI will include an additional file menu option that allows users to save and build assets with one click, instead of clicking the save option and then the build option immediately after.</p>
-    <p><strong>Added build parameter to redirect the build output</strong>Build output can now be optionally directed to a folder of your choosing instead of the current hard coded defaults. See earth_enterprise/BUILD.md in source code for more details.</p>
-    <p><strong>Added experimental build cache folder parameter to the build</strong>Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommend except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
+    <p><strong>Added build parameter to redirect the build output</strong>. Build output can now be optionally directed to a folder of your choosing instead of the current hard coded defaults. See earth_enterprise/BUILD.md in source code for more details.</p>
+    <p><strong>Added experimental build cache folder parameter to the build</strong>. Currently this was added as an experimental option to potentially speed up builds. Some more work remains to be done before using this option in production builds. Use of this option is not recommened except for giving feedback and/or helping to address issues with open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.</p>
   <h5>
     <p id="supported_5.2.4">Supported Platforms</p>
   </h5>

--- a/earth_enterprise/BUILD.md
+++ b/earth_enterprise/BUILD.md
@@ -21,7 +21,7 @@ For Linux build environments, see either the [Redhat and Centos Setup Instructio
 or the [Ubuntu Setup Instructions](./BUILD_Ubuntu.md) for those specific
 platforms on how to setup the dependencies, tools, and compilers.
 
-1. Clone the _earthenterprise_ repository in your build environment:
+2. Clone the _earthenterprise_ repository in your build environment:
 
     __NOTE:__ For development you should follow the instructions on the [Git Contributions](https://github.com/google/earthenterprise/wiki/Development:-Git-Contributions)
     page to clone the GEE repo to your personal fork, so that you can submit
@@ -42,7 +42,7 @@ platforms on how to setup the dependencies, tools, and compilers.
         git lfs pull
         ```
 
-1. In the build instructions below, the scons commands for building GEE/Fusion
+3. In the build instructions below, the scons commands for building GEE/Fusion
     have the following options:
 
     * `internal=1`: Build using non-optimized code, best for development and
@@ -69,14 +69,14 @@ platforms on how to setup the dependencies, tools, and compilers.
         the configuration to run again, otherwise the scons build may complain
         about missing libraries
 
-2. Build Earth Enterprise Fusion and Server:
+4. Build Earth Enterprise Fusion and Server:
 
     ```bash
     cd earthenterprise/earth_enterprise
     scons -j8 release=1 build
     ```
 
-3. Run unit tests (note: that the `REL` part of the path will vary if you use
+5. Run unit tests (note: that the `REL` part of the path will vary if you use
     `internal=1` or `optimize=1` instead of `release=1` or the full path may be
     something completly different if you used `build_folder`):
 

--- a/earth_enterprise/BUILD.md
+++ b/earth_enterprise/BUILD.md
@@ -51,6 +51,14 @@ platforms on how to setup the dependencies, tools, and compilers.
         information
     * `release=1`: Build a release using optimized code and no debugging
         information
+    *  `build_folder=some_path`: Gives you full control to where build output is
+        placed. Can be an absolute or relative path.  If it is a relative path then
+        it will be relative to `earth_enterprise\src`.  Nothing is appended to the
+        path so you have full control of the path.
+    * `cache_dir=some_path`: (Experimental) Should be an absolute path used by SCons
+        to cache build output.  Currently this parameter should be used for testing
+        builds using SCons cache.  There are some open issues with using SCons cache
+        and those working on the issues can use this option for testing their changes.
     * `-j#`: Specifies the number of simultaneous build jobs to use. Replace
         `#` with an integer. It should roughly match the number of processing
         cores available
@@ -61,15 +69,16 @@ platforms on how to setup the dependencies, tools, and compilers.
         the configuration to run again, otherwise the scons build may complain
         about missing libraries
 
-1. Build Earth Enterprise Fusion and Server:
+2. Build Earth Enterprise Fusion and Server:
 
     ```bash
     cd earthenterprise/earth_enterprise
     scons -j8 release=1 build
     ```
 
-1. Run unit tests (note that the `REL` part of the path will vary if you use
-    `internal=1` or `optimize=1` instead of `release=1`):
+3. Run unit tests (note: that the `REL` part of the path will vary if you use
+    `internal=1` or `optimize=1` instead of `release=1` or the full path may be
+    something completly different if you used `build_folder`):
 
     ```bash
     cd src/NATIVE-REL-x86_64/bin/tests


### PR DESCRIPTION
Documents fixes for #958 

Added new optional build parameters that add the needed flexibility to the build process of Open GEE for building code from less than optimal i/o devices. 
