### PR TITLE
Updated manual link to point to 5.2.4 documentation

### DIFF
--- a/earth_enterprise/docs/landing_page/manual
+++ b/earth_enterprise/docs/landing_page/manual
@@ -1,1 +1,1 @@
-../../../docs/geedocs/5.2.3
+../../../docs/geedocs/5.2.4


### PR DESCRIPTION
Fixes #1053 

"manual" symbolic link now points to 5.2.4 documentation.