### PR TITLE
Fixes #1037: Add new CLI parameter to match UI levels.

### DIFF
--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -72,7 +72,7 @@
   <h2>geaddtoimageryproject</h2>
   <pre>
 <code><b>geaddtoimageryproject</b> [--<strong>mercator</strong> | --<strong>flat]</strong> [--<strong>historical_imagery</strong> |
---<strong>no_historical_imagery</strong>] -o <em>projectname</em>{[--<strong>maxlevel</strong> <em>level</em>] <em>insetresource</em>}</code>...</pre>
+--<strong>no_historical_imagery</strong>] -o <em>projectname</em> {[--<strong>maxlevel</strong> <em>level</em> | --<strong>maxleveloverride</strong> <em>level</em>] <em>insetresource</em>}</code>...</pre>
   <h3>Purpose</h3>
   <p>Creates a new imagery project. This tool is capable of building Mercator imagery projects for 2D databases, or Flat (Plate Carrée) imagery projects with or without Historic Imagery Support for 3D databases.
 
@@ -89,8 +89,15 @@
   <pre>
 <code><b>--no_historical_imagery </b></code></pre>
   <p><i>Default</i>. Uses normal imagery for the project.</p>
-  <h2><a name="63542"></a>geconfigureassetroot</h2>
+  <h3>Options</h3>
   <pre>
+  <code><b>--maxlevel </b><i>level</i></code></pre>
+  <div class="alert"> Deprecated in release GEE 5.2.5 and higher. Use <code>--maxleveloverride</code></a> instead.</div>
+  <p><i>Optional</i>. Sets the maximum level for the imagery. Uses internal Fusion scale. Does not match the levels in the Fusion UI.</p>
+  <pre>
+  <code><b>-maxleveloverride </b><i>level</i></code></pre>
+  <p><i>Optional</i>. Sets the maximum level for the imagery. Uses the imagery scale in Fusion. Matches the levels in the Fusion UI.</p>
+ <h2><a name="63542"></a>geconfigureassetroot</h2>
 <code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>
   <h3>Purpose</h3>
   <p>To add volume definitions or edit existing volume definitions.</p>

--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -93,7 +93,7 @@
   <pre>
   <code><b>--maxlevel </b><i>level</i></code></pre>
   <div class="alert"> Deprecated in release GEE 5.2.5 and higher. Use <code>--maxleveloverride</code></a> instead.</div>
-  <p><i>Optional</i>. Sets the maximum level for the imagery. Uses internal Fusion scale. Does not match the levels in the Fusion UI.</p>
+  <p><i>Optional</i>. Sets the maximum level for the imagery. Uses internal Fusion scale. Deprecated because it not match the levels specified in the Fusion UI.</p>
   <pre>
   <code><b>--maxleveloverride </b><i>level</i></code></pre>
   <p><i>Optional</i>. Sets the maximum level for the imagery. Uses the imagery scale in Fusion. Matches the levels in the Fusion UI.</p>

--- a/docs/geedocs/5.2.5/answer/3481558.html
+++ b/docs/geedocs/5.2.5/answer/3481558.html
@@ -95,7 +95,7 @@
   <div class="alert"> Deprecated in release GEE 5.2.5 and higher. Use <code>--maxleveloverride</code></a> instead.</div>
   <p><i>Optional</i>. Sets the maximum level for the imagery. Uses internal Fusion scale. Does not match the levels in the Fusion UI.</p>
   <pre>
-  <code><b>-maxleveloverride </b><i>level</i></code></pre>
+  <code><b>--maxleveloverride </b><i>level</i></code></pre>
   <p><i>Optional</i>. Sets the maximum level for the imagery. Uses the imagery scale in Fusion. Matches the levels in the Fusion UI.</p>
  <h2><a name="63542"></a>geconfigureassetroot</h2>
 <code><b>geconfigureassetroot</b> {<b>--new</b> <b>--assetroot </b><i>path </i> [<b>--srcvol </b><i>path</i>] | <b>--repair</b> | <b>--editvolumes</b> | <b>--listvolumes</b> | <b>--addvolume</b> | <b>--fixmasterhost</b> | <strong>--noprompt</strong>}  [--nochown]</code></pre>

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -117,10 +117,11 @@ main(int argc, char *argv[]) {
 
     if (overridemax) {
       if (AssetType == AssetDefs::Imagery) {
-        overridemax = ImageryToProductLevel(overridemax_deprecated);
+        overridemax = ImageryToProductLevel(overridemax);
       }
       else {
-        overridemax = TmeshToProductLevel(overriddemax_deprecated);
+        overridemax = TmeshToProductLevel(overridemax);
+      }
     }
     
     if (overridemax_deprecated) {

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -126,6 +126,9 @@ main(int argc, char *argv[]) {
     
     if (overridemax_deprecated) {
       overridemax = overridemax_deprecated;
+      notify(NFY_WARN, "--maxlevel is deprecated, please use --maxleveloverride. "
+		      "To move to the new  command, subtract 8 from the level for imagery, and "
+		      "subtract 5 from the level for terrain.");
     }
 
     // Default to flat unless mercator imagery is specified.

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -117,10 +117,10 @@ main(int argc, char *argv[]) {
 
     if (overridemax) {
       if (AssetType == AssetDefs::Imagery) {
-        overridemax = ProductToImageryLevel(overridemax_deprecated);
+        overridemax = ImageryToProductLevel(overridemax_deprecated);
       }
       else {
-        overridemax = ProductToTmeshLevel(overriddemax_deprecated);
+        overridemax = TmeshToProductLevel(overriddemax_deprecated);
     }
     
     if (overridemax_deprecated) {

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -127,7 +127,7 @@ main(int argc, char *argv[]) {
     if (overridemax_deprecated) {
       overridemax = overridemax_deprecated;
       notify(NFY_WARN, "--maxlevel is deprecated, please use --maxleveloverride. "
-		      "To move to the new  command, subtract 8 from the level for imagery, and "
+		      "To move to the new command, subtract 8 from the level for imagery, and "
 		      "subtract 5 from the level for terrain.");
     }
 

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -50,7 +50,7 @@ usage(const std::string &progn, const char *msg = 0, ...)
           "                         (i.e., not a historical imagery project)\n"
           "   By default, new projects are NOT time machine projects"
           " unless --historical_imagery is specified.\n"
-	  "      --maxleveloverride <level> : Set the max level for a resource.\n",
+          "      --maxleveloverride <level> : Set the max level for a resource.\n",
           progn.c_str());
   exit(1);
 }

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -38,7 +38,7 @@ usage(const std::string &progn, const char *msg = 0, ...)
   }
 
   fprintf(stderr,
-          "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+          "\nusage: %s [options] -o <projectname> {[--maxleveloverride <level>] "
           "<insetresource>}...\n"
           "   Supported options are:\n"
           "      --help | -?:      Display this usage message\n"
@@ -49,7 +49,8 @@ usage(const std::string &progn, const char *msg = 0, ...)
           "      --no_historical_imagery : make this a normal project\n"
           "                         (i.e., not a historical imagery project)\n"
           "   By default, new projects are NOT time machine projects"
-          " unless --historical_imagery is specified.\n",
+          " unless --historical_imagery is specified.\n"
+	  "      --maxleveloverride <level> : Set the max level for a resource.\n",
           progn.c_str());
   exit(1);
 }


### PR DESCRIPTION
Fixes issue #1037. Adds a new CLI parameter, `--maxleveloverride`, for `genew*project`, `geaddto*project`, and `gemodify*project`. This parameter does the same thing as `--maxlevel` but uses the Terrain/Imagery levels instead of the internal "Product" level so that it matches the Fusion UI. At the same time, we will deprecated `--maxlevel`.

To test, install OpenGEE (Id recommend a clean VM) and add some imagery/terrain using the CLI and the `--maxleveloverride` parameter. The following commands can  be run as a shell script, or manually.

```
cd ~

git clone https://github.com/tst-cjeffries/earthenterprise.git

cd earthenterprise/earth_enterprise

sudo /etc/init.d/gefusion stop
sudo /etc/init.d/geserver stop

sudo ./src/installer/uninstall_fusion.sh
sudo ./src/installer/uninstall_server.sh

sudo rm -r /gevol

scons -j8 release=1 build
scons -j8 release=1 stage_install

sudo ./src/installer/install_server.sh
sudo ./src/installer/install_fusion.sh

sudo /etc/init.d/geserver stop
sudo /etc/init.d/geserver start

sudo /etc/init.d/gefusion stop
sudo /etc/init.d/gefusion start

cd /opt/google/share/tutorials/fusion
sudo ./download_tutorial.sh

cd ~

export PATH=$PATH:/opt/google/bin

genewimageryresource -o TestImageryResourceNew /opt/google/share/tutorials/fusion/Imagery/i3SF15-meter.tif
genewimageryresource -o TestImageryResourceDeprecated /opt/google/share/tutorials/fusion/Imagery/i3SF15-meter.tif
genewterrainresource -o TestTerrainResourceNew /opt/google/share/tutorials/fusion/Terrain/SF_terrain.tif
genewterrainresource -o TestTerrainResourceDeprecated /opt/google/share/tutorials/fusion/Terrain/SF_terrain.tif

genewimageryproject -o TestImageryProject
geaddtoimageryproject -o TestImageryProject --maxlevel 12 TestImageryResourceDeprecated
geaddtoimageryproject -o TestImageryProject --maxleveloverride 12 TestImageryResourceNew
genewterrainproject -o TestTerrainProject
geaddtoterrainproject -o TestTerrainProject --maxlevel 10 TestTerrainResourceDeprecated
geaddtoterrainproject -o TestTerrainProject --maxleveloverride 10 TestTerrainResourceNew
genewimageryproject -o TestImageryProject2 --maxleveloverride 12 TestImageryResourceNew
genewimageryproject -o TestImageryProject3 --maxleveloverride 12 TestImageryResourceNew
gemodifyimageryproject -o TestImageryProject3 --maxleveloverride 11 TestImageryResourceNew
genewterrainproject -o TestTerrainProject2 --maxleveloverride 10 TestTerrainResourceNew
genewterrainproject -o TestTerrainProject3 --maxleveloverride 10 TestTerrainResourceNew
gemodifyterrainproject -o TestTerrainProject3 --maxleveloverride 9 TestTerrainResourceNew
```

After running these commands, the first two imagery/terrain projects should have two resources, one for the new and one for the old maxlevel commands. The new command resource should have the FusionUI level matching the level provided in the parameter. The deprecated command resource should not match, and should be 8 levels lower for imagery, and 5 levels lower for terrain. Terrain/ImageryProject2 should have a single resource that matches the CLI parameter, and Terrain/ImageryProject3 should have a single resource that matches the CLI parameter of the modify command.