### PR TITLE
Issue #1104 - OpenGEE Build Fails on Centos 7

### DIFF
--- a/earth_enterprise/src/third_party/qt/SConscript
+++ b/earth_enterprise/src/third_party/qt/SConscript
@@ -69,8 +69,6 @@ if third_party_env['is_min_ubuntu'] and not third_party_env['native_cc']:
 else:
   env_opt += ''
 
-env_opt += ' PKG_CONFIG_PATH=. '
-
 if qt_env['release'] or qt_env['optimize']:
   config_opt = '-release'
 else:
@@ -82,12 +80,12 @@ qt_configure = qt_env.Command(
     qt_target, qt_patch,
     [qt_env.MultiCommand(
         'cd %s\n'
-        'ln -s /usr/lib64/pkgconfig/libpng12.pc libpng.pc\n'
         'echo yes | %s%s ./configure -platform linux-g++-64 '
         '-prefix /opt/google/qt '
         '-no-exceptions '
         '-system-zlib '
         '-system-libjpeg -system-libmng ' #-system-libpng
+        '-I/usr/include/libpng12 '
         '-qt-imgfmt-jpeg -qt-imgfmt-mng '
         '-thread '
         '-shared -no-cups -freetype -stl -xcursor -xinerama -xrandr -xrender '

--- a/earth_enterprise/src/third_party/qt/SConscript
+++ b/earth_enterprise/src/third_party/qt/SConscript
@@ -69,6 +69,8 @@ if third_party_env['is_min_ubuntu'] and not third_party_env['native_cc']:
 else:
   env_opt += ''
 
+env_opt += ' PKG_CONFIG_PATH=. '
+
 if qt_env['release'] or qt_env['optimize']:
   config_opt = '-release'
 else:
@@ -80,6 +82,7 @@ qt_configure = qt_env.Command(
     qt_target, qt_patch,
     [qt_env.MultiCommand(
         'cd %s\n'
+        'ln -s /usr/lib64/pkgconfig/libpng12.pc libpng.pc\n'
         'echo yes | %s%s ./configure -platform linux-g++-64 '
         '-prefix /opt/google/qt '
         '-no-exceptions '


### PR DESCRIPTION
This bug is due to an update of Centos 7 from "7.5" to "7.6" - libpng15 is added in "7.6", and is incompatible with libpng12.
