### PR TITLE
New versioning logic using automatically generated build numbers

### DIFF
--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -55,7 +55,7 @@ def _GitCommitCount(tagName='HEAD', baseRef=''):
     if not baseRef:
         return len(list(repo.iter_commits(tagName)))
     else:
-        return len(list(repo.iter_commits(baseRef + '.' + tagName)))
+        return len(list(repo.iter_commits(baseRef + '..' + tagName)))
 
 
 def _GitVersionNameAndBuildNumber():

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -87,10 +87,20 @@ def _IsReleaseBranch(branchName):
     # a release branch begins with 'release_' and has
     # a base tag that matches the release name
     if branchName[:8] == 'release_':
-        if _gitHasTag(_GetReleaseVersionName(branchName)):
+        versionName = _GetReleaseVersionName(branchName)
+        if _gitHasTag(versionName):
             return True
-    
-    return False
+        else:
+            # see if we can pull the tag down from any of the remotes
+            repo = _GetRepository()
+            for remote in repo.remotes:
+                try:
+                    remote.fetch('+refs/tags/{0}:refs/tags/{0}'.format(versionName), None, **{'no-tags':True})
+                except TypeError:
+                    pass
+            
+            # try one more time after the fetch attempt(s)
+            return _gitHasTag(versionName)
 
 def _gitHasTag(tagName):
     """See if a tag exists in git"""

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -116,7 +116,7 @@ def _GitPreviousReleaseTag(versionName):
 
     for tag in tags:
         if tag.name != tailTag.name:
-            if  _IsReleseBuildTag(tag.name):
+            if  _IsReleaseBuildTag(tag.name):
                 if  _GitTagRealCommitId(tag.name) == _GitTagRealCommitId(tailTag.name):
                     return tag.name
     
@@ -129,7 +129,7 @@ def _GitTagRealCommitId(tagName):
     return os.popen("git rev-list -n 1 '{0}'".format(tagName.replace("'", "'\"'\"'"))).read().strip()
 
 
-def _IsReleseBuildTag(tagName):
+def _IsReleaseBuildTag(tagName):
     """checks if the tag follows the pattern where if the
     tag is split on dash and the has at least two elements
     and the first two elements is a series of numbers delimited

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -160,6 +160,8 @@ def _IsReleaseBranch(branchName):
             
             # try one more time after the fetch attempt(s)
             return (_gitHasTag(versionName) is not None)
+    else:
+        return False
 
 
 def _gitHasTag(tagName):

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime
 import re
 
+
 def GetVersion(backupFile, label=''):
     """As getLongVersion(), but only return the leading *.*.* value."""
 
@@ -40,11 +41,13 @@ def GetLongVersion(backupFile, label=''):
 
     return ret
 
+
 def _GitGeneratedLongVersion():
     """Calculate the version name and build number into a single build string."""
 
     versionName, buildNumber = _GitVersionNameAndBuildNumber()
     return "{0}-{1}".format(versionName, buildNumber)
+
 
 def _GitCommitCount(baseRef=''):
     """calculate git commit counts"""
@@ -53,6 +56,7 @@ def _GitCommitCount(baseRef=''):
         return len(list(repo.iter_commits('HEAD')))
     else:
         return len(list(repo.iter_commits(baseRef + '..HEAD')))
+
 
 def _GitVersionNameAndBuildNumber():
     """Get the version name and build number based on state of git
@@ -82,6 +86,7 @@ def _GitVersionNameAndBuildNumber():
             else:
                 return _sanitizeBranchName(branchName),  _GitCommitCount()
 
+
 def _IsReleaseBranch(branchName):
     """Check if the branch name is a release branch"""
     # a release branch begins with 'release_' and has
@@ -102,17 +107,21 @@ def _IsReleaseBranch(branchName):
             # try one more time after the fetch attempt(s)
             return _gitHasTag(versionName)
 
+
 def _gitHasTag(tagName):
     """See if a tag exists in git"""
     return (next((tag for tag in _GetRepository().tags if tag.name == tagName), None) is not None)
+
 
 def _sanitizeBranchName(branchName):
     """sanitize branch names to ensure some characters are not used"""
     return re.sub('[$?*`\\-"\'\\\\/\\s]', '_', branchName)
 
+
 def _GetReleaseVersionName(branchName):
     """removes pre-pended 'release_' from branch name"""
     return branchName[8:]
+
 
 def _GitBranchName():
     """Returns current branch name or empty string"""
@@ -120,6 +129,7 @@ def _GitBranchName():
         return _GetRepository().active_branch.name
     except TypeError:
         return ''
+
 
 def _IsGitDescribeFirstParentSupported():
     """Checks whether --first-parent parameter is valid for the
@@ -154,74 +164,6 @@ def _IsCurrentCommitTagged(raw):
     return (len(raw.split("-")) < 4)
 
 
-def _VersionForTaggedHead(raw):
-    """When we're on the tagged commit, the version string is
-    either the tag itself (when repo is clean), or the tag with
-    date appended (when repo has uncommitted changes)"""
-    if _CheckDirtyRepository():
-        # Append the date if the repo contains uncommitted files
-        return '.'.join([raw, _GetDateString()])
-    return raw
-
-
-def _VersionFromTagHistory(raw):
-    """From the HEAD revision, this function finds the most recent
-    reachable version tag and returns a string representing the
-    version being built -- which is one version beyond the latest
-    found in the history."""
-
-    # Tear apart the information in the version string.
-    components = _ParseRawVersionString(raw)
-
-    # Determine how to update, since we are *not* on tagged commit.
-    if components['isFinal']:
-        components['patch'] = 0
-        components['patchType'] = "alpha"
-        components['revision'] = components['revision'] + 1
-    else:
-        components['patch'] = components['patch'] + 1
-
-    # Rebuild.
-    base = '.'.join([str(components[x]) for x in ("major", "minor", "revision")])
-    patch = '.'.join([str(components["patch"]), components["patchType"], _GetDateString()])
-    if not _CheckDirtyRepository():
-        patch = '.'.join([patch, components['hash']])
-
-    return '-'.join([base, patch])
-
-
-def _ParseRawVersionString(raw):
-    """Break apart a raw version string into its various components,
-    and return those entries via a dictionary."""
-
-    components = { }
-
-    # major.minor.revision-patch[.patchType][-commits][-hash]
-    rawComponents = raw.split("-")
-
-    base = rawComponents[0]
-    patchRaw = '' if not len(rawComponents) > 1 else rawComponents[1]
-    components['commits'] = -1 if not len(rawComponents) > 2 else rawComponents[2]
-    components['hash'] = None if not len(rawComponents) > 3 else rawComponents[3]
-
-    # Primary version (major.minor.revision)
-    baseComponents = base.split(".")
-    components['major'] = int(baseComponents[0])
-    components['minor'] = int(baseComponents[1])
-    components['revision'] = int(baseComponents[2])
-
-    # Patch (patch[.patchType])
-    components['isFinal'] = ((patchRaw[-5:] == "final") or
-                             (patchRaw[-7:] == "release"))
-
-    patchComponents = patchRaw.split(".")
-    components['patch'] = int(patchComponents[0])
-    components['patchType'] = 'alpha' if not len(patchComponents) > 1 else patchComponents[1]
-
-    repo = _GetRepository()
-    return components
-
-
 def _CheckGitAvailable():
     """Try the most basic of git commands, to see if there is
        currently any access to a repository."""
@@ -244,14 +186,6 @@ def _GetRepository():
         return git.Repo('.')
 
 
-def _CheckDirtyRepository():
-    """Check to see if the repository is not in a cleanly committed state."""
-    repo = _GetRepository()
-    str = repo.git.status("--porcelain")
-
-    return (len(str) > 0)
-
-
 def _ReadBackupVersionFile(target):
     """There should be a file checked in with the latest version
     information available; if git isn't available to provide
@@ -266,6 +200,7 @@ def _ReadBackupVersionFile(target):
 def _GetDateString():
     """Returns formatted date string representing current UTC time"""
     return datetime.utcnow().strftime("%Y%m%d%H%M")
+
 
 class OpenGeeVersion(object):
     """A class for storing Open GEE version information."""

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -61,11 +61,11 @@ def _GitVersionNameAndBuildNumber():
     otherwise use the branch name"""
 
     # For tagged commits use the tag
-    raw = _GetCommitRawDescription()
-    if _IsCurrentCommitTagged(raw):
+    rawDescription = _GetCommitRawDescription()
+    if _IsCurrentCommitTagged(rawDescription):
         # Extract version name and build number
         # from the tag (should be a release build tag)
-        splitTag = raw.split('-')
+        splitTag = rawDescription.split('-')
         return splitTag[0], splitTag[1]
     else:
         # Use branch name if we are not a detached HEAD
@@ -73,7 +73,7 @@ def _GitVersionNameAndBuildNumber():
         if not branchName:
             # we are a detached head not on a tag so just treat the
             # raw describe like a topic branch name
-            return raw, _GitCommitCount()
+            return rawDescription, _GitCommitCount()
         else:
             # Get the version name from the branch name
             if _IsReleaseBranch(branchName):
@@ -93,12 +93,15 @@ def _IsReleaseBranch(branchName):
     return False
 
 def _gitHasTag(tagName):
+    """See if a tag exists in git"""
     return (next((tag for tag in _GetRepository().tags if tag.name == tagName), None) is not None)
 
 def _sanitizeBranchName(branchName):
+    """sanitize branch names to ensure some characters are not used"""
     return re.sub('[$?*`\\-"\'\\\\/\\s]', '_', branchName)
 
 def _GetReleaseVersionName(branchName):
+    """removes pre-pended 'release_' from branch name"""
     return branchName[8:]
 
 def _GitBranchName():

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -96,7 +96,7 @@ def _IsReleaseBranch(branchName):
             for remote in repo.remotes:
                 try:
                     remote.fetch('+refs/tags/{0}:refs/tags/{0}'.format(versionName), None, **{'no-tags':True})
-                except TypeError:
+                except git.exc.GitCommandError:
                     pass
             
             # try one more time after the fetch attempt(s)


### PR DESCRIPTION
Addresses issue #1101.  New versioning logic that uses branch names for version name and commit log counts for build number

**Creating a release branch** is done by branching from master or from a previous release tag and naming the branch `release_<version name>` where version name should follow GEE normal version rules as they are today (minus the old patch number and the quality tag (i.e. alpha, beta, and final)).  Also when creating a release branch you are required to create a branch 'tail tag' that should have the same name as what was used for the 'version name'.  
**Closing out a release** you have to add the final release tag to the head of the release branch (should be what is returned from the getversion.py script) and then remove the 'tail tag'

**Note:** a future PR will have scripts to automate the above steps, update the documentation, and a script to return the git hash given the build number of a release.

Things to test (tip do testing on a clone you can just through way):
1) create a release branch from point within master
  a) should generate a version like `5.2.5-707.1` where the `5.2.2` is what follows `release_` in the branch name and `707` is the commit count at the point of the branch and the the `1` is the number of commits post branching.
  b) even after merging back to master the build number should stay the same
  c) create a tag simulating the end of the release and remove the 'tail tag'.  Version number should still be the same as it should pick it up from the release tag.
  d) re-open release branch by adding the 'tail tag' back in.  Do a few commits.  build number should increase again
  e) close branch back out by adding another release tag and removing the 'tail tag'.  Version number should be the same
  f) checkout using one of the above release tags.  Version number should still be the same on disconnected head.
2) do the same thing but create the release branch from one of the previous releases (note: you need to use a new 'version name' so if your previous release had a version name of `5.2.5` you should do something like `5.2.5.1`
3) should also test running getversion on an open release but where the 'tail tag' does not exist in the clone but instead exists in a remote known to the local clone.  This tag should be automatically pulled down for the user.
4) also test building and running a few smoke tests.