### PR TITLE
#788 Add flags for poi search, update documentation.

### DIFF
--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -75,7 +75,7 @@
 --<strong>no_historical_imagery</strong>] -o <em>projectname</em>{[--<strong>maxlevel</strong> <em>level</em>] <em>insetresource</em>}</code>...</pre>
   <h3>Purpose</h3>
   <p>Creates a new imagery project. This tool is capable of building Mercator imagery projects for 2D databases, or Flat (Plate Carrée) imagery projects with or without Historic Imagery Support for 3D databases.
-  
+
   <h3>Commands</h3>
   <pre>
 <code><b>--mercator </b></code></pre>
@@ -442,6 +442,16 @@ geserveradmin --garbagecollect
       <td><pre><code><b>--setecdefault</b> </code></pre></td>
       <td>Optional</td>
       <td>Publish this database as the default one for the Earth Client to connect to if no database or virtual host is specified upon initial connection.</td>
+    </tr>
+    <tr>
+      <td><pre><code><b>--enable_poisearch</b> </code></pre></td>
+      <td>Optional</td>
+      <td>Enable Point of Interest search if database contains POI data.</td>
+    </tr>
+    <tr>
+      <td><pre><code><b>--enable_enhancedsearch</b> </code></pre></td>
+      <td>Optional</td>
+      <td>If POI search is enabled, enable enhanced search.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -417,7 +417,7 @@ geserveradmin --garbagecollect
 </table>
 <h4><a name="geserveradmin_pdb"></a>Publish database</h4>
 <pre>
-<code><b>--publishdb</b> <i>db_name</i> <b>--targetpath</b> <i>target_path</i> [<b>--vhname</b> <i>vh_name</i>] [<b>--setecdefault</b>]</code></pre>
+<code><b>--publishdb</b> <i>db_name</i> <b>--targetpath</b> <i>target_path</i> [<b>--vhname</b> <i>vh_name</i>] [<b>--setecdefault</b>] [<b>--enable_poisearch</b> [<b>--enable_enhancedsearch</b>]]</code></pre>
 <p>Publish the specified database on the specified target path. If the virtual host name is omitted, it publishes to the default virtual host: "public".</p>
 <table class="nice-table">
   <tbody>

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -708,7 +708,9 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
 bool PublisherClient::PublishDatabase(const std::string& in_db_name,
                                       const std::string& in_target_path,
                                       const std::string& vh_name,
-                                      const bool ec_default_db) {
+                                      const bool ec_default_db,
+                                      const bool poi_search,
+                                      const bool enhanced_search) {
   try {
     std::string target_path = NormalizeTargetPath(in_target_path);
     if (target_path.empty()) {
@@ -750,7 +752,13 @@ bool PublisherClient::PublishDatabase(const std::string& in_db_name,
     stream_args += "&VirtualHostName=" + stream_vs_name;
     stream_args += "&TargetPath=" + target_path;
     stream_args += "&DbType=" + Itoa(db_manifest.GetDbType());
-    if (ec_default_db) { 
+    if (poi_search) {
+      stream_args += "&SearchDefName=POISearch";
+      if (enhanced_search) {
+        stream_args += "&PoiFederated=1";
+      }
+    }
+    if (ec_default_db) {
       stream_args += "&EcDefaultDb=1" ;
     }
     std::vector<std::string> empty_vector;
@@ -1355,7 +1363,7 @@ bool PublisherClient::SyncFiles(
         upload_entries.push_back(manifest_entries[index]);
 
         // some files are 'dependent files' that are not part of the original manifest reported to
-        // server but we still need to upload those files as they complete the specified file in the 
+        // server but we still need to upload those files as they complete the specified file in the
         // original manifest.  We can't include the file in the original manifest because in cases
         // like search manifests server does special processing on files in that manifest that
         // can't be done on the dependent files.

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.h
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.h
@@ -149,8 +149,10 @@ class PublisherClient : public PublishHelper {
   // serverdb.config) to the server and publishes stream data.
   bool PublishDatabase(const std::string& in_db_name,
                        const std::string& in_target_path,
-                       const std::string& vh_name = "", 
-                       const bool default_db = false);
+                       const std::string& vh_name = "",
+                       const bool default_db = false,
+                       const bool poi_search = false,
+                       const bool enhanced_search = false);
 
   // Re-publish database to be served with the existing target path.
   bool RepublishDatabase(const std::string& in_db_name,

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -96,7 +96,10 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
     "   [--setecdefault]         Publish this database as the default one for\n"
     "                            the Earth Client to connect to if no database\n"
     "                            or virtual host is specified upon initial\n"
-    "                            connection.\n" 
+    "                            connection.\n"
+    "   [--enable_poisearch]     Enable Point of Interest search.\n"
+    "   [--enable_enhancedsearch]If POI search is enabled, enable enhanced\n"
+    "                            search.\n"
     " --unpublish <target_path>  Unpublish the DB served from the specified\n"
     "                            target path.\n"
     " --republishdb <db_name>    Publish a registered DB on the specified\n"
@@ -305,6 +308,8 @@ int main(int argc, char* argv[]) {
     bool force_copy = false;
     bool vhssl = false;
     bool swaptargets = false;
+    bool enable_poisearch = false;
+    bool enable_enhancedsearch = false;
     std::string adddb, dbdetails, deletedb, publishdb,  unpublish;
     std::string republishdb, targetdetails;
     std::string target_path, dbalias;
@@ -342,6 +347,8 @@ int main(int argc, char* argv[]) {
     options.vecOpt("pushdb", pushdbs);
     options.opt("publishdb", publishdb);
     options.flagOpt("setecdefault", ec_default_db);
+    options.flagOpt("enable_poisearch", enable_poisearch);
+    options.flagOpt("enable_enhancedsearch", enable_enhancedsearch);
     options.opt("unpublish", unpublish);
     options.opt("republishdb", republishdb);
     options.flagOpt("swaptargets", swaptargets);
@@ -623,6 +630,10 @@ int main(int argc, char* argv[]) {
         throw khException("Target path is not specified.\n");
       }
 
+      if (enable_enhancedsearch && !enable_poisearch) {
+        throw khException("Enhanced search cannot be enabled without POI search.\n");
+      }
+
       // Convert the db name to a full gedb path.
       std::string gedb_path;
       if (!publishdb.empty()) {
@@ -632,7 +643,7 @@ int main(int argc, char* argv[]) {
       if (fusion_host.empty()) {
         SetFusionHost(&publisher_client, gedb_path, curr_host);
       }
-      if (publisher_client.PublishDatabase(gedb_path, target_path, vhname, ec_default_db)) {
+      if (publisher_client.PublishDatabase(gedb_path, target_path, vhname, ec_default_db, enable_poisearch, enable_enhancedsearch)) {
         fprintf(stdout, "Database successfully published.  EC Default Database: %s\n", ec_default_db ? "true" : "false");
       } else {
         throw khException(publisher_client.ErrMsg() +

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -631,7 +631,7 @@ int main(int argc, char* argv[]) {
         throw khException("Target path is not specified.\n");
       }
 
-      if ((enable_poiseach || enable_enhancedsearch) && !publishedb) {
+      if ((enable_poisearch || enable_enhancedsearch) && !publishdb.size()) {
         throw khException("POI search and enhanced search are only used when publishing a database.\n");
       }
 

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -394,6 +394,14 @@ int main(int argc, char* argv[]) {
       usage(progname);
     }
 
+    if ((enable_poisearch || enable_enhancedsearch) && !publishdb.size()) {
+      throw khException("POI search and enhanced search are only used when publishing a database.\n");
+    }
+
+    if (enable_enhancedsearch && !enable_poisearch) {
+      throw khException("Enhanced search cannot be enabled without POI search.\n");
+    }
+
     if (disable_cutter) {
       DisableCutter();
       return 0;
@@ -629,14 +637,6 @@ int main(int argc, char* argv[]) {
       fflush(stdout);
       if (target_path.empty()) {
         throw khException("Target path is not specified.\n");
-      }
-
-      if ((enable_poisearch || enable_enhancedsearch) && !publishdb.size()) {
-        throw khException("POI search and enhanced search are only used when publishing a database.\n");
-      }
-
-      if (enable_enhancedsearch && !enable_poisearch) {
-        throw khException("Enhanced search cannot be enabled without POI search.\n");
       }
 
       // Convert the db name to a full gedb path.

--- a/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
+++ b/earth_enterprise/src/fusion/gepublish/geserveradmin.cpp
@@ -97,7 +97,8 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
     "                            the Earth Client to connect to if no database\n"
     "                            or virtual host is specified upon initial\n"
     "                            connection.\n"
-    "   [--enable_poisearch]     Enable Point of Interest search.\n"
+    "   [--enable_poisearch]     Enable Point of Interest search if database\n"
+    "                            contains POI data.\n"
     "   [--enable_enhancedsearch]If POI search is enabled, enable enhanced\n"
     "                            search.\n"
     " --unpublish <target_path>  Unpublish the DB served from the specified\n"
@@ -628,6 +629,10 @@ int main(int argc, char* argv[]) {
       fflush(stdout);
       if (target_path.empty()) {
         throw khException("Target path is not specified.\n");
+      }
+
+      if ((enable_poiseach || enable_enhancedsearch) && !publishedb) {
+        throw khException("POI search and enhanced search are only used when publishing a database.\n");
       }
 
       if (enable_enhancedsearch && !enable_poisearch) {


### PR DESCRIPTION
Added flags to geserveradmin to allow publishing databases with POI search information. Updated the documentation of geserveradmin to reflect these new flags.

Automatic testing these changes would require rewriting PublisherClient.cpp, and testing the command line utility itself would require an additional testing framework outside of gtest. Because of the lack of automatic testing, manual test instructions are included below.

To test POI search flag for geserveradmin:

Create a test database, my test database used the 4km bluemarble imagery data and the California population vector data. Add POI information making sure it is searchable, I added the names of the cities.

Test 1) Publish the database using:
    `geserveradmin --publishdb <db_name> --targetpath <publish_name>`
Upon command success, open up the earth client. Try to search something, you should get no results as POI search is not enabled. Unpublish the database using either console commands or the geserver webpage.

Test 2) Publish the database using:
    `geserveradmin --publishdb <db_name> --targetpath <publish_name> --enable_poisearch`
Upon command success, open up the earth client. Search for something that is in your POI data (In my case I search "san", as there are many cities in California with "san" in their name). You should get results that are only in your database. Unpublish the database using either console commands or the geserver webpage.

Test 3) Publish the database using:
    `geserveradmin --publishdb <db_name> --targetpath <publish_name> --enable_poisearch --enable_enhancedsearch`
Open up the earth client. Search for something that is not in your POI data, perhaps a city in the US (In my case I search "Wooster", as there is no city in California called Wooster, but there are a few scattered throughout the rest of the US). You should get results for data outside your database using the GeocodingFederated plug-in. Unpublish the database using either console commands or the geserver webpage.

Test 4) Attempt to publish the database using:
    `geserveradmin --publishdb <db_name> --targetpath <publish_name> --enable_enhancedsearch`
You should get a fusion fatal error, indicating that you cannot enable enhanced search without POI search being enabled.

Fixes #788 