### PR TITLE
change tail tag to a less release sounding name

### DIFF
--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -69,7 +69,6 @@ def _GitVersionNameAndBuildNumber():
     if _IsCurrentCommitReleaseTagged():
         # Extract version name and build number
         # from the tag (should be a release build tag)
-        print "spliting raw description: " + rawDescription
         splitTag = rawDescription.split('-')
         return splitTag[0], splitTag[1]
     else:
@@ -83,10 +82,8 @@ def _GitVersionNameAndBuildNumber():
             # Get the version name from the branch name
             if _IsReleaseBranch(branchName):
                 tailTag = _GetReleaseTailTag(branchName)
-                print "looking for tail tag: " + tailTag
                 return _GetReleaseVersionName(branchName), '{0}.{1}'.format(_GitBranchedCommitCount(tailTag), _GitCommitCount('HEAD', tailTag))
             else:
-                print "not a release branch"
                 return _sanitizeBranchName(branchName),  str(_GitCommitCount())
 
 
@@ -234,7 +231,6 @@ def _IsCurrentCommitReleaseTagged():
     headCommit = _GitTagRealCommitId('HEAD')
     for tag in tags:
         if headCommit == _GitTagRealCommitId(tag.name) and _IsReleaseBuildTag(tag.name):
-            print "releaes tag found"
             return True
         else:
             pass

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -66,9 +66,10 @@ def _GitVersionNameAndBuildNumber():
 
     # For tagged commits use the tag
     rawDescription = _GetCommitRawDescription()
-    if _IsCurrentCommitTagged(rawDescription):
+    if _IsCurrentCommitReleaseTagged():
         # Extract version name and build number
         # from the tag (should be a release build tag)
+        print "spliting raw description: " + rawDescription
         splitTag = rawDescription.split('-')
         return splitTag[0], splitTag[1]
     else:
@@ -82,8 +83,10 @@ def _GitVersionNameAndBuildNumber():
             # Get the version name from the branch name
             if _IsReleaseBranch(branchName):
                 tailTag = _GetReleaseTailTag(branchName)
+                print "looking for tail tag: " + tailTag
                 return _GetReleaseVersionName(branchName), '{0}.{1}'.format(_GitBranchedCommitCount(tailTag), _GitCommitCount('HEAD', tailTag))
             else:
+                print "not a release branch"
                 return _sanitizeBranchName(branchName),  str(_GitCommitCount())
 
 
@@ -223,10 +226,20 @@ def _GetCommitRawDescription():
     return raw
 
 
-def _IsCurrentCommitTagged(raw):
+def _IsCurrentCommitReleaseTagged():
     """True if the current commit is tagged, otherwise False"""
     # If this condition hits, then we are currently on a tagged commit.
-    return (len(raw.split("-")) < 4)
+    repo = _GetRepository()
+    tags = _GetRepository().tags
+    headCommit = _GitTagRealCommitId('HEAD')
+    for tag in tags:
+        if headCommit == _GitTagRealCommitId(tag.name) and _IsReleaseBuildTag(tag.name):
+            print "releaes tag found"
+            return True
+        else:
+            pass
+    
+    return False
 
 
 def _CheckGitAvailable():

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -226,7 +226,6 @@ def _GetCommitRawDescription():
 def _IsCurrentCommitReleaseTagged():
     """True if the current commit is tagged, otherwise False"""
     # If this condition hits, then we are currently on a tagged commit.
-    repo = _GetRepository()
     tags = _GetRepository().tags
     headCommit = _GitTagRealCommitId('HEAD')
     for tag in tags:


### PR DESCRIPTION
Fixes issue #1111 and adds a `-RC1` to the tail tag