### PR TITLE
#1058: Added a `long_version` SCons build parameter.

### DIFF
--- a/earth_enterprise/src/SConscript
+++ b/earth_enterprise/src/SConscript
@@ -83,22 +83,25 @@ env.Command(date_file, [env.Value(build_date_str)],
             [env.WriteToFile(date_file, build_date_str)])
 
 # get the build version
-backup_file = File('#version.txt').abspath
+env.get_open_gee_version().backup_file = File('#version.txt').abspath
+env.get_open_gee_version().label = ARGUMENTS.get('label', '')
+if ARGUMENTS.get('long_version'):
+  env.get_open_gee_version().set_long(ARGUMENTS.get('long_version'))
+
 version_file = File('gee_version.txt').abspath
 built_version_file = env.Command(version_file, [ ],
-                      [env.EmitVersion(version_file, backup_file)])
+                      [env.EmitVersion(version_file)])
 env.AlwaysBuild(built_version_file)
 
-label = ARGUMENTS.get('label', '')
 long_version_file = File('gee_long_version.txt').abspath
 built_long_version_file = env.Command(long_version_file, [ ],
-                      [env.EmitLongVersion(long_version_file, backup_file, label)])
+                      [env.EmitLongVersion(long_version_file)])
 env.AlwaysBuild(built_long_version_file)
 env.install('root', long_version_file)
 
 version_header = File('gee_version.h').abspath
 built_version_header = env.Command(version_header, [ ],
-            [env.EmitVersionHeader(version_header, backup_file)])
+            [env.EmitVersionHeader(version_header)])
 env.AlwaysBuild(built_version_header)
 
 env.Alias('version_files', [version_header, long_version_file, version_file])

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -26,7 +26,6 @@ import subprocess
 import sys
 sys.path += ['scons']
 from khEnvironment import khEnvironment
-from khEnvironment import GetVersion
 
 # Add the OpenGEE Python libraries to the module search path:
 opengee_lib_path = os.path.join('lib', 'python')
@@ -86,6 +85,7 @@ ValidOptions = set(
      'log_performance',  # Include code for performance logging
      'cpp_standard',     # The standard of CPP that will be used.  Default is C++11
      'label',            # Value to combine with version strings.
+     'long_version',     # Value to override the Open GEE long version string.
      'build_folder',     # where to put the build output and intermediate files
      'cache_dir',        # use a cache dir to speed up build
      'third_party_only'  # build third party code only
@@ -117,6 +117,7 @@ log_performance = int( ARGUMENTS.get( 'log_performance', 0 ) )
 cpp_standard = ARGUMENTS.get('cpp_standard', 'gnu++11')
 build_folder = ARGUMENTS.get('build_folder', 0)
 label = ARGUMENTS.get('label', '')
+long_version = ARGUMENTS.get('long_version', None)
 
 # make some directory variables used by other parts of the build system
 top_dir = Dir('#').abspath
@@ -410,8 +411,6 @@ installdirs = {
     'htdocs': InstServerDir('gehttpd/htdocs'),
 }
 
-gee_version_number = GetVersion("version.txt", label)
-
 
 # create the environment that controls the builds
 
@@ -467,6 +466,14 @@ env = khEnvironment(
     python_version=python_version,
     python_major_version=python_major_version
 )
+
+env.get_open_gee_version().backup_file = "version.txt"
+env.get_open_gee_version().label = label
+if long_version:
+  env.get_open_gee_version().set_long(long_version)
+gee_version_number = env.get_open_gee_version().get_short()
+
+
 
 # Check if the version of the default compiler is at least 4.8:
 version = opengee.c_compiler.get_cc_version(env['CXX'])

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -4,6 +4,8 @@ import argparse
 import git
 from datetime import datetime
 
+
+
 def GetVersion(backupFile, label=''):
     """As getLongVersion(), but only return the leading *.*.* value."""
 
@@ -16,18 +18,24 @@ def GetVersion(backupFile, label=''):
 def GetLongVersion(backupFile, label=''):
     """Create a detailed version string based on the state of
     the software, as it exists in the repository."""
- 
+
+    if open_gee_version.long_version_string:
+        return open_gee_version.long_version_string
+
     if _CheckGitAvailable():
         ret = _GitGeneratedLongVersion()
 
-  # Without git, must use the backup file to create a string.
+    # Without git, must use the backup file to create a string.
     else:
         base = _ReadBackupVersionFile(backupFile)
         ret = '-'.join([base, _GetDateString()])
 
-  # Append the label, if there is one.
+    # Append the label, if there is one.
     if len(label):
         ret = '.'.join([ret, label])
+
+    # Cache the long version string:
+    open_gee_version.long_version_string = ret
 
     return ret
 
@@ -85,13 +93,13 @@ def _VersionFromTagHistory(raw):
         components['revision'] = components['revision'] + 1
     else:
         components['patch'] = components['patch'] + 1
-    
+
     # Rebuild.
     base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
     patch = '.'.join([str(components["patch"]), components["patchType"], _GetDateString()])
     if not _CheckDirtyRepository():
         patch = '.'.join([patch, components['hash']])
-    
+
     return '-'.join([base, patch])
 
 
@@ -101,9 +109,9 @@ def _ParseRawVersionString(raw):
 
     components = { }
 
-    # major.minor.revision-patch[.patchType][-commits][-hash]    
+    # major.minor.revision-patch[.patchType][-commits][-hash]
     rawComponents = raw.split("-")
-    
+
     base = rawComponents[0]
     patchRaw = '' if not len(rawComponents) > 1 else rawComponents[1]
     components['commits'] = -1 if not len(rawComponents) > 2 else rawComponents[2]
@@ -114,15 +122,15 @@ def _ParseRawVersionString(raw):
     components['major'] = int(baseComponents[0])
     components['minor'] = int(baseComponents[1])
     components['revision'] = int(baseComponents[2])
- 
+
     # Patch (patch[.patchType])
     components['isFinal'] = ((patchRaw[-5:] == "final") or
                              (patchRaw[-7:] == "release"))
-  
+
     patchComponents = patchRaw.split(".")
     components['patch'] = int(patchComponents[0])
     components['patchType'] = 'alpha' if not len(patchComponents) > 1 else patchComponents[1]
-    
+
     repo = _GetRepository()
     return components
 
@@ -134,7 +142,7 @@ def _CheckGitAvailable():
         repo = _GetRepository()
     except git.exc.InvalidGitRepositoryError:
         return False
-    
+
     return True
 
 
@@ -147,13 +155,13 @@ def _GetRepository():
         return git.Repo('.', search_parent_directories=True)
     except TypeError:
         return git.Repo('.')
- 
+
 
 def _CheckDirtyRepository():
     """Check to see if the repository is not in a cleanly committed state."""
     repo = _GetRepository()
     str = repo.git.status("--porcelain")
-    
+
     return (len(str) > 0)
 
 
@@ -172,24 +180,62 @@ def _GetDateString():
     """Returns formatted date string representing current UTC time"""
     return datetime.utcnow().strftime("%Y%m%d%H%M")
 
+class OpenGeeVersion(object):
+    """A class for storing Open GEE version information."""
+
+    def __init__(self):
+        # Cache version strings:
+        self.short_version_string = None
+        self.long_version_string = None
+
+        # Default parameter for GetVersion functions
+        self_path, _ = os.path.split(os.path.realpath(__file__))
+        self.backup_file = os.path.join(self_path, '..', 'version.txt')
+        self.label = ''
+
+    def get_short(self):
+        """Returns the short version string."""
+
+        if not self.short_version_string:
+            self.short_version_string = self.get_long().split("-")[0]
+
+        return self.short_version_string
+
+    def set_short(self, value):
+        """Overrides the short version string by using the given value."""
+
+        self.short_version_string = value
+
+    def get_long(self):
+        """Returns the short version string."""
+
+        if not self.long_version_string:
+            self.long_version_string = GetLongVersion(self.backup_file, self.label)
+
+        return self.long_version_string
+
+    def set_long(self, value):
+        """Overrides the long version string by using the given value.
+        Overriding the long version string would indirectly override the short
+        version string, as well, unless the former is also overridden.
+        """
+
+        self.long_version_string = value
+
+
+# Exported variable for use by other modules:
+open_gee_version = OpenGeeVersion()
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--long", action="store_true", help="Output long format of version string")
     args = parser.parse_args()
 
-    # default parameter to GetVersion functions
-    self_path, _ = os.path.split(os.path.realpath(__file__))
-    version_file = os.path.join(self_path, '../version.txt')
+    print open_gee_version.get_long() if args.long else open_gee_version.get_short()
 
-    version = ""
-    if args.long:
-        version = GetLongVersion(version_file)
-    else:
-        version = GetVersion(version_file)
 
-    print version
-
+__all__ = ['open_gee_version']
 
 if __name__ == "__main__":
     main()

--- a/earth_enterprise/src/scons/khEnvironment.py
+++ b/earth_enterprise/src/scons/khEnvironment.py
@@ -26,7 +26,7 @@ import os.path
 import sys
 import time
 from datetime import datetime
-from getversion import GetVersion, GetLongVersion
+from getversion import open_gee_version
 import SCons
 from SCons.Environment import Environment
 
@@ -187,11 +187,11 @@ def EmitBuildDateStrfunc(target, build_date):
   return 'EmitBuildDate(%s, %s)' % (target, build_date)
 
 
-def EmitVersionHeaderFunc(target, backupFile):
+def EmitVersionHeaderFunc(target):
   """Emit version information to the target file."""
 
-  versionStr = GetVersion(backupFile)
-  longVersionStr = GetLongVersion(backupFile)
+  versionStr = open_gee_version.get_short()
+  longVersionStr = open_gee_version.get_long()
 
   fp = open(target, 'w')
   fp.writelines(['// DO NOT MODIFY - auto-generated file\n',
@@ -203,38 +203,38 @@ def EmitVersionHeaderFunc(target, backupFile):
   fp.close()
 
 
-def EmitVersionHeaderStrfunc(target, backupFile):
-  return 'EmitVersionHeader(%s, %s)' % (target, backupFile)
+def EmitVersionHeaderStrfunc(target):
+  return 'EmitVersionHeader(%s)' % (target,)
   
 
-def EmitVersionFunc(target, backupFile):
+def EmitVersionFunc(target):
   """Emit version information to the target file."""
 
-  versionStr = GetVersion(backupFile)
-
-  with open(target, 'w') as fp:
-    fp.write(versionStr)
-  
-  with open(backupFile, 'w') as fp:
-    fp.write(versionStr)
-
-
-def EmitVersionStrfunc(target, backupFile):
-  return 'EmitVersion(%s, %s)' % (target, backupFile)
-  
-  
-def EmitLongVersionFunc(target, backupFile, label):
-  """Emit version information to the target file."""
-
-  versionStr = GetLongVersion(backupFile, label)
+  versionStr = open_gee_version.get_short()
 
   with open(target, 'w') as fp:
     fp.write(versionStr)
 
+  with open(open_gee_version.backup_file, 'w') as fp:
+    fp.write(versionStr)
 
-def EmitLongVersionStrfunc(target, backupFile, label):
-  return 'EmitLongVersion(%s, %s, %s)' % (target, backupFile, label)
-  
+
+def EmitVersionStrfunc(target):
+  return 'EmitVersion(%s)' % (target,)
+
+
+def EmitLongVersionFunc(target):
+  """Emit version information to the target file."""
+
+  versionStr = open_gee_version.get_long()
+
+  with open(target, 'w') as fp:
+    fp.write(versionStr)
+
+
+def EmitLongVersionStrfunc(target):
+  return 'EmitLongVersion(%s)' % (target,)
+
 
 # our derived class
 class khEnvironment(Environment):
@@ -537,6 +537,9 @@ class khEnvironment(Environment):
     root_dir = self.exportdirs['root']
     shobj_suffix = self['SHOBJSUFFIX']
     return [root_dir + p + shobj_suffix for p in sources if p]
+
+  def get_open_gee_version(self):
+    return open_gee_version
 
 
 def ProtocolBufferGenerator(source, target, env, for_signature):


### PR DESCRIPTION
* Added version string caching.
* Moved the version interface to a class with `label` and `backup_file` properties, rather than having to pass parameters around to functions.

Fixes #1058.