### PR TITLE
Issue #1033: Don't handle SIGTERM/SIGINT

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/khSystemManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khSystemManager.cpp
@@ -95,8 +95,18 @@ void handleExitSignals(int signum)
 void
 khSystemManager::SignalLoop(void)
 {
-  signal(SIGINT,handleExitSignals);
-  signal(SIGTERM,handleExitSignals);
+  // In Fusion versions 5.2.3 and earlier there was code to handle SIGTERM and
+  // SIGINT, but this code was not called when the relevant signals were sent
+  // to system manager. We fixed this in 5.2.4 with the unexpected side effect
+  // that gesystemmanager may not stop when the user runs
+  // "/etc/init.d/gefusion stop". Instead, gesystemmanager will catch the
+  // SIGTERM and wait until it finishes the current operation before stopping,
+  // which could take days. As a stopgap, we are reverting to the behavior
+  // from 5.2.3 and not handling SIGINT and SIGTERM. In 5.2.5 we will revisit
+  // this and implement better methods of starting and stopping system manager.
+  // At that point, the two lines below can be uncommented.
+  //signal(SIGINT,handleExitSignals);
+  //signal(SIGTERM,handleExitSignals);
   signal(SIGHUP,systemrc_reload);
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khSystemManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khSystemManager.cpp
@@ -76,7 +76,7 @@ khSystemManager::SetWantExit(void)
 // when SIGHUP is given, reload systemrc
 void systemrc_reload(int signum)
 {
-    notify(NFY_WARN, "Recieved SIGHUP, Reloading systemrc...");
+    notify(NFY_WARN, "Received SIGHUP, Reloading systemrc...");
     Systemrc systemrc;
     LoadSystemrc(systemrc,true);
     uint32 logLevel = systemrc.logLevel;
@@ -87,7 +87,7 @@ void systemrc_reload(int signum)
 
 void handleExitSignals(int signum)
 {
-    notify(NFY_WARN, "Recieved SIGINT or SIGTERM, Exiting...");
+    notify(NFY_WARN, "Received SIGINT or SIGTERM, Exiting...");
     theSystemManager.SetWantExit();
 }
 


### PR DESCRIPTION
Fixes #1033. For details, see that ticket.

To test:
1. Add a long sleep command to BuildAsset in earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp.
1. Start building an asset.
1. Run `/etc/init.d/gefusion stop` before the sleep command in step 1 finishes.
1. Run `ps aux | grep gesystemmanager` and verify that gesystemmanager is not running.
1. Run `/etc/init.d/gefusion start` and `/etc/init.d/gefusion reload`. Check the bottom of /opt/google/log/gesystemmanager.log and verify that a message similar to the one below appears at the bottom of the log:
```
[2018-10-01 10:25:50] Warning: Recieved SIGHUP, Reloading systemrc...
[2018-10-01 10:25:50] Warning: system log level changed to: NFY_<some notification level>
```
