### PR TITLE
Check if OpenGEE was installed with a package manager before before running installation and uninstallation scripts.

### DIFF
--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -69,6 +69,15 @@ gtag('config', 'UA-108632131-2');
             <th>Resolution</th>
           </tr>
           <tr>
+            <td>837</td>
+            <td>Manual install/uninstall scripts should be disabled when rpm installs active</td>
+            <td>
+              The install and uninstall scripts now check if Open GEE has been installed with a package
+              manager before installation begins, and will not install or remove any files when the
+              packages are installed.
+            </td>
+          </tr>
+          <tr>
             <td>934</td>
             <td>Polygon displayed at the wrong location when viewing GLC assemly</td>
             <td>

--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -45,6 +45,7 @@ gtag('config', 'UA-108632131-2');
   </h5>
     <p><strong>When a GEE server is queried for server definitions the response can be returned in proper JSON format.</strong> The <code>v</code> parameter can be added to query string to specify which version of the API will be returned. The valid options are <code>v=1</code> and <code>v=2</code>. Version one returns data in the current format. Version two returns data in JSON format. An example url which returns data in JSON format looks like: <code>http://&lt;GEE earth server&gt;/&lt;database_publish_point&gt;/query?request=Json&amp;v=2</code>.</p>
     <p><strong>Enable WMS when publishing from the commaind line.</strong> <code>geserveradmin --publishdb</code> has a new option <code>--serve_wms</code>. Passing this flag enables WMS for the database you are publishing.</p>
+    <p><strong>Installations scripts are disabled when Open GEE packages are installed.</strong>  The install and uninstall scripts will now check if Open GEE has been installed with a package manager before installation begins, and will not make any changes when the packages are installed.
   <h5>
     <p id="supported_5.2.5">Supported Platforms</p>
   </h5>
@@ -67,15 +68,6 @@ gtag('config', 'UA-108632131-2');
             <th>Number</th>
             <th class="narrow">Description</th>
             <th>Resolution</th>
-          </tr>
-          <tr>
-            <td>837</td>
-            <td>Manual install/uninstall scripts should be disabled when rpm installs active</td>
-            <td>
-              The install and uninstall scripts now check if Open GEE has been installed with a package
-              manager before installation begins, and will not install or remove any files when the
-              packages are installed.
-            </td>
           </tr>
           <tr>
             <td>934</td>

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -107,11 +107,15 @@ software_check()
     # args: $3: RHEL package
 
     if ! is_package_installed $2 $3 ; then
-	if [ "$MACHINE_OS" == "$UBUNTUKEY" ] && [ ! -z "$2" ]; then
+        if [ "$MACHINE_OS" == "$UBUNTUKEY" ] && [ ! -z "$2" ]; then
             echo -e "\nInstall $2 and restart the $1."
             software_check_retval=1
-	elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then 
+        elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then 
             echo -e "\nInstall $3 and restart the $1."
+            software_check_retval=1
+        else
+            echo -e "\nThe installer could not determine your machine's operating system."
+            echo -e "Supported Operating Systems: ${SUPPORTED_OS_LIST[*]}\n"
             software_check_retval=1
         fi
     fi
@@ -164,8 +168,10 @@ determine_os()
 show_opengee_package_installed()
 {
     #args: $1 "install" or "uninstall"
-    echo -e "\nThe opengee-common package is installed."
-    echo -e "This installer cannot $1 OpenGEE when a package manager install is present."
+    #args: $2 Software name, "Open GEE Fusion", "Open GEE Server"
+
+    echo -e "\nOpen GEE packages installed."
+    echo -e "Cannot $1 $2 because Open GEE packages have been installed with a package manager."
 }
 
 

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -82,22 +82,20 @@ xml_file_get_xpath()
 
 is_package_installed()
 {
-    local package_installed_retval=1
-
     # args: $1: Ubuntu package
     # args: $2: RHEL package
 
     if [ "$MACHINE_OS" == "$UBUNTUKEY" ] && [ ! -z "$1" ]; then
-        if [[ ! -z "$(dpkg --get-selections | sed s:install:: | sed -e 's:\s::g' | grep ^$1)" ]]; then
-            package_installed_retval=0
+        if [[ ! -z "$(dpkg -l $1 | grep "^ii")" ]]; then
+            return 0
         fi
     elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$2" ]; then
         if [[ ! -z "$(rpm -qa | grep ^$2)" ]]; then
-            package_installed_retval=0
+            return 0
         fi
     fi
 
-    return $package_installed_retval
+    return 1
 }
 
 software_check()

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -83,8 +83,8 @@ main_preinstall()
         fi
 
 	if is_package_installed "opengee-common" "opengee-common" ; then
-            show_opengee_package_installed "install"
-            exit 1
+        show_opengee_package_installed "install" "$GEEF"
+        exit 1
 	fi
 
 	if ! check_prereq_software; then

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -82,10 +82,15 @@ main_preinstall()
             exit 1
         fi
 
+	if is_package_installed "opengee-common" "opengee-common" ; then
+            show_opengee_package_installed "install"
+            exit 1
+	fi
+
 	if ! check_prereq_software; then
 		exit 1
 	fi
-	
+
 	# check to see if GE Fusion processes are running
 	if ! check_fusion_processes_running; then
 		show_fusion_running_message

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -77,10 +77,9 @@ main_preinstall()
   fi
 
   if is_package_installed "opengee-common" "opengee-common"; then
-      show_opengee_package_installed "install"
-      exit 1
+    show_opengee_package_installed "install" "$GEES" 
+    exit 1
   fi
-
 
   # 7) Check prerequisite software
   if ! check_prereq_software; then

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -76,6 +76,12 @@ main_preinstall()
     exit 1
   fi
 
+  if is_package_installed "opengee-common" "opengee-common"; then
+      show_opengee_package_installed "install"
+      exit 1
+  fi
+
+
   # 7) Check prerequisite software
   if ! check_prereq_software; then
     exit 1

--- a/earth_enterprise/src/installer/uninstall_fusion.sh
+++ b/earth_enterprise/src/installer/uninstall_fusion.sh
@@ -59,6 +59,11 @@ main_preuninstall()
         exit 1
     fi
 
+    if is_package_installed "opengee-common" "opengee-common"; then
+        show_opengee_package_installed "uninstall"
+        exit 1
+    fi
+
     if ! check_prereq_software; then
         exit 1
     fi

--- a/earth_enterprise/src/installer/uninstall_fusion.sh
+++ b/earth_enterprise/src/installer/uninstall_fusion.sh
@@ -60,7 +60,7 @@ main_preuninstall()
     fi
 
     if is_package_installed "opengee-common" "opengee-common"; then
-        show_opengee_package_installed "uninstall"
+        show_opengee_package_installed "uninstall" "$GEEF"
         exit 1
     fi
 

--- a/earth_enterprise/src/installer/uninstall_server.sh
+++ b/earth_enterprise/src/installer/uninstall_server.sh
@@ -62,8 +62,8 @@ main_preuninstall()
   fi
 
   if is_package_installed "opengee-common" "opengee-common"; then
-      show_opengee_package_installed "uninstall"
-      exit 1
+    show_opengee_package_installed "uninstall" "$GEES"
+    exit 1
   fi
 
   # check to see if GE Server processes are running

--- a/earth_enterprise/src/installer/uninstall_server.sh
+++ b/earth_enterprise/src/installer/uninstall_server.sh
@@ -61,6 +61,11 @@ main_preuninstall()
     exit 1
   fi
 
+  if is_package_installed "opengee-common" "opengee-common"; then
+      show_opengee_package_installed "uninstall"
+      exit 1
+  fi
+
   # check to see if GE Server processes are running
   if check_server_processes_running; then
     show_server_running_message


### PR DESCRIPTION
Added is_package_installed function to common.sh, refactored software_check to use it.

Made install_*.sh and uninstall_*.sh scripts check for opengee-common
installing or removing.

Fixes #837