### PR TITLE
I #984 Build fails from 5.2.4 beta tarball due to missing version.txt

### DIFF
--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -101,6 +101,7 @@ built_version_header = env.Command(version_header, [ ],
             [env.EmitVersionHeader(version_header, backup_file)])
 env.AlwaysBuild(built_version_header)
 
+env.Alias('version_files', [version_header, long_version_file, version_file])
 
 # For cross compiler set the binaries
 link_gcc = []

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -37,7 +37,18 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" --depth 1 "https://github.com/google/${REPO_NAME}.git" || exit
+git clone -b "${1}" "https://github.com/tst-eclamar/${REPO_NAME}.git" || exit # TEMPORARY: tst-eclamar => google
+
+cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
+git remote add upstream git://github.com/google/earthenterprise.git # TEMPORARY
+git fetch upstream # TEMPORARY
+git pull upstream master # TEMPORARY
+# generate version files based on tags within git
+scons version_files
+cd ../..
+# remove all un-tracked files except for version.txt
+git clean -f -d -x -e version.txt
+cd ..
 
 # Remove the git-related files from the repo
 find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -37,12 +37,9 @@ CLONE_DIR=`mktemp -d`
 
 # Download the repository
 cd "${CLONE_DIR}"
-git clone -b "${1}" "https://github.com/tst-eclamar/${REPO_NAME}.git" || exit # TEMPORARY: tst-eclamar => google
+git clone -b "${1}" "https://github.com/google/${REPO_NAME}.git" || exit
 
 cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
-git remote add upstream git://github.com/google/earthenterprise.git # TEMPORARY
-git fetch upstream # TEMPORARY
-git pull upstream master # TEMPORARY
 # generate version files based on tags within git
 scons version_files
 cd ../..

--- a/scripts/build_release_archive.sh
+++ b/scripts/build_release_archive.sh
@@ -42,10 +42,10 @@ git clone -b "${1}" "https://github.com/google/${REPO_NAME}.git" || exit
 cd "${CLONE_DIR}"/earthenterprise/earth_enterprise/src
 # generate version files based on tags within git
 scons version_files
-cd ../..
+cd "${CLONE_DIR}"/earthenterprise
 # remove all un-tracked files except for version.txt
 git clean -f -d -x -e version.txt
-cd ..
+cd "${CLONE_DIR}"
 
 # Remove the git-related files from the repo
 find "${REPO_NAME}" -name ".git*" -exec rm -Rf {} +


### PR DESCRIPTION
Issue #984 - Build fails from 5.2.4 beta tarball due to missing version.txt

Note: it was necessary to do step 11, 'Copy docs for next release', in order to make space for the new and updated webpages that point to 5.2.5.  Maybe I'm confused, but it looks like that this wasn't done for 5.2.4 ('Copy docs for next release').