### PR TITLE
#1012 Use the --ignore_imagery_depth parameter when calling geportablemapbuilder

### DIFF
--- a/docs/geedocs/5.2.5/answer/3230777.html
+++ b/docs/geedocs/5.2.5/answer/3230777.html
@@ -165,14 +165,17 @@ Executing: /opt/google/bin/geportableglcpacker --layer_info="/tmp/cutter/glc_205
 <p>The maximum resolution of the cut polygon area is no higher than the maximum resolution of the source map or globe. For example, if the maximum resolution in the cutter is specified at 24, but the source imagery is at 18 (approximately 1-meter resolution), the cut map or globe will contain level 18 imagery. You can leave this field blank to use the highest available imagery.</p>
 <p>You may enter a lower number to reduce the size of your map or globe, by not including the highest resolution imagery.</p>
 <hr/>
-<h3 id="advanced_polygon_resolution">Advanced Polygon Resolution</h3>
+<h3 id="advanced_settings">Advanced Settings</h3>
+<h4 id="advanced_polygon_resolution">Polygon Resolution</h4>
 <p>The <strong>Advanced</strong> option provides an additional globe-cutting option, namely <em>Polygon Resolution</em>. This setting is useful when cutting with large polygons. For example, you may use 12 for a country-sized polygon or 18 for a city-sized polygon. </p>
-<div class="note"> <strong>Note:</strong> Additional advanced settings may be offered in future versions. Use caution when changing them as they may dramatically increase build times and globe sizes. </div>
 <h4>To set the polygon resolution:</h4>
 <ul>
 <li>Click <strong>Advanced</strong> to display the Polygon Resolution option. </li>
 <li>Click the drop-down list to set the resolution value you want. </li>
 </ul>
+<h4 id="use_alternate_method">Continue Past Empty Levels</h4>
+<p>This option only applies to portable maps (2D databases). If a portable map does not contain imagery in the polygon at the resolution that you think it should, try recreating the portable map with this option set to Yes. This option will likely increase the build time, possibly significantly.</p>
+<div class="note"> <strong>Note:</strong> Additional advanced settings may be offered in future versions. Use caution when changing them as they may dramatically increase build times and globe sizes. </div>
 <hr/>
 <h3 id="building_the_globe">Building the map or globe</h3>
 <p>Depending on the size of your polygon, building your cut map or globe can take from a few minutes to a few hours; likewise, file size varies widely depending on the area selected and the desired resolution.</p>

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -288,7 +288,8 @@ class GlobeBuilder(object):
     self.Status("Build map ...")
     # Run this task as a background task.
     # Having trouble with permissions if output is redirected to a file.
-    os_cmd = ("%s/geportablemapbuilder --source=\"%s\" "
+    os_cmd = ("%s/geportablemapbuilder --ignore_imagery_depth "
+              "--source=\"%s\" "
               "--hires_qt_nodes_file=\"%s\" "
               "--map_directory=\"%s\"  --default_level=%d --max_level=%d "
               % (COMMAND_DIR, source, self.qtnodes_file,

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -283,17 +283,22 @@ class GlobeBuilder(object):
                  self.packet_info_file))
     common.utils.ExecuteCmdInBackground(os_cmd, self.logger)
 
-  def BuildMap(self, source, default_level, max_level):
+  def BuildMap(self, source, default_level, max_level, ignore_imagery_depth):
     """Executes command to cut map and save data into packet bundles."""
     self.Status("Build map ...")
+    ignore_imagery_depth_str = str()
+    if ignore_imagery_depth:
+        ignore_imagery_depth_str = "--ignore_imagery_depth"
     # Run this task as a background task.
     # Having trouble with permissions if output is redirected to a file.
-    os_cmd = ("%s/geportablemapbuilder --ignore_imagery_depth "
+    os_cmd = ("%s/geportablemapbuilder "
+              "%s "
               "--source=\"%s\" "
               "--hires_qt_nodes_file=\"%s\" "
               "--map_directory=\"%s\"  --default_level=%d --max_level=%d "
-              % (COMMAND_DIR, source, self.qtnodes_file,
-                 self.globe_dir, default_level, max_level))
+              % (COMMAND_DIR, ignore_imagery_depth_str, source,
+                 self.qtnodes_file, self.globe_dir, default_level, 
+                 max_level))
 
     common.utils.ExecuteCmdInBackground(os_cmd, self.logger)
 
@@ -836,13 +841,15 @@ if __name__ == "__main__":
       globe_builder.GrabKml(FORM.getvalue_url("source"))
 
     elif cgi_cmd == "BUILD_GLOBE":
+      ignore_imagery_depth = (FORM.getvalue("ignore_imagery_depth") is not None)
       globe_builder.CheckArgs(["globe_name", "source", "default_level",
                                "max_level"], FORM)
       is_2d = FORM.getvalue("is_2d")
       if is_2d == "t":
         globe_builder.BuildMap(FORM.getvalue_url("source"),
                                int(FORM.getvalue("default_level")),
-                               int(FORM.getvalue("max_level")))
+                               int(FORM.getvalue("max_level")),
+                               ignore_imagery_depth)
       else:
         globe_builder.BuildGlobe(FORM.getvalue_url("source"),
                                  int(FORM.getvalue("default_level")),

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
@@ -118,6 +118,11 @@
       <em  id="polygon_zoom_em"></em>
       <select id="polygon_zoom" class="CutterSelect SmallSelect"></select>
     </div>
+    <div id="UseAlternateMethodHolder" style="display:none;">
+      <label>Continue past empty levels</label>
+      <input type="radio" name="useAlternateMethod" checked>No
+      <input id="useAlternateMethod_radio" type="radio" name="useAlternateMethod">Yes
+    </div>
   </div>
   <h2></h2>
   <div class="ContentBlock" id="CutButtonDiv">

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
@@ -500,6 +500,9 @@ function updateOuterZoom(inner_zoom) {
 
 function toggleAdvancedZoom() {
   toggleElementDisplay(gees.dom.get('polyZoomHolder'));
+  if (isServing == '2D') {
+    toggleElementDisplay(gees.dom.get('UseAlternateMethodHolder'));
+  }
 }
 
 // First step to loading cutter is loading vardefs. If those fail, throw an

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_utils.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_utils.js
@@ -181,6 +181,14 @@ function geeAllowOverwrite() {
 }
 
 /**
+ * Checks flag for using alternate method of gathering tiles.
+ * @return {bool} whether alternate method should be used.
+ */
+function geeUseAlternateMethod() {
+  return gees.dom.isChecked('useAlternateMethod_radio');
+}
+
+/**
  * Get description of the globe.
  * @return {string} Description of the globe.
  */

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/map_cutter.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/map_cutter.js
@@ -74,6 +74,7 @@ function geeCheckMapParameters() {
  */
 function checkAndBuild() {
   var allowOverwriting = geeAllowOverwrite();
+  var useAlternateMethod = geeUseAlternateMethod();
 
   // Refresh the list of databases to be sure information is up to date.
   gees.initialize.databases();
@@ -96,7 +97,7 @@ function checkAndBuild() {
   }
 
   // If no published items are being overwritten, build the map.
-  geeBuildMap(allowOverwriting);
+  geeBuildMap(allowOverwriting, useAlternateMethod);
 }
 
 /**
@@ -117,7 +118,7 @@ function overwritingPublishedItemsMessage() {
  * Use a series of AJAX calls to cut a portable Map and make it available
  * for downloading. The AJAX calls provide some feedback along the way.
  */
-function geeBuildMap(allowOverwriting) {
+function geeBuildMap(allowOverwriting, useAlternateMethod) {
   hideBuildComplete();
   geeSetResponse('Building portable map ...');
   var msg = geeCheckMapParameters();
@@ -129,6 +130,7 @@ function geeBuildMap(allowOverwriting) {
     return;
   }
 
+  var useAlternateMethodStr = '';
   var url = '/cgi-bin/globe_cutter_app.py?cmd=UID&globe_name=' + geeGlobeName();
 
   if (isServing == '2D') {
@@ -137,6 +139,10 @@ function geeBuildMap(allowOverwriting) {
 
   if (allowOverwriting) {
     url += '&allow_overwrite=t';
+  }
+
+  if (useAlternateMethod) {
+    useAlternateMethodStr = '&ignore_imagery_depth=t';
   }
 
   jQuery.get(url,
@@ -203,7 +209,7 @@ function geeBuildMap(allowOverwriting) {
                        globe_name + '&' + polygon + '&' + polygon_level + back1;
                    sequence[2] = front + base_url + 'BUILD_GLOBE&' +
                        globe_name + '&' + source + '&' + default_level +
-                       '&' + max_level + back1;
+                       '&' + max_level + useAlternateMethodStr + back1;
                    sequence[3] = wait_for_task;
                    sequence[4] = front + base_url + 'EXTRACT_SEARCH_DB&' +
                        globe_name + '&' + source + '&' + polygon + back1;

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -111,6 +111,7 @@ void PortableMapBuilder::BuildMap() {
   std::vector<uint32> level_row(24);
   std::vector<uint32> level_col(24);
   int32 level = 0;
+  int32 max_level_traversed = 0;
   std::string qt_string = "";
   qt_char[level] = '0';
   level_row[level] = 1;
@@ -135,6 +136,9 @@ void PortableMapBuilder::BuildMap() {
       // Go to next qtnode at this level.
       qt_char[level] += 1;
     } else {
+      if (level > max_level_traversed) {
+        max_level_traversed = level;
+      }
       qt_string = qt_string.substr(0, level) + qt_char[level];
       // Note that we stop descending once we reach the first
       // missing packet, which is important since this cue
@@ -172,6 +176,14 @@ void PortableMapBuilder::BuildMap() {
 
   // Finish up writing all of the packet bundles.
   DeleteWriter();
+
+  // The "+1" for max_level_traversed is because the code uses zero
+  // for the first level but the cutter page and most humans use one.
+  if (max_level_traversed+1 < max_level_) {
+    notify(NFY_WARN,
+      "Max level is %d but processing stopped at level %d.",
+      max_level_, max_level_traversed+1);
+  }
 }
 
 // TODO: Keep track of these as we go along rather than

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -41,7 +41,6 @@
 #include "mttypes/DrainableQueue.h"
 #include "mttypes/WaitBaseManager.h"
 
-
 // TODO: Use Manas' technique for bundling packet requests.
 namespace fusion_portableglobe {
 
@@ -378,14 +377,17 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
   static bool first = true;
   if (first) {
     first = false;
-    std::cout << "request,qtpath,level(z),col(x),row(y)" << std::endl;
+    std::cout << "request,qtpath,level(z),col(x),row(y),packet.size" << std::endl;
   }
   #endif
   bool keep_node = KeepNode(qtpath_str);
   #ifdef WRITE_MAP_PACKETS_OUTPUT
-  std::cout << (keep_node ? "true," : "false,") << qtpath_str << "," << level << "," << col << "," << row << std::endl;
+  std::cout << (keep_node ? "true," : "false,") << qtpath_str << "," << level << "," << col << "," << row << ",";
   #endif
   if (!keep_node) {
+    #ifdef WRITE_MAP_PACKETS_OUTPUT
+    std::cout << "0" << std::endl;
+    #endif
     return false;
   }
 
@@ -403,6 +405,9 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
     std::string url = url_str;
     std::string raw_packet;
     server_->GetRawPacket(url, &raw_packet);
+    #ifdef WRITE_MAP_PACKETS_OUTPUT
+    std::cout << raw_packet.size() << std::endl;
+    #endif
     uint32 packet_type = layers_[i]->type_id;
     if (raw_packet.size() > 0) {
       if (packet_type == kImagePacket) {

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -102,10 +102,6 @@ PortableMapBuilder::~PortableMapBuilder() {
  */
 void PortableMapBuilder::BuildMap() {
   num_image_packets = 0;
-  num_vector_packets = 0;
-  image_size = 0;
-  vector_size = 0;
-  total_size = 0;
 
   // Add writers for the different packet types.
   AddWriter(kMapDataDirectory);
@@ -363,7 +359,7 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
                                            uint32 level,
                                            uint32 col,
                                            uint32 row) {
-  /*
+  #ifdef WRITE_MAP_PACKETS_OUTPUT
   // The following debug output is formatted for use in a spreadsheet.
   // It captures all calls to this function and indicates if the call
   // will result in an HTTP request.
@@ -372,9 +368,11 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
     first = false;
     std::cout << "request,qtpath,level(z),col(x),row(y)" << std::endl;
   }
-  */
+  #endif
   bool keep_node = KeepNode(qtpath_str);
-  //std::cout << (keep_node ? "true," : "false,") << qtpath_str << "," << level << "," << col << "," << row << std::endl;
+  #ifdef WRITE_MAP_PACKETS_OUTPUT
+  std::cout << (keep_node ? "true," : "false,") << qtpath_str << "," << level << "," << col << "," << row << std::endl;
+  #endif
   if (!keep_node) {
     return false;
   }

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -147,14 +147,17 @@ void PortableMapBuilder::BuildMap() {
       if (WriteMapPackets(qt_string, level,
                           level_col[level], level_row[level])) {
         ++num_image_packets;
-        ++level;
-        qt_char[level] = '0';
-        level_row[level] = (level_row[level - 1] << 1) + 1;
-        level_col[level] = level_col[level - 1] << 1;
 
-        if (level >= 24) {
-          std::cout << "Bad level" << std::endl;
-          exit(0);
+        if (level < 23) {
+          ++level;
+          qt_char[level] = '0';
+          level_row[level] = (level_row[level - 1] << 1) + 1;
+          level_col[level] = level_col[level - 1] << 1;
+        } else if (level == 23) {
+          qt_char[level] += 1;
+        } else {
+          std::cout << "Bad level (" << level << ")" << std::endl;
+          exit(1);
         }
       } else {
         qt_char[level] += 1;
@@ -360,7 +363,19 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
                                            uint32 level,
                                            uint32 col,
                                            uint32 row) {
-  if (!KeepNode(qtpath_str)) {
+  /*
+  // The following debug output is formatted for use in a spreadsheet.
+  // It captures all calls to this function and indicates if the call
+  // will result in an HTTP request.
+  static bool first = true;
+  if (first) {
+    first = false;
+    std::cout << "request,qtpath,level(z),col(x),row(y)" << std::endl;
+  }
+  */
+  bool keep_node = KeepNode(qtpath_str);
+  //std::cout << (keep_node ? "true," : "false,") << qtpath_str << "," << level << "," << col << "," << row << std::endl;
+  if (!keep_node) {
     return false;
   }
 


### PR DESCRIPTION
The fix for issue #1012 is to add the existing --ignore_imagery_depth parameter to the command line for geportablemapbuilder.

The default behavior for geportablemapbuilder is to stop searching for imagery when all GEE server HTTP requests for a zoom level return no imagery.  Using the existing --ignore_imagery_depth parameter causes the code to continue sending HTTP requests if the request contains any part of the polygon defined by the cutter operation.  This continues until the code reaches the "region level" provided specified by the user.

I created a 2D mercator map with the tutorial blue marble imagery (very low res) and one very high res (level 19) image.  I then used cutter and manually drew a square around the high resolution image.  When I create the cutfile without this fix, the high resolution imagery is missing from the cutfile.  With this change the high resolution imagery is there.  For my testing this caused a 15% increase in the number of HTTP requests to the GEE server to gather the additional imagery for the cutfile.

I created another 2D mercator map using the same blue marble and very high resolution image but also with imagery at two other resolution levels that were in-between the low and high levels.  This imagery covered the same area (but larger area) as the high resolution image.  I tested both before the fix and with the fix and the resulting cutfile is unchanged.  This is the result what we want for this test.  Additionally, I found that this generated the same number of HTTP requests to the GEE server.

EDIT:  Found scenarios where geportablemapbuilder generated correct output without using the --ignore_imagery_depth option and adding that option would substantially increase the running time.  The most recent commits remove --ignore_imagery_depth from always being used and make it an option on the cutter web page.  The "Continue past empty levels" option should only display if the operation is for a 2D map, and only when the user clicks on "Advanced".  Selecting "Yes" for that option will add the --ignore_imagery_depth option to the geportablemapbuilder command line.