### PR TITLE
getop timeout

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -105,7 +105,10 @@ main(int argc, char *argv[])
       TaskLists taskLists;
       if (!khAssetManagerProxy::GetCurrTasks("dummy", taskLists,
                                              error, timeout)) {
-        notify(NFY_FATAL, "%s", error.latin1());
+      	if (error.compare("GetCurrTasks: socket recvall: Resource temporarily unavailable") == 0)
+          outline("No data received from gesystemmanager\nStarting new request");
+        else
+          notify(NFY_FATAL, "%s", error.latin1());
       } else {
         // get the list of active keyhole processes
         std::vector<std::string> pslist;

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
     if (delay <= 0)
       usage(progname, "--delay must be positive");
     if (timeout < 0)
-      usage(progname, "--timeout must be zero or greater");
+      usage(progname, "--timeout must not be less than zero");
 
 
     std::string master    = AssetDefs::MasterHostName();

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -65,7 +65,8 @@ usage(const std::string &progn, const char *msg = 0, ...)
           "\nusage: %s [options]\n"
           "   Supported options are:\n"
           "      --help | -?:       Display this usage message\n"
-          "      --delay <seconds>: Seconds to wait between refreshes\n",
+          "      --delay <seconds>: Seconds to wait between refreshes\n"
+          "      --timeout <seconds>: Seconds to set as timeout for gesystemmanager repsonses.\n",
           progn.c_str());
   exit(1);
 }
@@ -78,16 +79,20 @@ main(int argc, char *argv[])
     int argn;
     bool help  = false;
     int delay = 5;
+    int timeout = 60;
     khGetopt options;
     options.flagOpt("help", help);
     options.flagOpt("?", help);
     options.opt("delay", delay);
+    options.opt("timeout", timeout);
     if (!options.processAll(argc, argv, argn))
       usage(progname);
     if (help)
       usage(progname);
     if (delay <= 0)
       usage(progname, "--delay must be positive");
+    if (timeout < 0)
+      usage(progname, "--timeout must be zero or greater");
 
 
     std::string master    = AssetDefs::MasterHostName();
@@ -99,7 +104,7 @@ main(int argc, char *argv[])
       QString error;
       TaskLists taskLists;
       if (!khAssetManagerProxy::GetCurrTasks("dummy", taskLists,
-                                             error)) {
+                                             error, timeout)) {
         notify(NFY_FATAL, "%s", error.latin1());
       } else {
         // get the list of active keyhole processes


### PR DESCRIPTION
Adds a timeout option for getop in order to avoid freezing when working on large projects. The default timeout is 60 seconds, but can be overridden by the user by using the timeout flag paired with the desired time, ex: (getop --timeout 100). 