### PR TITLE
#1011 Remove unused variable warning

### DIFF
--- a/earth_enterprise/src/fusion/gst/maprender/SGLHelps.cpp
+++ b/earth_enterprise/src/fusion/gst/maprender/SGLHelps.cpp
@@ -24,9 +24,6 @@
 #include "fusion/autoingest/.idl/storage/MapSubLayerConfig.h"
 
 
-__SK_FORCE_IMAGE_DECODER_LINKING;
-
-
 SkColor SkColorFromQColor(const QColor &color) {
   QRgb rgb = color.rgb();
   return SkColorSetARGB(qAlpha(rgb), qRed(rgb), qGreen(rgb), qBlue(rgb));
@@ -156,3 +153,7 @@ bool FontInfo::CheckTextStyleSanity(MapTextStyleConfig* config,
 
 }  // namespace maprender
 
+// Always leave these two lines last, otherwise it will
+// silence unused variables from the code below.
+#pragma GCC diagnostic ignored "-Wunused-variable"
+__SK_FORCE_IMAGE_DECODER_LINKING;


### PR DESCRIPTION
#1011
Silence error coming from SGLHelps.cpp. linking_forced variable included with #include <SKForceLinking.h> in SGLHelps.cpp is not referenced thus causing an "unused-variable" warning. The warning is treated as en error when building with gcc 5.5.0.

To verify:

build open on Ubuntu using gcc 5.5.0 and make sure that build succeeds.