### PR TITLE
Add ability to use non-standard build folder name and location.

### DIFF
--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -44,7 +44,7 @@ with open('rpms/build.properties', 'w') as f:
     print >> f, "## Manual changes will be overwritten."
     print >> f, str('staged=') + installdir.strip()
 
-installdir = Dir(installdir)
+installdir = Dir(installdir).abspath
 def dir_cat(installdir, subdir1, subdir2):
    if (len(subdir2) > 0):
       return Dir(subdir1 + subdir2, installdir)

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -58,33 +58,9 @@ import org.opengee.shell.GeeCommandLine
 def src_dir = "../src/"
 def scons_option = "release=1"
 
-// Look for command line parameters that specify how the packages are
-// to be built.  This can be either 'optimize' or 'debug'.
-// Option 'release' is the default.
-def native_dir = {
-  if ( project.hasProperty( 'optimize' ) ) {
-    scons_option = "optimize=1"
-    return "NATIVE-OPT-x86_64"
-  }  // end check for option 'optimze'
-  if ( project.hasProperty( 'debug' ) ) {
-    scons_option = "release=0"
-    return "NATIVE-DBG-x86_64"
-  }
-  return "NATIVE-REL-x86_64"
-}  // end native_dir
-
-// Build the actual file to be used
-def gee_long_version_txt = "${src_dir}${native_dir()}/gee_long_version.txt"
-
-
-def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
-
 def stagedInstall_path =
-    project.hasProperty('stageInstallPath') ?
-        project.stageInstallPath :
-        (project.hasProperty('buildOpenGee') ?
-            "${buildDir.getAbsolutePath()}/install" :
-            '/tmp/fusion_os_install')
+    project.hasProperty('stageInstallPath') ? project.stageInstallPath : '/tmp/fusion_os_install'
+
 if (new File('build.properties').exists()) {
     def props = new Properties()
     new File('build.properties').withInputStream {
@@ -94,6 +70,21 @@ if (new File('build.properties').exists()) {
         stagedInstall_path = props["staged"]
     }
 }
+
+// Look for command line parameters that specify how the packages are
+// to be built.  This can be either 'optimize' or 'debug'.
+// Option 'release' is the default.
+if ( project.hasProperty( 'optimize' ) ) {
+    scons_option = "optimize=1"
+}  // end check for option 'optimze'
+else if ( project.hasProperty( 'debug' ) ) {
+    scons_option = "release=0"
+}
+
+// Build the actual file to be used
+def gee_long_version_txt = "${stagedInstall_path}/gee_long_version.txt"
+
+def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
 
 // Create a file handle for gee_long_version_txt
 def openGeeVersionFile = new File( gee_long_version_txt )
@@ -149,12 +140,7 @@ def stagedInstallDir_tutorial = new File(stagedInstallDir, 'tutorial')
 def packageInstallRootDir = new File('/')
 def packageInstallLibDir = new File(packageInstallRootDir, 'opt/google/lib')
 
-def postGisInstallDir = new File(
-        project.projectDir,
-        "${src_dir}${native_dir()}/third_party/postgis/install"
-    ).getAbsolutePath()
-
-def postGisInstallDir_opt = new File(postGisInstallDir, 'opt')
+def stagedInstallDir_postgis_opt = new File(stagedInstallDir, 'postgis/opt')
 
 // Commands used in install-utils.sh:
 def packageSharedCommands = ['bash', 'flock', 'sed', 'xmllint']
@@ -249,7 +235,7 @@ task openGeePostGisRpm(type: GeeRpm) {
     autoFindRequires = true
     requires('opengee-common', openGeeVersion, GREATER | EQUAL)
 
-    from (postGisInstallDir_opt) {
+    from (stagedInstallDir_postgis_opt) {
         into new File(packageInstallRootDir, 'opt')
     }
 
@@ -559,13 +545,6 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
 
     from(stagedInstallDir_server_apachesupport) {
         into packageInstallRootDir
-    }
-
-    // Exclude files that go into the PostGIS RPM from this package:
-    eachFile {
-        if (new File(postGisInstallDir_opt, "../${it.path}").exists()) {
-            it.exclude()
-        }
     }
 
     // Create links

--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -57,12 +57,12 @@ if cache_dir:
 third_party_only = ARGUMENTS.get('third_party_only', 0)
 
 # list of dirs to try to build (if present)
-if third_party_only:
-  dirs = ['third_party']
-elif os.path.isfile('.treat_third_party_as_sdk'):
+if os.path.isfile('.treat_third_part_as_sdk'):
   # this is useful if you want to share pre-built 3rd party builds
   dirs = ['google', 'keyhole', 'common', 'fusion', 'server',
           'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']
+elif third_party_only:
+  dirs = ['third_party']
 else:
   dirs = ['third_party', 'google', 'keyhole', 'common', 'fusion', 'server',
           'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']

--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -54,8 +54,12 @@ cache_dir = ARGUMENTS.get('cache_dir', 0)
 if cache_dir:
   CacheDir(cache_dir)
 
+third_party_only = ARGUMENTS.get('third_party_only', 0)
+
 # list of dirs to try to build (if present)
-if os.path.isfile('.treat_third_part_as_sdk'):
+if third_party_only:
+  dirs = ['third_party']
+elif os.path.isfile('.treat_third_party_as_sdk'):
   # this is useful if you want to share pre-built 3rd party builds
   dirs = ['google', 'keyhole', 'common', 'fusion', 'server',
           'maps', 'share/taskrules', 'support', 'earthplugin', 'javascript']

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -336,18 +336,17 @@ def DirCat(install_dir, subdir1, subdir2):
 def InstCommonDir(subdir):
   return DirCat(installdir, 'common%s/' % optdir, subdir)
 
-
 def InstFusionDir(subdir):
   return DirCat(installdir, 'fusion%s/' % optdir, subdir)
 
+def InstPostgisDir(subdir):
+   return DirCat(installdir, 'postgis/opt/google/', subdir)
 
 def InstServerDir(subdir):
   return DirCat(installdir, 'server%s/' % optdir, subdir)
 
-
 def InstToolsDir(subdir):
   return DirCat(installdir, 'tools%s/' % optdir, subdir)
-
 
 def InstDisconnectedDir(subdir):
   return DirCat(installdir, 'disconnected%s/' % optdir, subdir)
@@ -382,6 +381,10 @@ installdirs = {
 
     'tools_bin': InstToolsDir('bin'),
     'tools_lib': InstToolsDir('lib'),
+
+    'postgis_bin': InstPostgisDir('bin'),
+    'postgis_lib': InstPostgisDir('lib'),
+    'postgis_share': InstPostgisDir('share'),
 
     'server_bin': InstServerDir('bin'),
     'server_etc': Dir('server/etc%s' % optdir, installdir),

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -87,7 +87,8 @@ ValidOptions = set(
      'cpp_standard',     # The standard of CPP that will be used.  Default is C++11
      'label',            # Value to combine with version strings.
      'build_folder',     # where to put the build output and intermediate files
-     'cache_dir'         # use a cache dir to speed up build
+     'cache_dir',        # use a cache dir to speed up build
+     'third_party_only'  # build third party code only
      ]);
 
 for argkey in ARGUMENTS:

--- a/earth_enterprise/src/common/tests/RunAllTests.pl
+++ b/earth_enterprise/src/common/tests/RunAllTests.pl
@@ -54,11 +54,11 @@ if($argc > 0) {
   }
 }
 
-# This script should be run from NATIVE-*-x86_64/bin/tests
+# This script should be run from <build_dir>/bin/tests
 my $scriptDir = dirname(abs_path($0));
-if ($scriptDir !~ /NATIVE-[a-zA-Z0-9_-]*\/bin\/tests$/) {
+if ($scriptDir !~ /[a-zA-Z0-9\._-]*\/bin\/tests$/ or not -e "$scriptDir/../../gee_version.txt") {
     print "This script should be run from <build_dir>/bin/tests.\n";
-    print "<build_dir> is usually something like NATIVE-REL-x86_64.\n";
+    print "<build_dir> should contain gee_version.txt.\n";
     exit;
 }
 chdir($scriptDir);
@@ -134,8 +134,8 @@ foreach my $test (@tests) {
               }
 
               #capture the test name from successes, which come in 2 different formats
-              $line =~ s/^\[.+\]\s+//; 
-              if ($line =~ /^(\[.+\]\w+)?(\w+)(\s+succeeded)$/) { 
+              $line =~ s/^\[.+\]\s+//;
+              if ($line =~ /^(\[.+\]\w+)?(\w+)(\s+succeeded)$/) {
                 $line = $2;
               }
               elsif ($line =~ /(.+)\s+\((\d+)\s+ms\).*$/) {
@@ -185,7 +185,7 @@ foreach my $test (@tests) {
       $test_count = 1;
     }
 
-    ### print xml for the test file we just ran 
+    ### print xml for the test file we just ran
     $testsuite .= " name=\"$basename\" tests=\"$test_count\">\n";
 
     #if there was a failure, save the output in the stderr-data xml block
@@ -207,8 +207,8 @@ foreach my $test (@tests) {
 
     print $fh $testsuite;
 
-    #print xml for each testcase inside this testsuite 
-    foreach my $testcase (@testcases) { 
+    #print xml for each testcase inside this testsuite
+    foreach my $testcase (@testcases) {
       print $fh $testcase;
       print $fh $stdout_data;
       print $fh $stderr_data;

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -322,6 +322,12 @@ copy_files_to_target()
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/common/opt/google/gepython" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/bin" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/lib" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/share" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/bin" "$BASEINSTALLDIR_OPT"

--- a/earth_enterprise/src/third_party/postgis/SConscript
+++ b/earth_enterprise/src/third_party/postgis/SConscript
@@ -121,8 +121,8 @@ postgis_install = postgis_env.Command(
                       install_root_opt,
                       install_root_opt, ge_version,
                       install_root_opt, ge_version,
-                      install_root_opt, 
-                      build_root, install_root_opt, 
+                      install_root_opt,
+                      build_root, install_root_opt,
                       install_root, root_dir,
                       install_root_opt,
                       install_root_opt,
@@ -147,16 +147,15 @@ postgis_env.ExecuteOnClean('rm -rf %s' % current_dir)
 if 'install' in COMMAND_LINE_TARGETS:
   postgis_env.InstallFileOrDir(
       '%s/bin/' % install_root_opt,
-      '%s/' % postgis_env.installdirs['server_bin'],
+      '%s/' % postgis_env.installdirs['postgis_bin'],
           postgis_install_build, 'install')
   postgis_env.InstallFileOrDir(
       '%s/lib/' % install_root_opt,
-      '%s/' % postgis_env.installdirs['server_lib'],
+      '%s/' % postgis_env.installdirs['postgis_lib'],
           postgis_install_build, 'install')
   postgis_env.InstallFileOrDir(
       '%s/share/' % install_root_opt,
-      '%s/' % postgis_env.installdirs['server_share'],
+      '%s/' % postgis_env.installdirs['postgis_share'],
           postgis_install_build, 'install')
 
 Return('postgis_extract postgis_install_build')
-


### PR DESCRIPTION
Changes:
- add ability to build third_party code only
- fix `scons install` not handling installdir absolute paths correctly
- remove hardcoded build path and allow tests to be run from a non-standard build folder location
- remove hardcoded build folder name from `rpms/build.gradle`
- do not stage install postgis with server

Repro steps:
- build third_party code only
`cd earthenterprise/earth_enterprise/src
scons -j4 build_folder=/tmp/build release=1 third_party_only=1`
- build everything
`cd earthenterprise/earth_enterprise
scons -j4 build_folder=/tmp/build release=1 installdir=/tmp/build/stage`
- verify that stage folder contains separate postgis subfolder
- run unit tests
`cd /tmp/build/bin/tests
perl RunAllTests.pl -o test.out`
- build RPMs
`cd earthenterprise/earth_enterprise/rpms
./gradlew openGeeRpms`
- verify that postgis RPM located in build/distributions subfolder contains postgis files
- install/uninstall RPMs 
- run non-RPM installer
`cd earthenterprise/earth_enterprise/src/installer
sudo ./install_fusion.sh -dir /tmp/build/stage
sudo ./install_server.sh -dir /tmp/build/stage`
- stop gefusion and geserver
`sudo /etc/init.d/gefusion stop
sudo /etc/init.d/geserver stop'
- uninstall gefusion and geserver
`sudo ./uninstall_fusion.sh
sudo ./uninstall_server.sh`




