### PR TITLE
#1079 Added --disable_historical flag to gerewritedbroot

### DIFF
--- a/docs/geedocs/5.2.5/answer/4485225.html
+++ b/docs/geedocs/5.2.5/answer/4485225.html
@@ -385,13 +385,15 @@
   <code><strong>gerewritedbroot</strong></code> <code>--source=<em>server_name</em> --icon_directory=<em>directory</em><br/>
     --dbroot_file=<em>filename</em>  --kml_map_file=<em>filename</em><br/>
     [--search_service=<em>search_service_url</em>] [--kml_server=<em>server_name]</em><br/>
-    [--kml_port=<em>num]</em> [--kml_url_path=<em>prefix]</em> [--use_ssl_for_kml=<em>bool</em>] [--preserve_kml_filenames]</code>
+    [--kml_port=<em>num]</em> [--kml_url_path=<em>prefix]</em> [--use_ssl_for_kml=<em>bool</em>] 
+    [--preserve_kml_filenames] [--disable_historical]</code>
   <h4>Description</h4>
   <ul>
     <li>Reads dbRoot and rewrites the search tabs so that they point to the given search server, port and path.</li>
     <li>Optionally creates a directory of all of the icons referred to by the dbroot. </li>
     <li>Optionally updates the host, path and/or filenames in KML Layer URLs in the dbRoot. </li>
     <li>Optionally creates a text file that lists the mapping from original KML Layer URLs to their updated filenames. </li>
+    <li>Optionally removes the reference to the server for historical imagery data. </li>
   </ul>
   <h4>Required</h4>
   <table class="nice-table">
@@ -440,6 +442,10 @@
       <tr>
         <td><code>--preserve_kml_filenames</code></td>
         <td>Preserve the existing filenames of any KML files. Not used when creating portable globes.</td>
+      </tr>
+      <tr>
+        <td><code>--disable_historical</code></td>
+        <td>Remove the reference to the server to obtain historical data.</td>
       </tr>
     </tbody>
   </table>

--- a/docs/geedocs/5.2.5/answer/4485225.html
+++ b/docs/geedocs/5.2.5/answer/4485225.html
@@ -384,7 +384,7 @@
   <h4>Usage</h4>
   <code><strong>gerewritedbroot</strong></code> <code>--source=<em>server_name</em> --icon_directory=<em>directory</em><br/>
     --dbroot_file=<em>filename</em>  --kml_map_file=<em>filename</em><br/>
-    [--search_service=<em>search_service_url</em>] [--kml_server=<em>server_name]</em><br/>
+    [--search_service=<em>search_service_url</em>] [--preserve_search_service] [--kml_server=<em>server_name]</em><br/>
     [--kml_port=<em>num]</em> [--kml_url_path=<em>prefix]</em> [--use_ssl_for_kml=<em>bool</em>] 
     [--preserve_kml_filenames] [--disable_historical]</code>
   <h4>Description</h4>
@@ -422,6 +422,10 @@
       <tr>
         <td><code>--search_service=<em>search_service_url</em></code></td>
         <td>Url to search service. If none is provided then uses relative url for standard Portable search.</td>
+      </tr>
+       <tr>
+        <td><code>--preserve_search_service</code></td>
+        <td>Preserve the existing search service url.</td>
       </tr>
       <tr>
         <td><code>--kml_server=<em>server_name</em></code></td>

--- a/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
@@ -51,6 +51,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "           --kml_url_path=<kml_url_path_string> \\\n"
           "           --use_ssl_for_kml=<use_ssl_for_kml_bool> \\\n"
           "           --preserve_kml_filenames \\\n"
+          "           --disable_historical \\\n"
           "\n"
           " Reads dbroot and rewrites the search tabs so that they point\n"
           " to the given search server and port. Optionally creates a directory\n"
@@ -88,7 +89,10 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "                    replacing the host and path in KML layer URLs\n"
           "                    in the dbroot.  When unset, files are renamed\n"
           "                    sequentially from kml_dbroot_000.kml upwards.\n"
-          "                    Default: false\n",
+          "                    Default: false\n"
+          "   --disable_historical:\n"    
+          "                    Removes the reference to the server for  \n"
+          "                    historical imagery.\n",
           
           progn.c_str());
   exit(1);
@@ -109,12 +113,14 @@ int main(int argc, char *argv[]) {
   std::string kml_server = "";
   std::string kml_port = "";
   std::string kml_url_path = "kml";
+  bool disable_historical = false;
 
   khGetopt options;
   options.flagOpt("help", help);
   options.flagOpt("?", help);
   options.flagOpt("use_ssl_for_kml", use_ssl_for_kml);
   options.flagOpt("preserve_kml_filenames", preserve_kml_filenames);
+  options.flagOpt("disable_historical", disable_historical);
   options.opt("source", source);
   options.opt("icon_directory", icon_directory);
   options.opt("dbroot_file", dbroot_file);
@@ -171,6 +177,11 @@ int main(int argc, char *argv[]) {
   try {
     // load the dbroot we just fetched from the server
     geProtoDbroot dbroot(dbroot_path, geProtoDbroot::kEncodedFormat);
+
+    // Remove reference to historical imagery server
+    if (disable_historical) {
+        DisableTimeMachine(&dbroot);
+    }
 
     // Remove layers of unused data types.
     RemoveUnusedLayers(data_type, &dbroot);

--- a/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
@@ -71,7 +71,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "                    then uses relative url for standard Portable\n"
           "                    search.\n"
           "   --preserve_search_service:\n" 
-          "                    Keep original search service url\n"
+          "                    Keep original search service url.\n"
           "   --icon_directory: Directory where icons should be stored.\n"
           "   --kml_map_file:  Output file where map of source kml urls to local\n"
           "                    files will be stored.\n"

--- a/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
@@ -104,6 +104,7 @@ int main(int argc, char *argv[]) {
   bool help = false;
   bool use_ssl_for_kml = false;
   bool preserve_kml_filenames = false;
+  bool disable_historical = false;
   std::string source;
   std::string icon_directory;
   std::string dbroot_file;
@@ -113,7 +114,6 @@ int main(int argc, char *argv[]) {
   std::string kml_server = "";
   std::string kml_port = "";
   std::string kml_url_path = "kml";
-  bool disable_historical = false;
 
   khGetopt options;
   options.flagOpt("help", help);

--- a/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/gerewritedbroot.cpp
@@ -45,6 +45,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "           --icon_directory=<icon_directory_string> \\\n"
           "           --dbroot_file=<dbroot_file_string> \\\n"
           "           --search_service=<search_service_url_string> \\\n"
+          "           --preserve_search_service \\\n"
           "           --kml_map_file=<kml_map_file_string> \\\n"
           "           --kml_server=<kml_server_string> \\\n"
           "           --kml_port=<kml_port_string> \\\n"
@@ -69,6 +70,8 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "   --search_service: Url to search service. If none is provided\n"
           "                    then uses relative url for standard Portable\n"
           "                    search.\n"
+          "   --preserve_search_service:\n" 
+          "                    Keep original search service url\n"
           "   --icon_directory: Directory where icons should be stored.\n"
           "   --kml_map_file:  Output file where map of source kml urls to local\n"
           "                    files will be stored.\n"
@@ -104,6 +107,7 @@ int main(int argc, char *argv[]) {
   bool help = false;
   bool use_ssl_for_kml = false;
   bool preserve_kml_filenames = false;
+  bool preserve_search_service = false;
   bool disable_historical = false;
   std::string source;
   std::string icon_directory;
@@ -120,6 +124,7 @@ int main(int argc, char *argv[]) {
   options.flagOpt("?", help);
   options.flagOpt("use_ssl_for_kml", use_ssl_for_kml);
   options.flagOpt("preserve_kml_filenames", preserve_kml_filenames);
+  options.flagOpt("preserve_search_service", preserve_search_service);
   options.flagOpt("disable_historical", disable_historical);
   options.opt("source", source);
   options.opt("icon_directory", icon_directory);
@@ -180,14 +185,16 @@ int main(int argc, char *argv[]) {
 
     // Remove reference to historical imagery server
     if (disable_historical) {
-        DisableTimeMachine(&dbroot);
+      DisableTimeMachine(&dbroot);
     }
 
     // Remove layers of unused data types.
     RemoveUnusedLayers(data_type, &dbroot);
 
     // modify base_url fields in search tabs
-    ReplaceSearchServer(search_service, &dbroot);
+    if (!preserve_search_service) {
+      ReplaceSearchServer(search_service, &dbroot);
+    }
 
     // modify kml_url fields in layers
     std::string new_kml_base_url;

--- a/earth_enterprise/src/fusion/portableglobe/rewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/rewritedbroot.cpp
@@ -171,7 +171,8 @@ void DisableTimeMachine(geProtoDbroot *dbroot) {
   assert(dbroot); 
   keyhole::dbroot::EndSnippetProto* end_snippet =
       dbroot->mutable_end_snippet();
-  keyhole::dbroot::TimeMachineOptionsProto* time_machine_options = end_snippet->mutable_time_machine_options(); 
+  keyhole::dbroot::TimeMachineOptionsProto* time_machine_options =
+      end_snippet->mutable_time_machine_options(); 
   time_machine_options->set_server_url("");
 }
 

--- a/earth_enterprise/src/fusion/portableglobe/rewritedbroot.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/rewritedbroot.cpp
@@ -163,6 +163,19 @@ void ReplaceSearchServer(const std::string &search_service,
 }
 
 /**
+ * Removes the reference to the server that the dbroot references for 
+ * historical imagery.
+ * @param dbroot geProtoDbroot to be modified
+ */
+void DisableTimeMachine(geProtoDbroot *dbroot) {
+  assert(dbroot); 
+  keyhole::dbroot::EndSnippetProto* end_snippet =
+      dbroot->mutable_end_snippet();
+  keyhole::dbroot::TimeMachineOptionsProto* time_machine_options = end_snippet->mutable_time_machine_options(); 
+  time_machine_options->set_server_url("");
+}
+
+/**
  * Replaces server and port in kml references with the given server and port.
  * It also saves the old kml references so that these can be pulled into
  * local files.

--- a/earth_enterprise/src/fusion/portableglobe/rewritedbroot.h
+++ b/earth_enterprise/src/fusion/portableglobe/rewritedbroot.h
@@ -27,6 +27,8 @@ void RemoveUnusedLayers(const std::string &data_type,
 void ReplaceSearchServer(const std::string &search_service,
                          geProtoDbroot *dbroot);
 
+void DisableTimeMachine(geProtoDbroot *dbroot);
+
 void ReplaceReferencedKml(const std::string &new_kml_base_url,
                           const std::string &kml_url_to_file_map_file,
                           const bool preserve_kml_filenames,


### PR DESCRIPTION
This fixes #1079

Portable globes cut from a database with an imagery project with historical imagery enabled contain a reference to the server which they were published from in the dbroot (time_machine_options { server_url: ...). This PR adds an option to the gerewritedbroot utility which sets the server_url field to an empty string.  This solves the issue where EC would hang when trying to open a portable globe with historical data while not having access to the time machine server.

Steps to test:
1. Cut a .glb from a database which has an imagery project with historical imagery. To verify that the dbroot references the server, run `/opt/google/bin/geglxinfo --glx <globe> --extract_all_files --output <output_file>` to extract the globe's files and `/opt/google/bin/gedumpdbroot <output_file>/dbroot/dbroot_localhost_9335` to view the contents of the dbroot.  Search for `time_machine_options` and see that the `server_url` is the server that the globe was cut on.
2. Run `/opt/google/bin/gerewritedbroot --source=<output_file>/dbroot/dbroot_localhost_9335 --dbroot_file=dbroot_localhost_9335 --disable_historical` to create a new dbroot without the reference to the server. Use gedumpdbroot again and see that the `server_url` field is blank.
3. Move the new dbroot into the extracted dbroot directory `mv dbroot_localhost_9335 <output_file>dbroot/`
4. Run `/opt/google/bin/geportableglobepacker --globe_directory <output_file> --output rebuilt_globe.glb --make_copy` to pack the globe files into a new .glb
5. Serve the globe with portable and view in EC