### PR TITLE
#1122 Explicitly import Image module from PIL

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
@@ -29,8 +29,8 @@ import sys
 
 try:
   pil_enabled = True
-  import Image
-  import ImageFile
+  from PIL import Image
+  from PIL import ImageFile
 except ImportError:
   pil_enabled = False
   print "PIL is not available."


### PR DESCRIPTION
This closes #1122. Portable - test for Python Imaging Library may returns an error "PIL is not available" depending on PIL installation method. 