### PR TITLE
Fixes #1004: don't read version file for tasks that don't need version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ earth_enterprise/tutorial/FusionTutorial/KML
 /*.files
 /*.includes
 
+.vscode/

--- a/earth_enterprise/.gitignore
+++ b/earth_enterprise/.gitignore
@@ -5,9 +5,6 @@
 /*.files
 /*.includes
 
-# vs code files
-/*.vscode
-
 # compiled python
 /**/*.pyc
 

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -81,6 +81,9 @@ else if ( project.hasProperty( 'debug' ) || project.hasProperty( 'internal' ) ) 
     scons_option = "internal=1"
 }
 
+//  define a group name for user facing packaging tasks
+def PACKAGE_GROUP = 'Packaging'
+
 // Build the actual file to be used
 def gee_long_version_txt = "${stagedInstall_path}/gee_long_version.txt"
 
@@ -88,34 +91,6 @@ def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
 
 // Create a file handle for gee_long_version_txt
 def openGeeVersionFile = new File( gee_long_version_txt )
-
-// Call scons to create the file 'gee_long_version.txt'
-// The actual parameter used by scons is based on the parameter
-// passing into Gradlew
-if ( !openGeeVersionFile.exists() ) {
-    GeeCommandLine.expand(
-      ["/usr/bin/scons", scons_option, gee_long_version_txt ],
-      "Runing `scons` to produce <${gee_long_version_txt}> failed!",
-      null, // Use default environment variables.
-      new File( src_dir )
-    )
-}
-
-def openGeeVersion =
-    openGeeVersionFile.readLines().
-    collect {
-        // Strip comments:
-        def commentIndex = it.indexOf('#')
-
-        commentIndex < 0 ? it : it.substring(0, commentIndex)
-    }.
-    collect { it.trim() }. // Trim whitespace.
-    findAll { !it.isEmpty() }. // Skip empty lines.
-    findResult {
-        it // The first string that remains is the version string.
-    }.
-    replaceAll(/-.*release/, '').
-    replaceAll('-', '.')
 
 def stagedInstallDir = new File(stagedInstall_path)
 def stagedInstallDir_common = new File(stagedInstallDir, 'common')
@@ -186,10 +161,8 @@ def rpmCommandFilter = {
     return rpmCapabilityMap.containsKey(it) ? rpmCapabilityMap[it] : it
 }
 
-
-
 ospackage {
-    version = openGeeVersion
+    version = "<version unset>"
     release = "1.${rpmPlatformString}"
     distribution = rpmPlatformString
     packager = 'gee-oss@googlegroups.com'
@@ -198,6 +171,29 @@ ospackage {
     os = LINUX
 }
 
+task setGeeVersion {
+    doLast {
+        // if the version file does not exist raise an error
+        if ( !openGeeVersionFile.exists() ) { // src_dir
+            throw new GradleException("Missing version file '${openGeeVersionFile}'.")
+        }
+        ospackage.version =
+            openGeeVersionFile.readLines().
+            collect {
+                // Strip comments:
+                def commentIndex = it.indexOf('#')
+
+                commentIndex < 0 ? it : it.substring(0, commentIndex)
+            }.
+            collect { it.trim() }. // Trim whitespace.
+            findAll { !it.isEmpty() }. // Skip empty lines.
+            findResult {
+                it // The first string that remains is the version string.
+            }.
+            replaceAll(/-.*release/, '').
+            replaceAll('-', '.')
+    }
+}
 
 // Build packages for all platforms by default:
 defaultTasks 'osPackage'
@@ -219,7 +215,17 @@ task stageOpenGeeInstall(type: Exec, dependsOn: 'compileOpenGee') {
         "installdir=${stagedInstallDir}")
 }
 
-task openGeePostGisRpm(type: GeeRpm) {
+if (project.hasProperty('buildOpenGee')) {
+    setGeeVersion.dependsOn stageOpenGeeInstall
+}
+else {
+    setGeeVersion.mustRunAfter stageOpenGeeInstall
+}
+
+task openGeePostGisRpm(type: GeeRpm, dependsOn: [setGeeVersion]) {
+    doFirst {
+        requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    }
     packageName = 'opengee-postgis'
     release = "1.${rpmPlatformString}"
     version = '2.3.4'
@@ -233,7 +239,6 @@ task openGeePostGisRpm(type: GeeRpm) {
     type = BINARY
     autoFindProvides = true
     autoFindRequires = true
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
 
     from (stagedInstallDir_postgis_opt) {
         into new File(packageInstallRootDir, 'opt')
@@ -250,11 +255,14 @@ task openGeePostGisRpm(type: GeeRpm) {
 if (project.hasProperty('buildOpenGee')) {
     openGeePostGisRpm.dependsOn stageOpenGeeInstall
 }
+else {
+    openGeePostGisRpm.mustRunAfter stageOpenGeeInstall
+}
 
 // Expands the `gevars.sh.template` and any other templates so they can be
 // used in the `common` package, and prefixed to install scripts for all the
 // various packages.
-task openGeeSharedFiles(type: Copy) {
+task openGeeSharedFiles(type: Copy, dependsOn: [setGeeVersion]) {
     from file('shared')
     into file('build/shared')
 
@@ -271,7 +279,7 @@ task openGeeSharedFiles(type: Copy) {
             def templateDir = it.file.parent
 
             def templateVariables = [
-                'openGeeVersion': openGeeVersion
+                'openGeeVersion': ospackage.version
             ]
 
             def expandTemplate = { text_or_file ->
@@ -293,10 +301,13 @@ task openGeeSharedFiles(type: Copy) {
     }
 }
 
-task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
+task openGeeCommonRpm(type: GeeRpm, dependsOn: [openGeeSharedFiles, setGeeVersion]) {
+    doFirst{
+        println "Setting version for GEE common RPM to ${ospackage.version}"
+        version = ospackage.version
+    }
     packageName = 'opengee-common'
     release = "1.${rpmPlatformString}"
-    version = openGeeVersion
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -387,11 +398,17 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeSharedFiles) {
 if (project.hasProperty('buildOpenGee')) {
     openGeeCommonRpm.dependsOn stageOpenGeeInstall
 }
+else {
+    openGeeCommonRpm.mustRunAfter stageOpenGeeInstall
+}
 
-task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
+task openGeeCommonDeb (type: GeeDeb, dependsOn: [openGeeSharedFiles, setGeeVersion]) {
+    doFirst {
+        println "Setting version for GEE common DEB to ${ospackage.version}"
+        version = ospackage.version
+    }
     packageName = openGeeCommonRpm.packageName
     release = openGeeCommonRpm.release
-    version = openGeeVersion
     user = openGeeCommonRpm.user
     permissionGroup = openGeeCommonRpm.permissionGroup
     packageGroup = 'misc'
@@ -447,12 +464,19 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeSharedFiles) {
 if (project.hasProperty('buildOpenGee')) {
     openGeeCommonDeb.dependsOn stageOpenGeeInstall
 }
+else {
+    openGeeCommonDeb.mustRunAfter stageOpenGeeInstall
+}
 
-task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
+task openGeeServerRpm (type: GeeRpm, dependsOn: [openGeeSharedFiles, setGeeVersion]) {
+    doFirst{
+        println "Setting version for GEE server RPM to ${ospackage.version}"
+        version = ospackage.version
+        requires('opengee-common', ospackage.version, GREATER | EQUAL)
+        requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
+    }
     packageName = 'opengee-server'
     release = "1.${rpmPlatformString}"
-    version = openGeeVersion
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -467,8 +491,6 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     requires('opengee-postgis', '2.3.4', GREATER | EQUAL)
     conflicts('opengee-postgis', '2.0', LESS )
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
-    requiresPre('opengee-common', openGeeVersion, GREATER | EQUAL)
     // `opengee-server` bundles Apache, and Apache requires utilities from the
     // `initscripts` package:
     requires('initscripts')
@@ -554,10 +576,19 @@ task openGeeServerRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
     link('/opt/google/gehttpd/htdocs/shared_assets/docs', '/opt/google/share/doc')
 }
 
-task openGeeServerDeb (type: Deb) {
-    packageName = 'opengee-server'
+if (project.hasProperty('buildOpenGee')) {
+    openGeeServerRpm.dependsOn stageOpenGeeInstall
+}
+else {
+    openGeeServerRpm.mustRunAfter stageOpenGeeInstall
+}
 
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
+task openGeeServerDeb (type: Deb, dependsOn: [setGeeVersion]) {
+    doFirst {
+        println "Setting version for GEE server DEB to ${ospackage.version}"
+        requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    }
+    packageName = 'opengee-server'
 
     from(stagedInstallDir_server_etc) {
         into new File(packageInstallRootDir, 'etc')
@@ -572,10 +603,21 @@ task openGeeServerDeb (type: Deb) {
     }
 }
 
-task openGeeFusionRpm (type: GeeRpm, dependsOn: openGeeSharedFiles) {
+if (project.hasProperty('buildOpenGee')) {
+    openGeeServerDeb.dependsOn stageOpenGeeInstall
+}
+else {
+    openGeeServerDeb.mustRunAfter stageOpenGeeInstall
+}
+
+task openGeeFusionRpm (type: GeeRpm, dependsOn: [openGeeSharedFiles, setGeeVersion]) {
+    doFirst{
+        println "Setting version for GEE fusion RPM to ${ospackage.version}"
+        version = ospackage.version
+        requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    }
     packageName = 'opengee-fusion'
     release = "1.${rpmPlatformString}"
-    version = openGeeVersion
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -593,8 +635,6 @@ built from raster, vector, and location properties data.
     autoFindRequires = true
 
     requires('proj-devel') /* This dependency is not being picked up automatically by GeeRpm task */
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
-
 
     requiresCommands(
         packageSharedCommands +
@@ -656,7 +696,7 @@ built from raster, vector, and location properties data.
                 def templateDir = it.file.parent
 
                 def templateVariables = [
-                    'openGeeVersion': openGeeVersion
+                    'openGeeVersion': ospackage.version
                 ]
 
                 def expandTemplate = { text_or_file ->
@@ -685,13 +725,30 @@ built from raster, vector, and location properties data.
     link('/opt/google/gehttpd/htdocs/shared_assets/docs', '/opt/google/share/doc')
 }
 
-task openGeeFusionDeb (type: Deb) {
+if (project.hasProperty('buildOpenGee')) {
+    openGeeFusionRpm.dependsOn stageOpenGeeInstall
+}
+else {
+    openGeeFusionRpm.mustRunAfter stageOpenGeeInstall
+}
+
+task openGeeFusionDeb (type: Deb, dependsOn: [setGeeVersion]) {
+    doFirst{
+        println "Setting version for GEE fusion DEB to ${ospackage.version}"
+        requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    }
     packageName = 'opengee-fusion'
-    requires('opengee-common', openGeeVersion, GREATER | EQUAL)
 
     from(stagedInstallDir_fusion) {
         into packageInstallRootDir
     }
+}
+
+if (project.hasProperty('buildOpenGee')) {
+    openGeeFusionDeb.dependsOn stageOpenGeeInstall
+}
+else {
+    openGeeFusionDeb.mustRunAfter stageOpenGeeInstall
 }
 
 task openGeeRpms(
@@ -704,6 +761,9 @@ task openGeeDebs(
     dependsOn: ['openGeeServerDeb', 'openGeeFusionDeb', 'openGeeCommonDeb'])
 
 task osPackage(dependsOn: org.opengee.os.Platform.osId == 'ubuntu' ? openGeeDebs : openGeeRpms)
+
+osPackage.group = PACKAGE_GROUP
+osPackage.description = "Build packages from staged install based on current OS"
 
 // Mostly for documentation purposes.  You need to comment out the rest of the
 // Gradle file to run this task:

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# This file is 'earth_enterprise/scr/SConstruct'
+# This file is 'earth_enterprise/src/SConstruct'
 
 
 """Top level SConstruct file."""

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+import os
+import argparse
+import git
+from datetime import datetime
+
+def GetVersion(backupFile, label=''):
+    """As getLongVersion(), but only return the leading *.*.* value."""
+
+    raw = GetLongVersion(backupFile, label)
+    final = raw.split("-")[0]
+
+    return final
+
+
+def GetLongVersion(backupFile, label=''):
+    """Create a detailed version string based on the state of
+    the software, as it exists in the repository."""
+ 
+    if _CheckGitAvailable():
+        ret = _GitGeneratedLongVersion()
+
+  # Without git, must use the backup file to create a string.
+    else:
+        base = _ReadBackupVersionFile(backupFile)
+        ret = '-'.join([base, _GetDateString()])
+
+  # Append the label, if there is one.
+    if len(label):
+        ret = '.'.join([ret, label])
+
+    return ret
+
+
+def _GitGeneratedLongVersion():
+    """Take the raw information parsed by git, and use it to
+       generate an appropriate version string for GEE."""
+
+    raw = _GetCommitRawDescription()
+
+    # For tagged commits, return the tag itself
+    if _IsCurrentCommitTagged(raw):
+        return _VersionForTaggedHead(raw)
+    else:
+        return _VersionFromTagHistory(raw)
+
+
+def _GetCommitRawDescription():
+    """Returns description of current commit"""
+    repo = _GetRepository()
+    raw = repo.git.describe('--first-parent', '--tags', '--match', '[0-9]*\.[0-9]*\.[0-9]*\-*')
+    raw = raw.rstrip()
+    return raw
+
+
+def _IsCurrentCommitTagged(raw):
+    """True if the current commit is tagged, otherwise False"""
+    # If this condition hits, then we are currently on a tagged commit.
+    return (len(raw.split("-")) < 4)
+
+
+def _VersionForTaggedHead(raw):
+    """When we're on the tagged commit, the version string is
+    either the tag itself (when repo is clean), or the tag with
+    date appended (when repo has uncommitted changes)"""
+    if _CheckDirtyRepository():
+        # Append the date if the repo contains uncommitted files
+        return '.'.join([raw, _GetDateString()])
+    return raw
+
+
+def _VersionFromTagHistory(raw):
+    """From the HEAD revision, this function finds the most recent
+    reachable version tag and returns a string representing the
+    version being built -- which is one version beyond the latest
+    found in the history."""
+
+    # Tear apart the information in the version string.
+    components = _ParseRawVersionString(raw)
+
+    # Determine how to update, since we are *not* on tagged commit.
+    if components['isFinal']:
+        components['patch'] = 0
+        components['patchType'] = "alpha"
+        components['revision'] = components['revision'] + 1
+    else:
+        components['patch'] = components['patch'] + 1
+    
+    # Rebuild.
+    base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
+    patch = '.'.join([str(components["patch"]), components["patchType"], _GetDateString()])
+    if not _CheckDirtyRepository():
+        patch = '.'.join([patch, components['hash']])
+    
+    return '-'.join([base, patch])
+
+
+def _ParseRawVersionString(raw):
+    """Break apart a raw version string into its various components,
+    and return those entries via a dictionary."""
+
+    components = { }
+
+    # major.minor.revision-patch[.patchType][-commits][-hash]    
+    rawComponents = raw.split("-")
+    
+    base = rawComponents[0]
+    patchRaw = '' if not len(rawComponents) > 1 else rawComponents[1]
+    components['commits'] = -1 if not len(rawComponents) > 2 else rawComponents[2]
+    components['hash'] = None if not len(rawComponents) > 3 else rawComponents[3]
+
+    # Primary version (major.minor.revision)
+    baseComponents = base.split(".")
+    components['major'] = int(baseComponents[0])
+    components['minor'] = int(baseComponents[1])
+    components['revision'] = int(baseComponents[2])
+ 
+    # Patch (patch[.patchType])
+    components['isFinal'] = ((patchRaw[-5:] == "final") or
+                             (patchRaw[-7:] == "release"))
+  
+    patchComponents = patchRaw.split(".")
+    components['patch'] = int(patchComponents[0])
+    components['patchType'] = 'alpha' if not len(patchComponents) > 1 else patchComponents[1]
+    
+    repo = _GetRepository()
+    return components
+
+
+def _CheckGitAvailable():
+    """Try the most basic of git commands, to see if there is
+       currently any access to a repository."""
+    try:
+        repo = _GetRepository()
+    except git.exc.InvalidGitRepositoryError:
+        return False
+    
+    return True
+
+
+def _GetRepository():
+    """Get a reference to the Git Repository.
+    Is there a cleaner option than searching from the current location?"""
+    # The syntax is different between library versions (particularly,
+    # those used by Centos 6 vs Centos 7).
+    try:
+        return git.Repo('.', search_parent_directories=True)
+    except TypeError:
+        return git.Repo('.')
+ 
+
+def _CheckDirtyRepository():
+    """Check to see if the repository is not in a cleanly committed state."""
+    repo = _GetRepository()
+    str = repo.git.status("--porcelain")
+    
+    return (len(str) > 0)
+
+
+def _ReadBackupVersionFile(target):
+    """There should be a file checked in with the latest version
+    information available; if git isn't available to provide
+    information, then use this file instead."""
+
+    with open(target, 'r') as fp:
+        line = fp.readline()
+
+    return line
+
+
+def _GetDateString():
+    """Returns formatted date string representing current UTC time"""
+    return datetime.utcnow().strftime("%Y%m%d%H%M")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-l", "--long", action="store_true", help="Output long format of version string")
+    args = parser.parse_args()
+
+    # default parameter to GetVersion functions
+    self_path, _ = os.path.split(os.path.realpath(__file__))
+    version_file = os.path.join(self_path, '../version.txt')
+
+    version = ""
+    if args.long:
+        version = GetLongVersion(version_file)
+    else:
+        version = GetVersion(version_file)
+
+    print version
+
+
+if __name__ == "__main__":
+    main()

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -21,12 +21,12 @@ central place and reuse it in all SConscripts as much as possible.
 """
 
 import errno
-import git
 import os
 import os.path
 import sys
 import time
 from datetime import datetime
+from getversion import GetVersion, GetLongVersion
 import SCons
 from SCons.Environment import Environment
 
@@ -234,149 +234,6 @@ def EmitLongVersionFunc(target, backupFile, label):
 
 def EmitLongVersionStrfunc(target, backupFile, label):
   return 'EmitLongVersion(%s, %s, %s)' % (target, backupFile, label)
-  
-
-def GetLongVersion(backupFile, label=''):
-  """Create a detailed version string based on the state of
-     the software, as it exists in the repository."""
- 
-  if CheckGitAvailable():
-    ret = GitGeneratedLongVersion()
-
-  # Without git, must use the backup file to create a string.
-  else:
-    base = ReadBackupVersionFile(backupFile)
-    date = datetime.utcnow().strftime("%Y%m%d%H%M")
-    ret = '-'.join([base, date])
-
-  # Append the label, if there is one.
-  if len(label):
-    ret = '.'.join([ret, label])
-
-  return ret
-
-
-def GetVersion(backupFile, label=''):
-  """As getLongVersion(), but only return the leading *.*.* value."""
-
-  raw = GetLongVersion(backupFile, label)
-  final = raw.split("-")[0]
-
-  return final
-
-
-def GetRepository():
-    """Get a reference to the Git Repository.
-    Is there a cleaner option than searching from the current location?"""
-
-    # The syntax is different between library versions (particularly,
-    # those used by Centos 6 vs Centos 7).
-    try:
-        return git.Repo('.', search_parent_directories=True)
-    except TypeError:
-        return git.Repo('.')
- 
-
-def CheckGitAvailable():
-    """Try the most basic of git commands, to see if there is
-       currently any access to a repository."""
-    
-    try:
-        repo = GetRepository()
-    except git.exc.InvalidGitRepositoryError:
-        return False
-    
-    return True
-
-
-def CheckDirtyRepository():
-    """Check to see if the repository is not in a cleanly committed state."""
-
-    repo = GetRepository()
-    str = repo.git.status("--porcelain")
-    
-    # Ignore version.txt for this purpose, as a build may modify the file
-    # and lead to an erroneous interpretation on repeated consecutive builds.
-    if (str == " M earth_enterprise/src/version.txt\n"):
-        return False
-    
-    return (len(str) > 0)
-    
-
-def ReadBackupVersionFile(target):
-  """There should be a file checked in with the latest version
-     information available; if git isn't available to provide
-     information, then use this file instead."""
-
-  with open(target, 'r') as fp:
-    line = fp.readline()
-
-  return line
-
-def GitGeneratedLongVersion():
-    """Take the raw information parsed by git, and use it to
-       generate an appropriate version string for GEE."""
-
-    repo = GetRepository()
-    raw = repo.git.describe('--tags', '--match', '[0-9]*\.[0-9]*\.[0-9]*\-*')
-    raw = raw.rstrip()
-
-    # Grab the datestamp.
-    date = datetime.utcnow().strftime("%Y%m%d%H%M")
-
-    # If this condition hits, then we are currently on a tagged commit.
-    if (len(raw.split("-")) < 4):
-        if CheckDirtyRepository():
-            return '.'.join([raw, date])
-        return raw
-
-    # Tear apart the information in the version string.
-    components = ParseRawVersionString(raw)
-  
-    # Determine how to update, since we are *not* on tagged commit.
-    if components['isFinal']:
-        components['patch'] = 0
-        components['patchType'] = "alpha"
-        components['revision'] = components['revision'] + 1
-    else:
-        components['patch'] = components['patch'] + 1
-    
-    # Rebuild.
-    base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
-    patch = '.'.join([str(components["patch"]), components["patchType"], date])
-    if not CheckDirtyRepository():
-        patch = '.'.join([patch, components['hash']])
-    
-    return '-'.join([base, patch])
-
-
-def ParseRawVersionString(raw):
-    """Break apart a raw version string into its various components,
-    and return those entries via a dictionary."""
-
-    components = { }    
-    rawComponents = raw.split("-")
-    
-    base = rawComponents[0]
-    patchRaw = rawComponents[1]
-    components['numCommits'] = rawComponents[2]
-    components['hash'] = rawComponents[3]
-    components['isFinal'] = ((patchRaw[-5:] == "final") or
-                             (patchRaw[-7:] == "release"))
-  
-    baseComponents = base.split(".")
-    components['major'] = int(baseComponents[0])
-    components['minor'] = int(baseComponents[1])
-    components['revision'] = int(baseComponents[2])
-  
-    patchComponents = patchRaw.split(".")
-    components['patch'] = int(patchComponents[0])
-    if (len(patchComponents) < 2):
-        components['patchType'] = "alpha"
-    else:
-        components['patchType'] = patchComponents[1]
-        
-    return components
   
 
 # our derived class


### PR DESCRIPTION
…d it (#1005)

* don't read version file for tasks that don't need to read it

* added mustRunAfter to each of the packaging tasks and added visibility to the 'osPackage' task when 'gradle tasks' is run.