### PR TITLE
#999 Fix cleanall bug

### DIFF
--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -214,7 +214,7 @@ env.PhonyTargets(**this_dict)
 
 if 'cleanall' in COMMAND_LINE_TARGETS:
     #clean the search and getomcat install folders.
-    file = installdir.get_path()
+    file = installdir
     commands.getstatusoutput("rm -rf " + file)
 
     #clean /tmp/fusion_os_install


### PR DESCRIPTION
#999 
Fix for recent bug introduced with #987. Fixing handling of absolute installdir paths in #987 changed the type of installdir causing cleanall target to break.

To verify:
`cd earthenterprise/earth_enterprise`
`scons release=1 -c cleanall`