### PR TITLE
Issue #622 Change default API behavior

### DIFF
--- a/docs/geedocs/5.2.5/answer/1089795.html
+++ b/docs/geedocs/5.2.5/answer/1089795.html
@@ -56,6 +56,13 @@ var painted_map_layer = new GFusionTileLayer(geeServerDefs.serverUrl, geeServerD
 var labels_layer = new GFusionTileLayer(geeServerDefs.serverUrl, geeServerDefs.layers[2]);</code></p>
 <p>You can access the server definitions and other information about map and imagery layers directly from a web browser by using a URL in this format: <code>http://yourserver.org/virtual-server-name/query?request=Json&amp;vars=geeServerDefs</code>. Responses will look like the image below:</p>
 <p><img alt="GEE server definitions" src="../art/fusion/projects/2972270_server_definitions.jpg"/></p>
+<p>This data can also be returned by using the optional <code>v</code> parameter.o</p>
+<ul>
+<li><code>v=1</code> returns the data in the format shown in the image above.</li>
+<li><code>v=2</code> returns the data in the JSON format.</li>
+<li> A query without the <code>v</code> parameter acts as <code>v=1</code>.</li>
+</ul>
+<p>A example of a query using the <code>v</code> parameter: <code>http://&lt;GEE earth server&gt;/&lt;database_publish_point&gt;/query?request=Json&amp;v=2</code>
 </li>
 <li>Associate layers with buttons by using the <code>GMapType</code> class to define a map type for each of the <code>GTileLayer</code> objects. See the example below:
 <p><code>var painted_map_type = new GMapType([painted_map_layer],new LatLngProjection(MAX_ZOOM_LEVEL),"Maps");<br/>

--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -43,8 +43,7 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5.2.5">New Features</p>
   </h5>
-    <p><strong>C++98 no longer supported</strong>. As of 5.2.4 C++11 syntax can be used and building open GEE using C++98 standard will no longer be supported</p>
-
+  <p><strong>When a GEE server is queried for server definitions the response can be returned in proper JSON format.</strong> The <code>v</code> parameter can be added to query string to specify which version of the API will be returned. The valid options are <code>v=1</code> and <code>v=2</code>. Version one returns data in the current format. Version two returns data in JSON format. An example url which returns data in JSON format looks like: <code>http://&lt;GEE earth server&gt;/&lt;database_publish_point&gt;/query?request=Json&amp;v=2</code>.</p>
   <h5>
     <p id="supported_5.2.5">Supported Platforms</p>
   </h5>

--- a/earth_enterprise/src/common/serverdb/serverdbReader.h
+++ b/earth_enterprise/src/common/serverdb/serverdbReader.h
@@ -24,7 +24,6 @@
 #include "common/serverdb/serverdb.h"
 #include "common/serverdb/map_tile_utils.h"
 
-
 class ServerdbReader {
  public:
   typedef geindex::UnifiedReader::ReadBuffer ReadBuffer;

--- a/earth_enterprise/src/common/serverdb/serverdbReader.h
+++ b/earth_enterprise/src/common/serverdb/serverdbReader.h
@@ -24,6 +24,7 @@
 #include "common/serverdb/serverdb.h"
 #include "common/serverdb/map_tile_utils.h"
 
+
 class ServerdbReader {
  public:
   typedef geindex::UnifiedReader::ReadBuffer ReadBuffer;
@@ -115,6 +116,11 @@ class ServerdbReader {
                const std::string& language,
                const std::string& region,
                ReadBuffer& buf);
+  //
+  void GetJsonV1(const std::string& json_variable_name,
+                 const std::string& language,
+                 const std::string& region,
+                 ReadBuffer& buf);
   void GetIcon(const std::string& icon_path, ReadBuffer& buf,
                const bool size_only);
 


### PR DESCRIPTION
Fixes #622

This PR includes: changing the default behavior when requesting json data for any given map and allows users to specify "v=1" in the query string to retrieve the data in the previous format.

I choose to split the versions into different files so that it is simple to remove the older (V1) logic and easier to maintain the new logic. 

Currently the code (dbmanifest.cpp 972...) allowing users to specify which version they want to use is not working and only the new format is being served.