### PR TITLE
997 git based alpha builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ earth_enterprise/tutorial/FusionTutorial/KML
 /*.files
 /*.includes
 
+.vscode/

--- a/earth_enterprise/.gitignore
+++ b/earth_enterprise/.gitignore
@@ -5,9 +5,6 @@
 /*.files
 /*.includes
 
-# vs code files
-/*.vscode
-
 # compiled python
 /**/*.pyc
 

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This file is 'earth_enterprise/scr/SConstruct'
+# This file is 'earth_enterprise/src/SConstruct'
 
 
 """Top level SConstruct file."""

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -32,10 +32,6 @@ def GetLongVersion(backupFile, label=''):
     return ret
 
 
-def _GetDateString():
-    """Returns formatted date string representing current UTC time"""
-    return datetime.utcnow().strftime("%Y%m%d%H%M")
-
 def _GitGeneratedLongVersion():
     """Take the raw information parsed by git, and use it to
        generate an appropriate version string for GEE."""
@@ -81,36 +77,6 @@ def _GetRepository():
     except TypeError:
         return git.Repo('.')
  
-
-def _CheckGitAvailable():
-    """Try the most basic of git commands, to see if there is
-       currently any access to a repository."""
-    try:
-        repo = _GetRepository()
-    except git.exc.InvalidGitRepositoryError:
-        return False
-    
-    return True
-
-
-def _CheckDirtyRepository():
-    """Check to see if the repository is not in a cleanly committed state."""
-    repo = _GetRepository()
-    str = repo.git.status("--porcelain")
-    
-    return (len(str) > 0)
-
-
-def _ReadBackupVersionFile(target):
-    """There should be a file checked in with the latest version
-    information available; if git isn't available to provide
-    information, then use this file instead."""
-
-    with open(target, 'r') as fp:
-        line = fp.readline()
-
-    return line
-
 
 def _GetCommitRawDescription():
     """Returns description of current commit"""
@@ -161,6 +127,41 @@ def _ParseRawVersionString(raw):
     repo = _GetRepository()
     components['hash'] = repo.git.rev_parse('--short=8', 'HEAD')  
     return components
+
+
+def _CheckGitAvailable():
+    """Try the most basic of git commands, to see if there is
+       currently any access to a repository."""
+    try:
+        repo = _GetRepository()
+    except git.exc.InvalidGitRepositoryError:
+        return False
+    
+    return True
+
+
+def _CheckDirtyRepository():
+    """Check to see if the repository is not in a cleanly committed state."""
+    repo = _GetRepository()
+    str = repo.git.status("--porcelain")
+    
+    return (len(str) > 0)
+
+
+def _ReadBackupVersionFile(target):
+    """There should be a file checked in with the latest version
+    information available; if git isn't available to provide
+    information, then use this file instead."""
+
+    with open(target, 'r') as fp:
+        line = fp.readline()
+
+    return line
+
+
+def _GetDateString():
+    """Returns formatted date string representing current UTC time"""
+    return datetime.utcnow().strftime("%Y%m%d%H%M")
 
 
 def main():

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -160,7 +160,9 @@ def _ParseRawVersionString(raw):
         components['patch'] = -1
     else:
         components['patchType'] = patchComponents[1]
-        
+    
+    repo = _GetRepository()
+    components['hash'] = repo.git.rev_parse('--short=8', 'HEAD')  
     return components
   
 def main():

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -81,7 +81,11 @@ def _GitGeneratedLongVersion():
        generate an appropriate version string for GEE."""
 
     repo = _GetRepository()
-    raw = repo.git.describe('--tags', '--match', '[0-9]*\.[0-9]*\.[0-9]*\-*')
+
+    # Get reverse sorted list of tags that are reachable (--merged) from HEAD:
+    tags = repo.git.tag('--list', '[0-9]*\.[0-9]*\.[0-9]*\-*', '--sort=-v:refname', '--merged').split('\n')
+    # Get the first one safely (or '')
+    raw = next(iter(tags or ['']), '')
     raw = raw.rstrip()
 
     # Grab the datestamp.

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 import os
-#import sys
 import argparse
-import re
+#import re
 import git
-import subprocess
+#import subprocess
 from datetime import datetime
 
 def GetLongVersion(backupFile, label=''):
@@ -65,11 +64,6 @@ def CheckDirtyRepository():
 
     repo = GetRepository()
     str = repo.git.status("--porcelain")
-    
-    # Ignore version.txt for this purpose, as a build may modify the file
-    # and lead to an erroneous interpretation on repeated consecutive builds.
-    if (str == " M earth_enterprise/src/version.txt\n"):
-        return False
     
     return (len(str) > 0)
     

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+import os
+#import sys
+import argparse
+import re
+import git
+import subprocess
+from datetime import datetime
+
+def GetLongVersion(backupFile, label=''):
+  """Create a detailed version string based on the state of
+     the software, as it exists in the repository."""
+ 
+  if CheckGitAvailable():
+    ret = GitGeneratedLongVersion()
+
+  # Without git, must use the backup file to create a string.
+  else:
+    base = ReadBackupVersionFile(backupFile)
+    date = datetime.utcnow().strftime("%Y%m%d%H%M")
+    ret = '-'.join([base, date])
+
+  # Append the label, if there is one.
+  if len(label):
+    ret = '.'.join([ret, label])
+
+  return ret
+
+
+def GetVersion(backupFile, label=''):
+  """As getLongVersion(), but only return the leading *.*.* value."""
+
+  raw = GetLongVersion(backupFile, label)
+  final = raw.split("-")[0]
+
+  return final
+
+
+def GetRepository():
+    """Get a reference to the Git Repository.
+    Is there a cleaner option than searching from the current location?"""
+
+    # The syntax is different between library versions (particularly,
+    # those used by Centos 6 vs Centos 7).
+    try:
+        return git.Repo('.', search_parent_directories=True)
+    except TypeError:
+        return git.Repo('.')
+ 
+
+def CheckGitAvailable():
+    """Try the most basic of git commands, to see if there is
+       currently any access to a repository."""
+    
+    try:
+        repo = GetRepository()
+    except git.exc.InvalidGitRepositoryError:
+        return False
+    
+    return True
+
+
+def CheckDirtyRepository():
+    """Check to see if the repository is not in a cleanly committed state."""
+
+    repo = GetRepository()
+    str = repo.git.status("--porcelain")
+    
+    # Ignore version.txt for this purpose, as a build may modify the file
+    # and lead to an erroneous interpretation on repeated consecutive builds.
+    if (str == " M earth_enterprise/src/version.txt\n"):
+        return False
+    
+    return (len(str) > 0)
+    
+
+def ReadBackupVersionFile(target):
+  """There should be a file checked in with the latest version
+     information available; if git isn't available to provide
+     information, then use this file instead."""
+
+  with open(target, 'r') as fp:
+    line = fp.readline()
+
+  return line
+
+def GitGeneratedLongVersion():
+    """Take the raw information parsed by git, and use it to
+       generate an appropriate version string for GEE."""
+
+    repo = GetRepository()
+    raw = repo.git.describe('--tags', '--match', '[0-9]*\.[0-9]*\.[0-9]*\-*')
+    raw = raw.rstrip()
+
+    # Grab the datestamp.
+    date = datetime.utcnow().strftime("%Y%m%d%H%M")
+
+    # If this condition hits, then we are currently on a tagged commit.
+    if (len(raw.split("-")) < 4):
+        if CheckDirtyRepository():
+            return '.'.join([raw, date])
+        return raw
+
+    # Tear apart the information in the version string.
+    components = ParseRawVersionString(raw)
+  
+    # Determine how to update, since we are *not* on tagged commit.
+    if components['isFinal']:
+        components['patch'] = 0
+        components['patchType'] = "alpha"
+        components['revision'] = components['revision'] + 1
+    else:
+        components['patch'] = components['patch'] + 1
+    
+    # Rebuild.
+    base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
+    patch = '.'.join([str(components["patch"]), components["patchType"], date])
+    if not CheckDirtyRepository():
+        patch = '.'.join([patch, components['hash']])
+    
+    return '-'.join([base, patch])
+
+
+def ParseRawVersionString(raw):
+    """Break apart a raw version string into its various components,
+    and return those entries via a dictionary."""
+
+    components = { }    
+    rawComponents = raw.split("-")
+    
+    base = rawComponents[0]
+    patchRaw = rawComponents[1]
+    components['numCommits'] = rawComponents[2]
+    components['hash'] = rawComponents[3]
+    components['isFinal'] = ((patchRaw[-5:] == "final") or
+                             (patchRaw[-7:] == "release"))
+  
+    baseComponents = base.split(".")
+    components['major'] = int(baseComponents[0])
+    components['minor'] = int(baseComponents[1])
+    components['revision'] = int(baseComponents[2])
+  
+    patchComponents = patchRaw.split(".")
+    components['patch'] = int(patchComponents[0])
+    if (len(patchComponents) < 2):
+        components['patchType'] = "alpha"
+    else:
+        components['patchType'] = patchComponents[1]
+        
+    return components
+  
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-l", "--long", action="store_true", help="Output long format of version string")
+    args = parser.parse_args()
+
+    # default parameter to GetVersion functions
+    self_path, _ = os.path.split(os.path.realpath(__file__))
+    version_file = os.path.join(self_path, '../version.txt')
+
+    version = ""
+    if args.long:
+        version = GetLongVersion(version_file)
+    else:
+        version = GetVersion(version_file)
+
+    print version
+
+if __name__ == "__main__":
+    main()

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -67,17 +67,6 @@ def _GitGeneratedLongVersion():
     return '-'.join([base, patch])
 
 
-def _GetRepository():
-    """Get a reference to the Git Repository.
-    Is there a cleaner option than searching from the current location?"""
-    # The syntax is different between library versions (particularly,
-    # those used by Centos 6 vs Centos 7).
-    try:
-        return git.Repo('.', search_parent_directories=True)
-    except TypeError:
-        return git.Repo('.')
- 
-
 def _GetCommitRawDescription():
     """Returns description of current commit"""
     repo = _GetRepository()
@@ -139,6 +128,17 @@ def _CheckGitAvailable():
     
     return True
 
+
+def _GetRepository():
+    """Get a reference to the Git Repository.
+    Is there a cleaner option than searching from the current location?"""
+    # The syntax is different between library versions (particularly,
+    # those used by Centos 6 vs Centos 7).
+    try:
+        return git.Repo('.', search_parent_directories=True)
+    except TypeError:
+        return git.Repo('.')
+ 
 
 def _CheckDirtyRepository():
     """Check to see if the repository is not in a cleanly committed state."""

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -154,6 +154,7 @@ def _ParseRawVersionString(raw):
     components['patch'] = int(patchComponents[0])
     if (len(patchComponents) < 2):
         components['patchType'] = "alpha"
+        components['patch'] = -1
     else:
         components['patchType'] = patchComponents[1]
         

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -21,12 +21,12 @@ central place and reuse it in all SConscripts as much as possible.
 """
 
 import errno
-import git
 import os
 import os.path
 import sys
 import time
 from datetime import datetime
+from getversion import GetVersion, GetLongVersion
 import SCons
 from SCons.Environment import Environment
 
@@ -234,149 +234,6 @@ def EmitLongVersionFunc(target, backupFile, label):
 
 def EmitLongVersionStrfunc(target, backupFile, label):
   return 'EmitLongVersion(%s, %s, %s)' % (target, backupFile, label)
-  
-
-def GetLongVersion(backupFile, label=''):
-  """Create a detailed version string based on the state of
-     the software, as it exists in the repository."""
- 
-  if CheckGitAvailable():
-    ret = GitGeneratedLongVersion()
-
-  # Without git, must use the backup file to create a string.
-  else:
-    base = ReadBackupVersionFile(backupFile)
-    date = datetime.utcnow().strftime("%Y%m%d%H%M")
-    ret = '-'.join([base, date])
-
-  # Append the label, if there is one.
-  if len(label):
-    ret = '.'.join([ret, label])
-
-  return ret
-
-
-def GetVersion(backupFile, label=''):
-  """As getLongVersion(), but only return the leading *.*.* value."""
-
-  raw = GetLongVersion(backupFile, label)
-  final = raw.split("-")[0]
-
-  return final
-
-
-def GetRepository():
-    """Get a reference to the Git Repository.
-    Is there a cleaner option than searching from the current location?"""
-
-    # The syntax is different between library versions (particularly,
-    # those used by Centos 6 vs Centos 7).
-    try:
-        return git.Repo('.', search_parent_directories=True)
-    except TypeError:
-        return git.Repo('.')
- 
-
-def CheckGitAvailable():
-    """Try the most basic of git commands, to see if there is
-       currently any access to a repository."""
-    
-    try:
-        repo = GetRepository()
-    except git.exc.InvalidGitRepositoryError:
-        return False
-    
-    return True
-
-
-def CheckDirtyRepository():
-    """Check to see if the repository is not in a cleanly committed state."""
-
-    repo = GetRepository()
-    str = repo.git.status("--porcelain")
-    
-    # Ignore version.txt for this purpose, as a build may modify the file
-    # and lead to an erroneous interpretation on repeated consecutive builds.
-    if (str == " M earth_enterprise/src/version.txt\n"):
-        return False
-    
-    return (len(str) > 0)
-    
-
-def ReadBackupVersionFile(target):
-  """There should be a file checked in with the latest version
-     information available; if git isn't available to provide
-     information, then use this file instead."""
-
-  with open(target, 'r') as fp:
-    line = fp.readline()
-
-  return line
-
-def GitGeneratedLongVersion():
-    """Take the raw information parsed by git, and use it to
-       generate an appropriate version string for GEE."""
-
-    repo = GetRepository()
-    raw = repo.git.describe('--tags', '--match', '[0-9]*\.[0-9]*\.[0-9]*\-*')
-    raw = raw.rstrip()
-
-    # Grab the datestamp.
-    date = datetime.utcnow().strftime("%Y%m%d%H%M")
-
-    # If this condition hits, then we are currently on a tagged commit.
-    if (len(raw.split("-")) < 4):
-        if CheckDirtyRepository():
-            return '.'.join([raw, date])
-        return raw
-
-    # Tear apart the information in the version string.
-    components = ParseRawVersionString(raw)
-  
-    # Determine how to update, since we are *not* on tagged commit.
-    if components['isFinal']:
-        components['patch'] = 0
-        components['patchType'] = "alpha"
-        components['revision'] = components['revision'] + 1
-    else:
-        components['patch'] = components['patch'] + 1
-    
-    # Rebuild.
-    base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
-    patch = '.'.join([str(components["patch"]), components["patchType"], date])
-    if not CheckDirtyRepository():
-        patch = '.'.join([patch, components['hash']])
-    
-    return '-'.join([base, patch])
-
-
-def ParseRawVersionString(raw):
-    """Break apart a raw version string into its various components,
-    and return those entries via a dictionary."""
-
-    components = { }    
-    rawComponents = raw.split("-")
-    
-    base = rawComponents[0]
-    patchRaw = rawComponents[1]
-    components['numCommits'] = rawComponents[2]
-    components['hash'] = rawComponents[3]
-    components['isFinal'] = ((patchRaw[-5:] == "final") or
-                             (patchRaw[-7:] == "release"))
-  
-    baseComponents = base.split(".")
-    components['major'] = int(baseComponents[0])
-    components['minor'] = int(baseComponents[1])
-    components['revision'] = int(baseComponents[2])
-  
-    patchComponents = patchRaw.split(".")
-    components['patch'] = int(patchComponents[0])
-    if (len(patchComponents) < 2):
-        components['patchType'] = "alpha"
-    else:
-        components['patchType'] = patchComponents[1]
-        
-    return components
   
 
 # our derived class


### PR DESCRIPTION
Parallel development of a release branch and a future release are now possible on the earthenterprise repo.

Steps to enable alpha release development:
1. Create a branch for the current release (i.e. release_5.2.4):

```
git checkout master
git checkout -b release_5.2.4

```

2. On the master branch, add an empty commit and tag it using Major.Minor.Release-Patch format (i.e. 5.2.5-0):

```
git checkout master
git commit --allow-empty -m"5.2.5-0 commit for tag"
```

That's it.  The next commit to master will produce the version 5.2.5-0.alpha, and commits on the release_5.2.4 branch will continue on the 5.2.4 version sequence.


The script earthenterprise/earth_enterprise/src/scons/getversion.py generates the version string, and can be run independently:

# long version (5.2.5-0.alpha.timestamp.hash)
earthenterprise/earth_enterprise/src/scons/getversion.py --long

# short version (5.2.5)
earthenterprise/earth_enterprise/src/scons/getversion.py
