### PR TITLE
Make portable packet walker work for 3d files

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.cpp
@@ -295,7 +295,11 @@ bool FileUnpacker::FindMapDataPacket(const char* qtpath,
 
 bool FileUnpacker::MapDataPacketWalker(int layer, const map_packet_walker& walker)
 {
-  return mapdata_packet_finder_->MapDataPacketWalker(layer, walker);
+  PacketBundleFinder* finder = mapdata_packet_finder_;
+  if (has_3d_data_) {
+    finder = data_packet_finder_;
+  }
+  return finder->MapDataPacketWalker(layer, walker);
 }
 
 /**


### PR DESCRIPTION
Addresses #954 

This is not yet used in portable server code.  Walking packets in the file unpacker should work the same for 3d portable files as it does for 2d portable files.

To verify this change simply ensure opengee and portable both still build without errors.