### PR TITLE
Fixes #1038: Allow flat imagery with mercator databases on CLI

### DIFF
--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -254,6 +254,25 @@ instead.
 <pre>
 <code>--sendver dbver </code></pre>
 <p><i>Optional</i>. Specify which database version to send. Use the <code>?version=...</code> syntax. Available database versions may be found with the <code>gequery --versions</code> command.</p>
+<h2>genewmapdatabase</h2>
+  <pre>
+<code><b>genewmapdatabase</b> [--<strong>mercator</strong> | --<strong>flat]</strong> ] -o <em>databasename</em> [--<strong>imagery</strong> <em>imagery project</em>] [--<strong>map</strong> <em>imap project</em>]</code>...</pre>
+  <h3>Purpose</h3>
+  <p>Creates a new 2D map database. If an imagery or map project is specified, it is added to the database. Flat or mercator databases can be created. Mercator databases can use either mercator or flat imagery projects, with mercator projects given priority if there is a nameing collision. Flat databases can only use flat imagery projects.
+
+  <h3>Commands</h3>
+  <pre>
+<code>--mercator </code></pre>
+  <p><i>Optional</i>. Uses Mercator map projection.</p>
+  <pre>
+<code>--flat </code></pre>
+  <p><i>Default</i>. Uses Flat map (Plate Carrée) projection.</p>
+  <pre>
+<code><b>--imagery</b> imagery project </code></pre>
+  <p><i>Optional</i>. The imagery project to be added to the database. If the database is mercator, the imagery project can be flat or mercator, with mercator being given priority during naming collisions. If the database is flat, the imagery project must be flat.</p>
+  <pre>
+<code><b>--map</b> map project </code></pre>
+  <p><i>Optional</i>. The map project to be added to the database.</p>
 <h2>gepublishdatabase</h2>
 <div class="alert">
   <p>Deprecated in GEE 4.0.</p>

--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -258,7 +258,7 @@ instead.
   <pre>
 <code><b>genewmapdatabase</b> [--<strong>mercator</strong> | --<strong>flat]</strong> ] -o <em>databasename</em> [--<strong>imagery</strong> <em>imagery project</em>] [--<strong>map</strong> <em>imap project</em>]</code>...</pre>
   <h3>Purpose</h3>
-  <p>Creates a new 2D map database. If an imagery or map project is specified, it is added to the database. Flat or mercator databases can be created. Mercator databases can use either mercator or flat imagery projects, with mercator projects given priority if there is a nameing collision. Flat databases can only use flat imagery projects.
+  <p>Creates a new 2D map database. If an imagery or map project is specified, it is added to the database. Flat or mercator databases can be created. Mercator databases can use either mercator or flat imagery projects, with mercator projects given priority if there is a naming collision. Flat databases can only use flat imagery projects.
 
   <h3>Commands</h3>
   <pre>

--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -87,6 +87,13 @@ gtag('config', 'UA-108632131-2');
               <code>gestartdaemon</code> and <code>gestopdaemon</code> utilities have been removed.
             </td>
           </tr>
+	  <tr>
+            <td>1038</td>
+            <td><code>genewmapdatabase</code> does not allow flat imagery to be used with mercator databses</td>
+            <td><code>genewmapdatabase</code> now looks for flat imagery projects as well as 
+               mercator imagery projects when adding imagery projects to mercator databases. 
+               Mercator imagery projects are given priority over flat imagery projects in the case of               a naming collision. Flat databases can still only use flat imagery projects.</td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -92,7 +92,9 @@ gtag('config', 'UA-108632131-2');
             <td><code>genewmapdatabase</code> does not allow flat imagery to be used with mercator databses</td>
             <td><code>genewmapdatabase</code> now looks for flat imagery projects as well as 
                mercator imagery projects when adding imagery projects to mercator databases. 
-               Mercator imagery projects are given priority over flat imagery projects in the case of               a naming collision. Flat databases can still only use flat imagery projects.</td>
+               Mercator imagery projects are given priority over flat imagery projects in the 
+               case of a naming collision. Flat databases can still only use flat imagery 
+               projects.</td>
           </tr>
         </tbody>
       </table>

--- a/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
@@ -34,7 +34,7 @@ usage(const std::string &progn, const char *msg = 0, ...)
   }
 
   fprintf(stderr,
-          "\nusage: %s [options] [--meta <key>=<value>]... -o <dbname> [--imagery <imagery project>] [--map <map project>] [--mercator : use mercator projection database] [--flat : use flat(Plate Carre) projection database (default)]\n"
+          "\nusage: %s [options] [--meta <key>=<value>]... -o <dbname> [--imagery <imagery project>] [--map <map project>] [--mercator : use mercator projection] [--flat : use flat(Plate Carre) projection (default)]\n"
           "   Supported options are:\n"
           "      --help | -?:               Display this usage message\n",
           progn.c_str());

--- a/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/genewmapdatabase.cpp
@@ -1,4 +1,5 @@
-// Copyright 2018 Google Inc.
+// Copyright 2017 Google Inc.
+// Copyright 2018 the Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2017 Open GEE Authors
+# Copyright 2018 Open GEE Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2018 Open GEE Authors
+# Copyright 2017 Open GEE Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/publish_tutorial.sh
@@ -32,3 +32,7 @@ echo "Using asset root: $ASSET_ROOT"
 /opt/google/bin/geserveradmin --adddb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc.kmmdatabase/mapdb.kda/ver001/mapdb"
 /opt/google/bin/geserveradmin --pushdb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc.kmmdatabase/mapdb.kda/ver001/mapdb"
 /opt/google/bin/geserveradmin --publishdb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc.kmmdatabase/mapdb.kda/ver001/mapdb" --targetpath /SF_2d_Merc
+
+/opt/google/bin/geserveradmin --adddb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery.kmmdatabase/mapdb.kda/ver001/mapdb"
+/opt/google/bin/geserveradmin --pushdb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery.kmmdatabase/mapdb.kda/ver001/mapdb"
+/opt/google/bin/geserveradmin --publishdb "$ASSET_ROOT/Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery.kmmdatabase/mapdb.kda/ver001/mapdb" --targetpath /SF_2d_Merc_With_Flat_Imagery

--- a/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eu
 #
-# Copyright 2018 Google Inc.
+# Copyright 2017 Google Inc.
+# Copyright 2018 Open GEE Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
@@ -135,7 +135,11 @@ sudo /etc/init.d/geserver restart
 
 /opt/google/bin/genewmapdatabase --mercator -o Tutorial/Databases/SF_2d_Merc --imagery Tutorial/Projects/Imagery/SFBayArea_merc --map Tutorial/Projects/Maps/CAProjects
 
+/opt/google/bin/genewmapdatabase --mercator -o Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery --imagery Tutorial/Projects/Imagery/SFBayArea --map Tutorial/Projects/Maps/CAProjects
+
 /opt/google/bin/gebuild Tutorial/Databases/SF_2d_Merc
+
+/opt/google/bin/gebuild Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery
 
 set +x
 
@@ -156,3 +160,4 @@ echo " The same for all other databases..."
 /opt/google/bin/gequery Tutorial/Databases/SFDb_3d --status
 /opt/google/bin/gequery Tutorial/Databases/SFDb_3d_TM --status
 /opt/google/bin/gequery Tutorial/Databases/SF_2d_Merc --status
+/opt/google/bin/gequery Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery --status

--- a/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/run_tutorial.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/status.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2017 Open GEE Authors
+# Copyright 2018 Open GEE Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/tools/gee_test/status.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/status.sh
@@ -25,3 +25,4 @@ echo "Using asset root: $ASSET_ROOT"
 /opt/google/bin/gequery Tutorial/Databases/SFDb_3d --status
 /opt/google/bin/gequery Tutorial/Databases/SFDb_3d_TM --status
 /opt/google/bin/gequery Tutorial/Databases/SF_2d_Merc --status
+/opt/google/bin/gequery Tutorial/Databases/SF_2d_Merc_With_Flat_Imagery --status

--- a/earth_enterprise/src/fusion/tools/gee_test/status.sh
+++ b/earth_enterprise/src/fusion/tools/gee_test/status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2018 Open GEE Authors
+# Copyright 2017 Open GEE Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Allows `genewmapdatabase` to handle adding a flat imagery project to a mercator database. If there is a naming collision, the mercator imagery project will be prioritized. Documentation was added to for `genewmapdatabase` was added to the command list. Basic tests for this specific issue were incorporated into then gee_tests tutorial scripts. 

The steps below thoroughly test issue. These commands can be run as a shell script from your home directory on a machine that already has the OpenGEE requirements installed.

```
git clone https://github.com/tst-cjeffries/earthenterprise.git

cd earthenterprise/earth_enterprise

sudo /etc/init.d/gefusion stop
sudo /etc/init.d/geserver stop

sudo ./src/installer/uninstall_fusion.sh
sudo ./src/installer/uninstall_server.sh

sudo rm -r /gevol

scons -j8 release=1 build
scons -j8 release=1 stage_install

sudo ./src/installer/install_server.sh
sudo ./src/installer/install_fusion.sh

sudo /etc/init.d/geserver stop
sudo /etc/init.d/geserver start

sudo /etc/init.d/gefusion stop
sudo /etc/init.d/gefusion start

cd /opt/google/share/tutorials/fusion
sudo ./download_tutorial.sh

cd ~

export PATH=$PATH:/opt/google/bin

genewimageryresource --mercator -o Merc1 /opt/google/share/tutorials/fusion/Imagery/bluemarble_4km.tif
genewimageryresource --mercator -o Merc2 /opt/google/share/tutorials/fusion/Imagery/i3SF15-meter.tif
genewimageryresource -o Flat /opt/google/share/tutorials/fusion/Imagery/bluemarble_4km.tif

genewimageryproject --mercator -o Merc Merc1
geaddtoimageryproject --mercator -o Merc Merc2
genewimageryproject --mercator -o NameCollision Merc1
geaddtoimageryproject --mercator -o NameCollision Merc2
genewimageryproject -o Flat Flat
genewimageryproject -o NameCollision Flat

genewmapdatabase --mercator -o Test1MercWithMerc --imagery Merc
genewmapdatabase --mercator -o Test2MercWithFlat --imagery Flat
genewmapdatabase -o Test3FlatWithFlat --imagery Flat
genewmapdatabase --mercator -o Test4MercWithNameCollision --imagery NameCollision
genewmapdatabase -o Test5FlatWithNameCollision --imagery NameCollision

gebuild Test1MercWithMerc
gebuild Test2MercWithFlat
gebuild Test3FlatWithFlat
gebuild Test4MercWithNameCollision
gebuild Test5FlatWithNameCollision

sleep 300

geserveradmin --adddb Test1MercWithMerc
geserveradmin --pushdb Test1MercWithMerc
geserveradmin --publishdb Test1MercWithMerc --targetpath /Test1MercWithMerc

geserveradmin --adddb Test2MercWithFlat
geserveradmin --pushdb Test2MercWithFlat
geserveradmin --publishdb Test2MercWithFlat --targetpath /Test2MercWithFlat

geserveradmin --adddb Test3FlatWithFlat
geserveradmin --pushdb Test3FlatWithFlat
geserveradmin --publishdb Test3FlatWithFlat --targetpath /Test3FlatWithFlat

geserveradmin --adddb Test4MercWithNameCollision
geserveradmin --pushdb Test4MercWithNameCollision
geserveradmin --publishdb Test4MercWithNameCollision --targetpath /Test4MercWithNameCollision

geserveradmin --adddb Test5FlatWithNameCollision
geserveradmin --pushdb Test5FlatWithNameCollision
geserveradmin --publishdb Test5FlatWithNameCollision --targetpath /Test5FlatWithNameCollision
```

Once the databases are all published, open up your web browser and look at each database. Tests 1 and 4 should include some higher resolution San Francisco imagery, while Tests 2,3, and 5 should only have the Blue Marble imagery.