### PR TITLE
fixes issue #984: Build fails from 5.2.4 beta tarball due to missing version.txt

### DIFF
--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -79,6 +79,7 @@ env.Command(date_file, [env.Value(build_date_str)],
             [env.WriteToFile(date_file, build_date_str)])
 
 # get the build version
+
 backup_file = File('#version.txt').abspath
 version_file = File('gee_version.txt').abspath
 built_version_file = env.Command(version_file, [ ],
@@ -97,6 +98,7 @@ built_version_header = env.Command(version_header, [ ],
             [env.EmitVersionHeader(version_header, backup_file)])
 env.AlwaysBuild(built_version_header)
 
+env.Alias('version_files', [version_header, long_version_file, version_file])
 
 # For cross compiler set the binaries
 link_gcc = []

--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -50,9 +50,19 @@ for root, dirs, files in os.walk('..'):
       # If we find one tar file that seems OK, assume all are OK
       break
 
+cache_dir = ARGUMENTS.get('cache_dir', 0)
+if cache_dir:
+  CacheDir(cache_dir)
+
 # list of dirs to try to build (if present)
-dirs = ['third_party', 'google', 'keyhole', 'common', 'fusion', 'server',
-        'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+if os.path.isfile('.treat_third_part_as_sdk'):
+  # this is useful if you want to share pre-built 3rd party builds
+  dirs = ['google', 'keyhole', 'common', 'fusion', 'server',
+          'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+else:
+  dirs = ['third_party', 'google', 'keyhole', 'common', 'fusion', 'server',
+          'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+
 
 # get the build date
 build_date = time.localtime(time.time())

--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -79,7 +79,6 @@ env.Command(date_file, [env.Value(build_date_str)],
             [env.WriteToFile(date_file, build_date_str)])
 
 # get the build version
-
 backup_file = File('#version.txt').abspath
 version_file = File('gee_version.txt').abspath
 built_version_file = env.Command(version_file, [ ],

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -86,7 +86,8 @@ ValidOptions = set(
      'log_performance',  # Include code for performance logging
      'cpp_standard',     # The standard of CPP that will be used.  Default is C++11
      'label',            # Value to combine with version strings.
-     'build_folder'      # where to put the build output and intermediate files 
+     'build_folder',     # where to put the build output and intermediate files
+     'cache_dir'         # use a cache dir to speed up build
      ]);
 
 for argkey in ARGUMENTS:
@@ -113,7 +114,7 @@ bundle_3rd_libs = int(ARGUMENTS.get('bundle_3rd_libs', 0))
 cc_dir = ARGUMENTS.get('cc_dir', None)
 log_performance = int( ARGUMENTS.get( 'log_performance', 0 ) )
 cpp_standard = ARGUMENTS.get('cpp_standard', 'gnu++11')
-build_folder = ARGUMENTS.get('build_folder', Dir('#/.').abspath)
+build_folder = ARGUMENTS.get('build_folder', 0)
 label = ARGUMENTS.get('label', '')
 
 # make some directory variables used by other parts of the build system
@@ -152,8 +153,15 @@ builddir += march
 if native_cc:
   builddir = 'NATIVE-' + builddir
 
+if build_folder:
+  builddir = build_folder
+
 # setup export directories
-exportdir = os.path.join(build_folder, builddir) 
+if os.path.isabs(builddir):
+  exportdir = builddir
+else:
+  exportdir = Dir('#/%s' % builddir).abspath
+
 exportdirs = {
     'root': exportdir+'/',
     'lib': exportdir+'/lib/',
@@ -435,10 +443,10 @@ env = khEnvironment(
     CPPFLAGS=cppflags,
     CPPPATH=[
              # generated 3rd party headers
-             Dir(exportdir + '/include'),
-             Dir(exportdir),  # generated headers
+             Dir(builddir + '/include'),
+             Dir(builddir),  # generated headers
              Dir('.'),
-             Dir(exportdir+'/common'),
+             Dir(builddir + '/common'),
              Dir('common'),
              Dir('common/khmisc'),
              src_keyhole_abs_dir],
@@ -469,7 +477,7 @@ if not opengee.version.is_version_ge(version, [4, 8]):
         if version == None:
             print "Unable to determine GCC version, minimum required is 4.8"
         else:
-            print ("GCC version " + '.'.join(version) + 
+            print ("GCC version " + '.'.join(version) +
                    " detected. Minimum required version is 4.8")
             Exit(1)
 
@@ -508,6 +516,7 @@ env['LRELEASE'] = qtdir+'/bin/lrelease'
 
 env['KHIDL'] = File('#common/khxml/khidl.pl')
 
-SConscript('SConscript', build_dir=exportdir, duplicate=0)
+env.PhonyTargets(build_dir = 'BUILD_DIR=' + builddir)
+SConscript('SConscript', variant_dir=builddir, duplicate=0)
 
 env.Clean('cleanall', [[exportdir+"/"+x for x in os.listdir(exportdir) if x != "third_party"]])

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -39,12 +39,12 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" "https://github.com/tst-eclamar/${REPO_NAME}.git" || exit
+git clone -b "${1}" "https://github.com/tst-eclamar/${REPO_NAME}.git" || exit # TEMPORARY: tst-eclamar => google
 
 cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
 git remote add upstream git://github.com/google/earthenterprise.git # TEMPORARY
-git fetch upstream
-git pull upstream master
+git fetch upstream # TEMPORARY
+git pull upstream master # TEMPORARY
 scons version_files
 cd ../..
 git clean -f -d -x -e version.txt

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -13,6 +13,8 @@
 # branch, run
 # ./build_release_archive.sh release_5.2.0
 
+#set -v -x
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <branch>"
   echo "where <branch> is a branch or tag that defines the release to be archived."
@@ -27,7 +29,7 @@ if [ -z "${SMUDGE_HOOK}" ]; then
   exit
 fi
 
-REPO_NAME="earthenterprise"
+REPO_NAME="tst-eclamar"
 TAR_FILE=${REPO_NAME}.tar.gz
 ZIP_FILE=${REPO_NAME}.zip
 RUN_DIR=`pwd`
@@ -37,7 +39,13 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" --depth 1 "https://github.com/google/${REPO_NAME}.git" || exit
+git clone -b "${1}" "https://github.com/google/${REPO_NAME}.git" || exit
+
+cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
+scons version_files
+cd ../..
+git clean -f -d -x -e version.txt
+cd ..
 
 # Remove the git-related files from the repo
 find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -43,8 +43,10 @@ cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
 git remote add upstream git://github.com/google/earthenterprise.git # TEMPORARY
 git fetch upstream # TEMPORARY
 git pull upstream master # TEMPORARY
+# generate version files based on tags within git
 scons version_files
 cd ../..
+# remove all un-tracked files except for version.txt
 git clean -f -d -x -e version.txt
 cd ..
 

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -13,8 +13,6 @@
 # branch, run
 # ./build_release_archive.sh release_5.2.0
 
-#set -v -x
-
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <branch>"
   echo "where <branch> is a branch or tag that defines the release to be archived."

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -29,7 +29,7 @@ if [ -z "${SMUDGE_HOOK}" ]; then
   exit
 fi
 
-REPO_NAME="tst-eclamar"
+REPO_NAME="earthenterprise"
 TAR_FILE=${REPO_NAME}.tar.gz
 ZIP_FILE=${REPO_NAME}.zip
 RUN_DIR=`pwd`
@@ -39,9 +39,12 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" "https://github.com/google/${REPO_NAME}.git" || exit
+git clone -b "${1}" "https://github.com/tst-eclamar/${REPO_NAME}.git" || exit
 
 cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
+git remote add upstream git://github.com/google/earthenterprise.git # TEMPORARY
+git fetch upstream
+git pull upstream master
 scons version_files
 cd ../..
 git clean -f -d -x -e version.txt


### PR DESCRIPTION
fixes issue #984 

This is a very simple change.  However, to test it requires some temporary changes to build_release_archive.sh.  Normally, we'd checkout 'google/earthenterprise', but to test the code we need to checkout the branch that the modified code currently lives in.  The lines marked "# Temporary" will either be changed or deleted.