### PR TITLE
Allow extracting globe packets from portable file

### DIFF
--- a/docs/_posts/2018-10-11-524-release.md
+++ b/docs/_posts/2018-10-11-524-release.md
@@ -1,0 +1,32 @@
+---
+layout: blogpost
+title:  "5.2.4 Release Announcement"
+section_id: blog
+date:   2018-10-11 12:00:00
+author: Open GEE Development Team
+---
+
+<br />
+Hi Open GEE Community!
+ 
+We are happy to announce the official release of Open GEE 5.2.4!  This release updates Open GEE with minor enhancements and bug fixes for GEE Fusion and Server.
+ 
+Enhancements include:
+
+**Progress indicators during gesystemmanager processing**. Added progress log messages to gesystemmanager while assets are being built.
+
+**New "Save and Build" file menu option**. Fusion UI now includes a new file menu option that allows users to save and build assets with one click, instead of clicking the save option and then the build option immediately after.
+
+**C++98 no longer supported**. Building open GEE using C++98 standard is deprecated and is no longer supported. C++11 syntax can be used.
+
+**New build parameter to redirect the build output**. Build output can now be optionally directed to a folder of your choosing instead of the current hard-coded defaults. See earth_enterprise/BUILD.md in source code for more details.
+
+**New experimental build cache folder parameter to the build**. This is an experimental option to potentially speed up builds. More work remains to be done before using this option in production builds. Use of this option is not recommended except for giving feedback and/or helping to address issues with Open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.
+
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.4-4.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160004.html).
+ 
+Our thanks go out to all of the contributors who helped make this release possible! The next release, Open GEE 5.2.5, is already underway!
+ 
+Would you like to be part of the project? Please join us on [Slack](http://slack.opengee.org/) and visit [the project’s Github repository](https://github.com/google/earthenterprise). We would love to see you there!
+ 
+–Open GEE Development Team

--- a/earth_enterprise/src/common/geterrain.h
+++ b/earth_enterprise/src/common/geterrain.h
@@ -1,0 +1,243 @@
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include "khEndian.h"
+#include "khTypes.h"
+
+
+// Terrain mesh
+namespace geterrain {
+
+const double kEpsilonXY = 1.0e-10;
+const double kEpsilonZ = 1.0e-5;
+
+const std::string kLinePrefix = "\n      ";
+
+template<class T1,class T2,class T3> void FormatThree(std::ostream &strm,
+                                             const T1 &v1,
+                                             const T2 &v2,
+                                             const T3 &v3) {
+  strm << "(" << v1 << "," << v2 << "," << v3 << ")";
+}
+
+const size_t kEmptyMeshHeaderSize = 16;
+
+// Structures for mesh vertices and faces
+
+struct MeshVertex {
+  unsigned int x;
+  unsigned int y;
+  float z;
+
+  void Pull(EndianReadBuffer &buf) {
+    unsigned char c_tmp;
+    buf >> c_tmp;
+    x = c_tmp;
+    buf >> c_tmp;
+    y = c_tmp;
+    buf >> z;
+  }
+};
+
+std::ostream &operator<<(std::ostream &strm, const MeshVertex &v) {
+  FormatThree(strm, v.x, v.y, v.z);
+  return strm;
+}
+
+struct MeshFace {
+  uint16 a, b, c;
+
+  void Pull(EndianReadBuffer &buf) {
+    buf >> a >> b >> c;
+  }
+};
+
+std::ostream &operator<<(std::ostream &strm, const MeshFace &f) {
+  FormatThree(strm, f.a, f.b, f.c);
+  return strm;
+}
+
+class Mesh {
+ public:
+  Mesh() { Reset(); }
+  ~Mesh() {}
+  void Reset() {
+    source_size_ = 0;
+    ox_ = 0.0;
+    oy_ = 0.0;
+    dx_ = 0.0;
+    dy_ = 0.0;
+    num_points_ = 0;
+    num_faces_ = 0;
+    level_ = 0;
+    faces_.clear();
+    vertices_.clear();
+  }
+  inline int32 source_size() const { return source_size_; }
+  inline double ox() const { return ox_; }
+  inline double oy() const { return oy_; }
+  inline double dx() const { return dx_; }
+  inline double dy() const { return dy_; }
+  inline int32 num_points() const { return num_points_; }
+  inline int32 num_faces() const { return num_faces_; }
+  inline int32 level() const { return level_; }
+  inline const MeshVertex &Vertex(size_t i) { return vertices_.at(i); }
+  inline const MeshFace &Face(size_t i) { return faces_.at(i); }
+
+  void Pull(EndianReadBuffer &buf) {
+    // If size is 0, this is an empty (16 byte) header
+    buf >> source_size_;
+    if (source_size_ != 0) {
+      EndianReadBuffer::size_type start_pos = buf.CurrPos();
+      buf >> ox_
+          >> oy_
+          >> dx_
+          >> dy_
+          >> num_points_
+          >> num_faces_
+          >> level_;
+      vertices_.resize(num_points_);
+      for (int i = 0; i < num_points_; ++i) {
+        buf >> vertices_[i];
+      }
+      faces_.resize(num_faces_);
+      for (int i = 0; i < num_faces_; ++i) {
+        buf >> faces_[i];
+      }
+      if (buf.CurrPos() != start_pos + source_size_) {
+        throw khSimpleException(
+            "Terrain mesh header error, size doesn't match contents");
+      }
+    } else {
+      buf.Skip(kEmptyMeshHeaderSize - sizeof(source_size_));
+      Reset();
+    }
+  }
+
+  void PrintHeader(std::ostream &strm) {
+    strm << "[size=" << source_size()
+         << " o=(" << ox() << "," << oy() << ")"
+         << " d=(" << dx() << "," << dy() << ")"
+         << " points=" << num_points()
+         << " faces=" << num_faces()
+         << " level=" << level() << "]";
+  }
+
+  void PrintMesh(std::ostream &strm) {
+    static const std::string kMeshPrefix(kLinePrefix + " ");
+
+    strm << kMeshPrefix;
+    PrintHeader(strm);
+    strm << kMeshPrefix << " Points:";
+    for (size_t i = 0; i < vertices_.size(); ++i) {
+      strm << kMeshPrefix << "   p[" << i << "] = " << vertices_[i];
+    }
+    strm << kMeshPrefix << " Faces:";
+    for (size_t i = 0; i < faces_.size(); ++i) {
+      strm << kMeshPrefix << "   f[" << i << "] = " << faces_[i];
+    }
+  }
+ private:
+  int32 source_size_;
+  double ox_;
+  double oy_;
+  double dx_;
+  double dy_;
+  int32 num_points_;
+  int32 num_faces_;
+  int32 level_;
+  std::vector<MeshVertex> vertices_;
+  std::vector<MeshFace> faces_;
+};
+
+inline bool IsAlmostEqual(const double a, const double b, const double epsilon) {
+  return (fabs(a-b) <= epsilon) ? true : false;
+}
+
+inline bool IsAlmostEqual(const MeshVertex &v1, const MeshVertex &v2) {
+  return v1.x == v2.x && v1.y == v2.y && IsAlmostEqual(v1.z, v2.z, kEpsilonZ);
+}
+
+bool CompareMesh(int mesh_number,
+                 EndianReadBuffer *buffer1,
+                 EndianReadBuffer *buffer2,
+                 const bool ignore_mesh,
+                 std::ostream *snippet) {
+  Mesh mesh1, mesh2;
+  *buffer1 >> mesh1;
+  *buffer2 >> mesh2;
+
+  if (getNotifyLevel() >= NFY_VERBOSE) {
+    std::ostringstream headers;
+    headers << "Mesh " << mesh_number
+            << " Terrain Headers:\n";
+    mesh1.PrintHeader(headers);
+    headers << "\n";
+    mesh2.PrintHeader(headers);
+    notify(NFY_VERBOSE, "%s", headers.str().c_str());
+  }
+
+  if (mesh1.source_size() == 0  &&  mesh2.source_size() == 0) {
+    return true;                        // filler for missing mesh
+  }
+
+  if (!IsAlmostEqual(mesh1.ox(), mesh2.ox(), kEpsilonXY)
+      || !IsAlmostEqual(mesh1.oy(), mesh2.oy(), kEpsilonXY)
+      || !IsAlmostEqual(mesh1.dx(), mesh2.dx(), kEpsilonXY)
+      || !IsAlmostEqual(mesh1.dy(), mesh2.dy(), kEpsilonXY)
+      || mesh1.level() != mesh2.level()) {
+    *snippet << kLinePrefix << "Mesh " << mesh_number << " header mismatch:"
+             << kLinePrefix << "  ";
+    mesh1.PrintHeader(*snippet);
+    *snippet << kLinePrefix << "  ";
+    mesh2.PrintHeader(*snippet);
+    return false;
+  }
+
+  if (ignore_mesh)
+    return true;
+
+  if(mesh1.num_points() != mesh2.num_points()
+     || mesh1.num_faces() != mesh2.num_faces()) {
+    *snippet << kLinePrefix << "Mesh " << mesh_number
+             << " header point/face count mismatch:"
+             << kLinePrefix << "  ";
+    mesh1.PrintHeader(*snippet);
+    *snippet << kLinePrefix << "  ";
+    mesh2.PrintHeader(*snippet);
+    return false;
+  }
+
+  bool success = true;
+
+  // Compare mesh points
+  for (int i = 0; i < mesh1.num_points(); ++i) {
+    if (!IsAlmostEqual(mesh1.Vertex(i), mesh2.Vertex(i))) {
+      *snippet << kLinePrefix << "Mesh " << mesh_number
+               << " point ["<< i << "] mismatch";
+      success = false;
+    }
+  }
+
+  // Compare mesh faces
+  for (int i = 0; i < mesh1.num_faces(); ++i) {
+    const MeshFace &f1 = mesh1.Face(i);
+    const MeshFace &f2 = mesh2.Face(i);
+    if ((f1.a != f2.a || f1.b != f2.b || f1.c != f2.c)) {
+      *snippet << kLinePrefix << "Mesh " << mesh_number
+               << " face [" << i << "] mismatch";
+      success = false;
+    }
+  }
+
+  if (!success) {
+    *snippet << kLinePrefix << "Source 1 mesh " << mesh_number << ":";
+    mesh1.PrintMesh(*snippet);
+    *snippet << kLinePrefix << "Source 2 mesh " << mesh_number << ":";
+    mesh2.PrintMesh(*snippet);
+  }
+
+  return success;
+}
+
+} // namespace geterrain

--- a/earth_enterprise/src/fusion/gecrawler/compareterrain.cpp
+++ b/earth_enterprise/src/fusion/gecrawler/compareterrain.cpp
@@ -22,244 +22,7 @@
 #include <notify.h>
 #include <khEndian.h>
 #include "compareterrain.h"
-
-namespace {
-
-const double kEpsilonXY = 1.0e-10;
-const double kEpsilonZ = 1.0e-5;
-
-const std::string kLinePrefix = "\n      ";
-
-template<class T1,class T2,class T3> void FormatThree(std::ostream &strm,
-                                             const T1 &v1,
-                                             const T2 &v2,
-                                             const T3 &v3) {
-  strm << "(" << v1 << "," << v2 << "," << v3 << ")";
-}
-
-const size_t kEmptyMeshHeaderSize = 16;
-
-// Structures for mesh vertices and faces
-
-struct MeshVertex {
-  unsigned int x;
-  unsigned int y;
-  float z;
-
-  void Pull(EndianReadBuffer &buf) {
-    unsigned char c_tmp;
-    buf >> c_tmp;
-    x = c_tmp;
-    buf >> c_tmp;
-    y = c_tmp;
-    buf >> z;
-  }
-};
-
-std::ostream &operator<<(std::ostream &strm, const MeshVertex &v) {
-  FormatThree(strm, v.x, v.y, v.z);
-  return strm;
-}
-
-struct MeshFace {
-  uint16 a, b, c;
-
-  void Pull(EndianReadBuffer &buf) {
-    buf >> a >> b >> c;
-  }
-};
-
-std::ostream &operator<<(std::ostream &strm, const MeshFace &f) {
-  FormatThree(strm, f.a, f.b, f.c);
-  return strm;
-}
-
-// Terrain mesh
-
-class Mesh {
- public:
-  Mesh() { Reset(); }
-  ~Mesh() {}
-  void Reset() {
-    source_size_ = 0;
-    ox_ = 0.0;
-    oy_ = 0.0;
-    dx_ = 0.0;
-    dy_ = 0.0;
-    num_points_ = 0;
-    num_faces_ = 0;
-    level_ = 0;
-    faces_.clear();
-    vertices_.clear();
-  }
-  inline int32 source_size() const { return source_size_; }
-  inline double ox() const { return ox_; }
-  inline double oy() const { return oy_; }
-  inline double dx() const { return dx_; }
-  inline double dy() const { return dy_; }
-  inline int32 num_points() const { return num_points_; }
-  inline int32 num_faces() const { return num_faces_; }
-  inline int32 level() const { return level_; }
-  inline const MeshVertex &Vertex(size_t i) { return vertices_.at(i); }
-  inline const MeshFace &Face(size_t i) { return faces_.at(i); }
-
-  void Pull(EndianReadBuffer &buf) {
-    // If size is 0, this is an empty (16 byte) header
-    buf >> source_size_;
-    if (source_size_ != 0) {
-      EndianReadBuffer::size_type start_pos = buf.CurrPos();
-      buf >> ox_
-          >> oy_
-          >> dx_
-          >> dy_
-          >> num_points_
-          >> num_faces_
-          >> level_;
-      vertices_.resize(num_points_);
-      for (int i = 0; i < num_points_; ++i) {
-        buf >> vertices_[i];
-      }
-      faces_.resize(num_faces_);
-      for (int i = 0; i < num_faces_; ++i) {
-        buf >> faces_[i];
-      }
-      if (buf.CurrPos() != start_pos + source_size_) {
-        throw khSimpleException(
-            "Terrain mesh header error, size doesn't match contents");
-      }
-    } else {
-      buf.Skip(kEmptyMeshHeaderSize - sizeof(source_size_));
-      Reset();
-    }
-  }
-
-  void PrintHeader(std::ostream &strm) {
-    strm << "[size=" << source_size()
-         << " o=(" << ox() << "," << oy() << ")"
-         << " d=(" << dx() << "," << dy() << ")"
-         << " points=" << num_points()
-         << " faces=" << num_faces()
-         << " level=" << level() << "]";
-  }
-
-  void PrintMesh(std::ostream &strm) {
-    static const std::string kMeshPrefix(kLinePrefix + " ");
-
-    strm << kMeshPrefix;
-    PrintHeader(strm);
-    strm << kMeshPrefix << " Points:";
-    for (size_t i = 0; i < vertices_.size(); ++i) {
-      strm << kMeshPrefix << "   p[" << i << "] = " << vertices_[i];
-    }
-    strm << kMeshPrefix << " Faces:";
-    for (size_t i = 0; i < faces_.size(); ++i) {
-      strm << kMeshPrefix << "   f[" << i << "] = " << faces_[i];
-    }
-  }
- private:
-  int32 source_size_;
-  double ox_;
-  double oy_;
-  double dx_;
-  double dy_;
-  int32 num_points_;
-  int32 num_faces_;
-  int32 level_;
-  std::vector<MeshVertex> vertices_;
-  std::vector<MeshFace> faces_;
-};
-
-inline bool IsAlmostEqual(const double a, const double b, const double epsilon) {
-  return (fabs(a-b) <= epsilon) ? true : false;
-}
-
-inline bool IsAlmostEqual(const MeshVertex &v1, const MeshVertex &v2) {
-  return v1.x == v2.x && v1.y == v2.y && IsAlmostEqual(v1.z, v2.z, kEpsilonZ);
-}
-
-bool CompareMesh(int mesh_number,
-                 EndianReadBuffer *buffer1,
-                 EndianReadBuffer *buffer2,
-                 const bool ignore_mesh,
-                 std::ostream *snippet) {
-  Mesh mesh1, mesh2;
-  *buffer1 >> mesh1;
-  *buffer2 >> mesh2;
-
-  if (getNotifyLevel() >= NFY_VERBOSE) {
-    std::ostringstream headers;
-    headers << "Mesh " << mesh_number
-            << " Terrain Headers:\n";
-    mesh1.PrintHeader(headers);
-    headers << "\n";
-    mesh2.PrintHeader(headers);
-    notify(NFY_VERBOSE, "%s", headers.str().c_str());
-  }
-
-  if (mesh1.source_size() == 0  &&  mesh2.source_size() == 0) {
-    return true;                        // filler for missing mesh
-  }
-
-  if (!IsAlmostEqual(mesh1.ox(), mesh2.ox(), kEpsilonXY)
-      || !IsAlmostEqual(mesh1.oy(), mesh2.oy(), kEpsilonXY)
-      || !IsAlmostEqual(mesh1.dx(), mesh2.dx(), kEpsilonXY)
-      || !IsAlmostEqual(mesh1.dy(), mesh2.dy(), kEpsilonXY)
-      || mesh1.level() != mesh2.level()) {
-    *snippet << kLinePrefix << "Mesh " << mesh_number << " header mismatch:"
-             << kLinePrefix << "  ";
-    mesh1.PrintHeader(*snippet);
-    *snippet << kLinePrefix << "  ";
-    mesh2.PrintHeader(*snippet);
-    return false;
-  }
-
-  if (ignore_mesh)
-    return true;
-
-  if(mesh1.num_points() != mesh2.num_points()
-     || mesh1.num_faces() != mesh2.num_faces()) {
-    *snippet << kLinePrefix << "Mesh " << mesh_number
-             << " header point/face count mismatch:"
-             << kLinePrefix << "  ";
-    mesh1.PrintHeader(*snippet);
-    *snippet << kLinePrefix << "  ";
-    mesh2.PrintHeader(*snippet);
-    return false;
-  }
-
-  bool success = true;
-
-  // Compare mesh points
-  for (int i = 0; i < mesh1.num_points(); ++i) {
-    if (!IsAlmostEqual(mesh1.Vertex(i), mesh2.Vertex(i))) {
-      *snippet << kLinePrefix << "Mesh " << mesh_number
-               << " point ["<< i << "] mismatch";
-      success = false;
-    }
-  }
-
-  // Compare mesh faces
-  for (int i = 0; i < mesh1.num_faces(); ++i) {
-    const MeshFace &f1 = mesh1.Face(i);
-    const MeshFace &f2 = mesh2.Face(i);
-    if ((f1.a != f2.a || f1.b != f2.b || f1.c != f2.c)) {
-      *snippet << kLinePrefix << "Mesh " << mesh_number
-               << " face [" << i << "] mismatch";
-      success = false;
-    }
-  }
-
-  if (!success) {
-    *snippet << kLinePrefix << "Source 1 mesh " << mesh_number << ":";
-    mesh1.PrintMesh(*snippet);
-    *snippet << kLinePrefix << "Source 2 mesh " << mesh_number << ":";
-    mesh2.PrintMesh(*snippet);
-  }
-
-  return success;
-}
-
-} // namespace
+#include "common/geterrain.h"
 
 namespace gecrawler {
 
@@ -274,27 +37,27 @@ bool CompareTerrainPackets(EndianReadBuffer *buffer1,
 
   try {
     while (!buffer1->AtEnd() && !buffer2->AtEnd()) {
-      if (!CompareMesh(mesh_number, buffer1, buffer2, ignore_mesh, snippet)) {
+      if (!geterrain::CompareMesh(mesh_number, buffer1, buffer2, ignore_mesh, snippet)) {
         success = false;
       }
       ++mesh_number;
     }
 
     if (success && !buffer1->AtEnd()) {
-      *snippet << kLinePrefix
+      *snippet << geterrain::kLinePrefix
                << "Excess content at end of source 1 terrain packet, sizes=("
                << buffer1->size() << "," << buffer2->size() << ")";
       success = false;
     }
     if (success && !buffer2->AtEnd()) {
-      *snippet << kLinePrefix
+      *snippet << geterrain::kLinePrefix
                << "Excess content at end of source 2 terrain packet, sizes=("
                << buffer1->size() << "," << buffer2->size() << ")";
       success = false;
     }
   }
   catch (khSimpleException ex) {
-    *snippet << kLinePrefix << "ERROR: Caught exception comparing mesh "
+    *snippet << geterrain::kLinePrefix << "ERROR: Caught exception comparing mesh "
              << mesh_number << ": " << ex.what();
     success = false;
   }

--- a/earth_enterprise/src/fusion/portableglobe/SConscript
+++ b/earth_enterprise/src/fusion/portableglobe/SConscript
@@ -97,7 +97,7 @@ portable_glc_reader_sobj = env.SharedObject('servers/fileunpacker/shared/portabl
 geglxinfo = env.executable(
     'geglxinfo',
     ['geglxinfo.cpp', portable_glc_reader_sobj],
-    LIBS=['geutil', 'gecommon', 'glb'])
+    LIBS=['geutil', 'gecommon', 'glb', 'geprotobuf'])
 
 # Do NOT install this tool.
 gedecode = env.executable('gedecode',

--- a/earth_enterprise/src/fusion/portableglobe/SConscript
+++ b/earth_enterprise/src/fusion/portableglobe/SConscript
@@ -97,7 +97,7 @@ portable_glc_reader_sobj = env.SharedObject('servers/fileunpacker/shared/portabl
 geglxinfo = env.executable(
     'geglxinfo',
     ['geglxinfo.cpp', portable_glc_reader_sobj],
-    LIBS=['geutil', 'gecommon', 'glb', 'geprotobuf'])
+    LIBS=['geutil', 'gecommon', 'glb', 'geprotobuf', 'geqtpacket'])
 
 # Do NOT install this tool.
 gedecode = env.executable('gedecode',

--- a/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
@@ -26,6 +26,7 @@
 #include "common/etencoder.h"
 #include "common/khAbortedException.h"
 #include "common/khFileUtils.h"
+#include "common/geterrain.h"
 #include "common/khEndian.h"
 #include "common/khGetopt.h"
 #include "common/khSimpleException.h"
@@ -189,7 +190,15 @@ void extractAllPackets(GlcUnpacker* const unpacker,
           }
         }
         else if (index_item.packet_type == kTerrainPacket) {
-          writePacketToFile(index_item, buffer, true, "_terrain");
+          LittleEndianReadBuffer decompressed;
+          etEncoder::DecodeWithDefaultKey(&buffer[0], buffer.size());
+          if (KhPktDecompress(buffer.data(), buffer.size(), &decompressed)) {
+            geterrain::Mesh m;
+            m.Pull(decompressed);
+            std::ostringstream s;
+            m.PrintMesh(s);
+            writePacketToFile(index_item, s.str(), false, "_terrain");
+          }
         }
         else if (index_item.packet_type == kDbRootPacket) {
           writePacketToFile(index_item, buffer, true, "_dbroot");

--- a/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
@@ -32,6 +32,7 @@
 #include "common/khSimpleException.h"
 #include "common/khTypes.h"
 #include "common/proto_streaming_imagery.h"
+#include "common/packet.h"
 #include "common/packetcompress.h"
 #include "common/qtpacket/quadtreepacket.h"
 #include "fusion/portableglobe/servers/fileunpacker/shared/file_package.h"
@@ -182,11 +183,9 @@ void extractAllPackets(GlcUnpacker* const unpacker,
                               buffer.size(),
                               &decompressed)) {
             // todo: some magic here to make metadata into a human readable string
-            //qtpacket::KhQuadTreeQuantum16 theMetadata;
-            //decompressed >> theMetadata;
-            std::string metadataObjAsString;  // <- replace this when above is done
-            decompressed >> metadataObjAsString;
-            writePacketToFile(index_item, metadataObjAsString, false, "_meta");
+            qtpacket::KhQuadTreePacket16 theMetadata;
+            decompressed >> theMetadata;
+            writePacketToFile(index_item, theMetadata.ToString(true,true), false, "_meta");
           }
         }
         else if (index_item.packet_type == kTerrainPacket) {
@@ -204,7 +203,67 @@ void extractAllPackets(GlcUnpacker* const unpacker,
           writePacketToFile(index_item, buffer, true, "_dbroot");
         }
         else if (index_item.packet_type == kVectorPacket) {
-          writePacketToFile(index_item, buffer, true, "_vector");
+          // uint32 magic word
+          // uint32 size of payload (after decompression)
+          LittleEndianReadBuffer decompressed;
+          etEncoder::DecodeWithDefaultKey(&buffer[0], buffer.size());
+          //writePacketToFile(index_item, buffer, false, "_vector");
+          if (KhPktDecompress(buffer.data(), buffer.size(), &decompressed)) {
+            std::vector<char> mutableData(decompressed.size());
+            memcpy(mutableData.data(), decompressed.data(), decompressed.size());
+            etDrawablePacket thePacket;
+            if (thePacket.load(mutableData.data(), mutableData.size()) != 0) {
+              std::cout << "Error loading data into vector packet format!" << std::endl;
+            }
+            else {
+              thePacket.offsetToPointer();
+              for ( uint jj = 0; jj < thePacket.packetHeader.numInstances; ++jj ) {
+                etDataPacket* p = thePacket.getPtr(jj);
+                switch (p->packetHeader.dataTypeID) {
+                  case TYPE_STREETPACKET_UTF8:
+                    ((etStreetPacket*)p)->offsetToPointer();
+                    for ( uint ii = 0; ii < p->packetHeader.numInstances; ++ii ) {
+                      etStreetPacketData* sd = ((etStreetPacket*)p)->getPtr(ii);
+                      std::cout << "Found data for " << sd->name.string << std::endl;
+                    }
+                    break;
+                  default:
+                    std::cout << "Found an unhandled vector packet of type " << p->packetHeader.dataTypeID << std::endl;
+                }
+                
+              }
+            }
+            // decompressed data format
+            // uint32 keyhole magic ID (32301)
+            // uint32 datatypeId
+            // uint32 packetVersion
+            // uint32 numInstances
+            // uint32 dataInstanceSize
+            // uint32 dataBufferOffset
+            // uint32 dataBufferSize
+            // uint32 metaBufferSize
+            /*qtpacket::KhQuadTreePacket16 theMetadata;
+            decompressed >> theMetadata;
+            std::vector<qtpacket::KhQuadtreeDataReference> qtp_refs1;
+            std::vector<qtpacket::KhQuadtreeDataReference> qtp2_refs1;
+            std::vector<qtpacket::KhQuadtreeDataReference> img_refs1;
+            std::vector<qtpacket::KhQuadtreeDataReference> ter_refs1;
+            std::vector<qtpacket::KhQuadtreeDataReference> vec_refs1;
+            qtpacket::KhQuadtreeDataReferenceGroup refs(&qtp_refs1,
+                                                         &qtp2_refs1,
+                                                         &img_refs1,
+                                                         &ter_refs1,
+                                                         &vec_refs1);
+            qtpacket::KhQuadtreeDataReference qtp_read;
+            QuadtreePath qt_path = qtp_read.qt_path();
+            keyhole::JpegCommentDate unused;
+            theMetadata.GetDataReferences(&refs, qt_path, unused);
+            std::cout << "q=" << qtp_refs1.size() << " q2=" << qtp2_refs1.size() << " i=" << img_refs1.size() << " t=" << ter_refs1.size() << " v=" << vec_refs1.size() << std::endl;
+            writePacketToFile(index_item, theMetadata.ToString(true, true), false, "_vector");
+          }*/
+            std::string mystr(decompressed);
+            writePacketToFile(index_item, mystr, false, "_vector");
+          }
         }
         else {
           std::cout << "Found unhandled packet type of " << int(index_item.packet_type) << std::endl;


### PR DESCRIPTION
Addresses #1072 

When a 3d cut file is provided as input to `geglxinfo` the packets are dumped in a manner similar to 2d packet dumps.  Vector data isn't quite human readable but gives a hint at the contents of the packet.

Verification steps:
* compile or obtain `geglxinfo` for this PR as well as `geglxinfo` from master
* obtain or create the following files:
  1. 2d `.glm` file
  2. `.glc` file with 2d contents
  3. `.glc` file with 3d contents
  4. 3d `.glb` file
* Run original `geglxinfo --glx <filename> --extract_packets --layer_idx 0 &> output.txt` against file types 1 and 2 above and save the output from each
* Run PR `geglxinfo --glx <filename> --extract_packets --layer_idx 0 &> output.txt` against all portable file types and save the output
* For file types 1 and 2, ensure output of new `geglxinfo` matches the output of the old `geglxinfo` exactly.
* Ensure output of new `geglxinfo` for file types 3 and 4 produces a `maptiles` directory with all the different expected subfiles and data