### PR TITLE
991 dns test failure

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -50,7 +50,7 @@ def GetHostInfo():
     raise AssertionError('Hostname cannot be one of %s' % ','.join(BAD_HOSTNAMES))
   ipaddr = GetIP(hostname)
   host_check, host_aliases, _ = socket.gethostbyaddr(ipaddr)
-  return hostname, ipaddr, (host_aliases + [host_check])
+  return hostname, ipaddr, host_aliases + [host_check]
 
 
 def IsFusionInstalled():

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -46,11 +46,11 @@ PROCESS_INFO_LIST = ['cmdline']
 def GetHostInfo():
   """Get information about the host."""
   hostname = GetFQDN()
-  ipaddr = GetIP(hostname)
-  host_check, _, _ = socket.gethostbyaddr(ipaddr)
   if hostname in BAD_HOSTNAMES:
     raise AssertionError('Hostname cannot be one of %s' % ','.join(BAD_HOSTNAMES))
-  return hostname, ipaddr, host_check
+  ipaddr = GetIP(hostname)
+  host_check, host_aliases, _ = socket.gethostbyaddr(ipaddr)
+  return hostname, ipaddr, (host_aliases + [host_check])
 
 
 def IsFusionInstalled():

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/dns_test.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/user_tests/dns_test.py
@@ -28,8 +28,8 @@ class TestDns(unittest.TestCase):
 
     def testDns(self):
       """Test DNS to ensure hostname is correct for IP Address. """
-      self.hostname, self.ip, self.host_check = common.GetHostInfo()
-      self.assertEqual(self.hostname, self.host_check)
+      self.hostname, self.ip, self.host_check_list = common.GetHostInfo()
+      self.assertTrue(self.hostname in self.host_check_list)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #991 

The dns test will now look at aliases in addition to the FQDN.