### PR TITLE
WIP: Fixes #782 migrate fusion hostname

### DIFF
--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -37,7 +37,6 @@ Usage:
    - and optionally, the Server hostname, if different
 """
 
-
 import os
 import sys
 import shutil

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -98,7 +98,7 @@ _DRYRUN = True  # Test only - Skip all permanent/destructive changes
 
 #### Function Definitions ####
 
-def change_hostname_server_only():
+def migrate_hostname_server_only():
     """Change the hostname for a GEE Server-only machine.
 
     *** Requires root permissions. ***
@@ -109,7 +109,7 @@ def change_hostname_server_only():
 
     Note: This is for GEE Server-only machines.
         For a Development machine (Server + Fusion), use
-        change_hostname_dev_machine()
+        migrate_hostname_dev_machine()
 
     If global _DRYRUN is true, will test each step but
     not execute any permanent changes.
@@ -168,7 +168,7 @@ def change_hostname_server_only():
     # TODO return something?
 
 
-def change_hostname_dev_machine():
+def migrate_hostname_dev_machine():
     """Change the hostname for a Development machine
         (contains both Fusion and GEE Server)
 
@@ -180,7 +180,7 @@ def change_hostname_dev_machine():
 
     Note: This is for machines with BOTH GEE Fusion and GEE Server
         For GEE Server-only machines, use
-        change_hostname_server_only()
+        migrate_hostname_server_only()
 
     If global _DRYRUN is true, will test each step but
     not execute any permanent changes.
@@ -311,6 +311,43 @@ def handle_input_args():
         exit_early("Error: Must specify mode (Server/Dev)")
         # TODO add "usage" message?
 
+
+def change_hostname(new_name):
+    """Update system hostname.
+
+    Args:
+        new_name: The new hostname (str)
+                  Must be a valid Unix hostname
+
+    Returns:
+        Return code of hostnamectl call
+
+    Raises:
+        Passes any uncaught exceptions from subprocess call
+        (ValueError, OSError, etc.)
+    """
+    # TODO this might be OS dependent - only tested on Centos7
+
+    my_args = ["hostnamectl",
+               "set-hostname",
+               _NEW_HOSTNAME,
+               ]
+
+    if _DRYRUN:
+        print "dryrun: skipping change_hostname"
+        return 0
+    else:
+        # run subprocess
+        pass
+
+               
+
+def change_IP():
+    """Update system IP address.
+
+    """
+    print "Warning: udpate_IP() not yet implemented."
+    pass
 
 
 def daemon_start_stop(daemon, command):
@@ -597,12 +634,12 @@ def main():
 
         # TODO any more checks?
 
-        change_hostname_dev_machine()
+        migrate_hostname_dev_machine()
 
     elif _MODE == "SERVER":
         # TODO check if in SERVER mode if hostname matches (need new input arg)
 
-        change_hostname_server_only()
+        migrate_hostname_server_only()
 
     else:
         # TODO raise exception instead?

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -337,6 +337,7 @@ def change_hostname(new_hostname):
     """
     # TODO this might be OS dependent - only tested on Centos7
     # TODO may need to check OS (Centos/Red Hat/Ubuntu at runtime)
+    # TODO update /etc/hosts too?
 
     my_args = ["hostnamectl",
                # TODO add --no-ask-password arg?

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -31,7 +31,9 @@ import subprocess
 from socket import gethostname    # preferred way to get hostname
 
 
-# TODO fix tabs/spaces, use pylint to check
+# Main To-Do List (see also inline TODO's!):
+# TODO run pylint
+# TODO add user confirmation before deletions, etc.
 
 # GLOBALS:
 
@@ -101,12 +103,14 @@ def change_hostname_server_only():
     # Remove the contents of /gevol/published_dbs/stream_space
     # and /gevol/published_dbs/search_space.
     # TODO Prompt user before deletion?
+    # TODO use return codes?
     delete_folder_contents(_PUBLISHED_STREAM_FOLDER)
     delete_folder_contents(_PUBLISHED_SEARCH_FOLDER)
 
     # TODO Change directory to /tmp 
     # and execute 
     # sudo -u gepguser /opt/google/bin/geresetpgdb.
+    # TODO START HERE. CHECK ABOVE STUFF TOO!
 
     # Start the GEE Server: /etc/init.d/geserver start.
     daemon_start_stop(_SERVER_DAEMON, "start")

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -326,6 +326,9 @@ def handle_input_args():
 def change_hostname(new_hostname):
     """Update system hostname.
 
+    Requires sufficient user permission to change hostname,
+    but not necessarily root.
+
     Args:
         new_name: The new hostname (str)
                   Must be a valid Unix hostname

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -17,6 +17,148 @@
 #	- GEE Server only (no Fusion)
 #	- Development System (both Fusion and GEE Server)
 # Both have similar steps with minor differences.
+#
+# Usage:
+# - user provides current hostname and the new hostname
+#	- and optionally, the Server hostname, if different
+# 
 
+import os
+import sys
 import argparse
 import subprocess
+from socket import gethostname	# preferred way to get hostname
+
+
+# TODO fix tabs/spaces, use pylint to check
+
+# GLOBALS:
+# Internal Globals:
+# Constants:
+_FUSION_DAEMON = "/etc/init.d/gefusion"
+_SERVER_DAEMON = "/etc/init.d/geserver"
+
+
+# TODO change non-consts to lowercase
+_OLD_HOSTNAME = None	# Current hostname of Fusion machine
+_NEW_HOSTNAME = None	# New hostname to change to
+_MODE = None		# Server-only or Dev/Combo machine (Fusion + Server)
+# TODO replace "MODE" with something like "_HAS_FUSION"?
+_DRYRUN = False		# Don't make any real changes, just test workflow/permissions
+
+
+def exit_early(msg="", errcode=1):
+	"""Print msg and exit with status code errcode.
+	
+	Convenience function to exit early. Set msg with useful error message
+	if exiting due to an error/exception.
+	Change errcode to 0 if exiting normally.
+
+	Args:
+		msg: Optional error message (string)
+		errcode: Status code to exit with (int)
+	"""
+
+	if msg:
+		print msg
+	print "Exiting..."
+	sys.exit(errcode)
+
+def handle_input_args():
+	"""Parse command line arguments and set global variables."""
+
+	global _MODE, _DRYRUN
+	parser = argparse.ArgumentParser(description="Update GEE Fusion Hostname andfix all existing published GEE databases")
+
+	parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
+	parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
+	parser.add_argument("--dry-run", help="Test only - do not make any actual changes", action="store_true")
+
+	# TODO is mutex group required or do we need to specify that??
+	# TODO necessary to do default=False for store_trues?
+	mode_grp = parser.add_mutually_exclusive_group()
+	mode_grp.add_argument("-s", "--server_only", help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion", action="store_true")
+	mode_grp.add_argument("-c", "--combo_machine", help="Use -d if this is a development machine (Fusion AND GEE Server combined)", action="store_true")
+
+	# TODO do we need the Server hostname? maybe good idea for -s mode even if only as a double check...
+	args = parser.parse_args()
+
+	# Test and Assign Globals:
+
+	_OLD_HOSTNAME = args.old_hostname
+
+	# TODO test that new hostname is a valid hostname, and not null?
+	_NEW_HOSTNAME = args.new_hostname
+
+	if args.server_only:
+		_MODE = "SERVER"
+	elif args.combo_machine:
+		_MODE = "DEV"
+	# else, it stays None
+	# TODO quit early if mode is not specified
+
+
+def daemon_start_stop(daemon, command):
+	"""Send start/stop command to a daemon service.
+
+	Sends the given command to an existing daemon.
+	Only "start" or "stop" are allowed, as stdout output is not checked.
+
+	*** Requires root privileges. ***
+
+	Args:
+		daemon: the full path to an existing system daemon (string)
+			eg. "/etc/init.d/gefusion"
+		command: either "start" or "stop" (string)
+
+	Returns:
+		Exit code of daemon call. (int)
+
+	Raises:
+		ValueError: if given an invalid input for "command"
+		OSError: If "daemon" path is invalid or doesn't exist
+	"""
+	# TODO raise error on lack of root privelige?
+	# TODO is service ok?
+
+	if command not in ["start", "stop"]:
+		raise ValueError("Invalid argument for 'command': only 'start' and 'stop' are allowed.")
+	try:
+		subprocess.check_call([daemon, command])
+	except subprocess.CalledProcessError as e:
+		print "Subprocess Error in %s, exit code: %d" % (daemon, e.returncode)
+		print e.cmd
+		print e.message
+		print e.output
+		return e.returncode
+
+	return 0
+
+
+def main():
+	handle_input_args()
+
+	# Test for valid inputs:
+	# TODO move to separate function?
+	if _MODE is None:
+		exit_early("Error: Must specify mode (Server/Dev)")	# TODO add "usage" message?
+
+	# TODO check for root permission, if necessary?
+
+	if _MODE == "DEV":
+		if (_OLD_HOSTNAME != gethostname()):
+			exit_early("Error: Incorrect current hostname - please double check and retry.")
+		else:
+			print "Old hostname matches... ok!"
+	# TODO check if in SERVER mode if hostname matches (need new input arg)
+
+
+	# **** Stop Daemons ****
+	# this requires root
+	#daemon_start_stop(_SERVER_DAEMON, "stop")
+	#if _MODE == "DEV":
+	#	daemon_start_stop(_FUSION_DAEMON, "stop")
+
+
+if __name__ == "__main__":
+	main()

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -121,7 +121,8 @@ def migrate_hostname_server_only():
         TODO
 
     Raises:
-        TODO
+        Passes any uncaught exceptions from called functions,
+        particularly OSError and ValueError from subprocess calls.
     """
 
     # Shut down the geserver daemon at /etc/init.d/geserver stop.
@@ -129,8 +130,16 @@ def migrate_hostname_server_only():
 
     # TODO confirm daemons stopped?
 
-    # TODO Update the hostname and IP address to the correct
+    # Update the hostname 
+    if prompt_user_confirm("Change hostname to: %s" % _NEW_HOSTNAME):
+        change_hostname(_NEW_HOSTNAME)
+    else:
+        exit_early()  # TODO message?
+
+    # TODO update IP address to the correct
     # entries for the machine.
+    # TODO make argparse arg for changing the IP, and only call this
+    # if the IP argument is specified
 
     # Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
     # and update any hardcoded URLs to the new machine URL.
@@ -312,7 +321,7 @@ def handle_input_args():
         # TODO add "usage" message?
 
 
-def change_hostname(new_name):
+def change_hostname(new_hostname):
     """Update system hostname.
 
     Args:
@@ -327,20 +336,23 @@ def change_hostname(new_name):
         (ValueError, OSError, etc.)
     """
     # TODO this might be OS dependent - only tested on Centos7
+    # TODO may need to check OS (Centos/Red Hat/Ubuntu at runtime)
 
     my_args = ["hostnamectl",
+               # TODO add --no-ask-password arg?
                "set-hostname",
-               _NEW_HOSTNAME,
+               new_hostname,
                ]
 
     if _DRYRUN:
-        print "dryrun: skipping change_hostname"
+        print "dryrun: skipping change_hostname()"
         return 0
     else:
-        # run subprocess
-        pass
+        ret_code = subproc_check_call_wrapper(my_args)
 
-               
+    return ret_code
+
+
 
 def change_IP():
     """Update system IP address.

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+#
+# TODO insert appropriate copyright info
+#
+# TODO insert license info
+
+# 
+# Tool to automate the necessary database changes after changing 
+# the Fusion hostname, to avoid having to delete/re-push/re-publish 
+# existing (already published) GEE databases
+#
+# Reference:
+# This tool automates the steps found in "Fusion Issues":
+# http://www.opengee.org/geedocs/answer/172780.html
+# 
+# The mode must be specified by the user:
+#	- GEE Server only (no Fusion)
+#	- Development System (both Fusion and GEE Server)
+# Both have similar steps with minor differences.
+
+import argparse
+import subprocess

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -2,7 +2,7 @@
 #
 # TODO insert appropriate copyright info
 #
-# TODO insert license info
+# TODO insert appropriate license info
 
 # 
 # Tool to automate the necessary database changes after changing 
@@ -34,10 +34,18 @@ from socket import gethostname    # preferred way to get hostname
 # TODO fix tabs/spaces, use pylint to check
 
 # GLOBALS:
-# Internal Globals:
+
 # Constants:
+# All paths should be absolute paths starting with "/" for safety.
 _FUSION_DAEMON = "/etc/init.d/gefusion"
 _SERVER_DAEMON = "/etc/init.d/geserver"
+_PUBLISHED_STREAM_FOLDER = "/gevol/published_dbs/stream_space"
+_PUBLISHED_SEARCH_FOLDER = "/gevol/published_dbs/search_space"
+# Constants for
+# sudo -u gepguser /opt/google/bin/geresetpgdb
+_GOOGLE_SCRIPT_FOLDER = "/opt/google/bin"
+_RESET_DB_SCRIPT = "geresetpgdb"
+_RESET_DB_USER = "gepguser"
 
 
 # TODO change non-consts to lowercase
@@ -67,12 +75,13 @@ def change_hostname_server_only():
     If global _DRYRUN is true, will test each step but 
     not execute any permanent changes.
 
-    Args: None
-
-    Raises:
-        TODO
+    Args:
+        None
 
     Returns:
+        TODO
+
+    Raises:
         TODO
     """
 
@@ -89,10 +98,14 @@ def change_hostname_server_only():
     # TODO What is the format for the * part?
     # does it include hostname? or just a unique id?
 
-    # TODO Remove the contents of /gevol/published_dbs/stream_space
+    # Remove the contents of /gevol/published_dbs/stream_space
     # and /gevol/published_dbs/search_space.
+    # TODO Prompt user before deletion?
+    delete_folder_contents(_PUBLISHED_STREAM_FOLDER)
+    delete_folder_contents(_PUBLISHED_SEARCH_FOLDER)
 
-    # TODO Change directory to /tmp and execute 
+    # TODO Change directory to /tmp 
+    # and execute 
     # sudo -u gepguser /opt/google/bin/geresetpgdb.
 
     # Start the GEE Server: /etc/init.d/geserver start.
@@ -118,12 +131,13 @@ def change_hostname_dev_machine():
     If global _DRYRUN is true, will test each step but 
     not execute any permanent changes.
 
-    Args: None
-
-    Raises:
-        TODO
+    Args:
+        None
 
     Returns:
+        TODO
+
+    Raises:
         TODO
     """
 
@@ -147,11 +161,15 @@ def change_hostname_dev_machine():
         # TODO /gevol/assets/.userdata/snippets.xml
     # TODO Replace assets with the name of your asset root. For example, /gevol/tutorial.
 
-    # TODO Edit the /gevol/assets/.userdata/snippets.xml file and update the hardcoded URLs to match the new hostname URL of the production machine.
+    # TODO Edit the /gevol/assets/.userdata/snippets.xml file 
+    # and 
+    # TODO update the hardcoded URLs to match the new hostname URL of the production machine.
 
-    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html and update any hardcoded URLs to the new machine URL.
+    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html 
+    # and update any hardcoded URLs to the new machine URL.
 
-    # TODO Remove the contents of /gevol/published_dbs/stream_space and /gevol/published_dbs/search_space.
+    # TODO Remove the contents of /gevol/published_dbs/stream_space 
+    # TODO and /gevol/published_dbs/search_space.
 
     # TODO Change directory to /tmp and execute sudo -u gepguser /opt/google/bin/geresetpgdb.
 
@@ -236,16 +254,43 @@ def daemon_start_stop(daemon, command):
         print "dryrun: skipping %s %s" % (daemon, command)
         return 0
 
+    return subproc_check_call_wrapper([daemon, command])
+
+
+def subproc_check_call_wrapper(arglist):
+    """Wrapper for subprocess.check_call, to catch exceptions.
+
+    Calls subprocess.check_call(arglist) and handles/prints
+    exception information if necessary.
+
+    Args:
+        arglist: list of string arguments passed to 
+            subprocess.check_call()
+            See subprocess documentation for correct formatting
+            of the 'args' input variable
+
+    Returns:
+        Return code of called function (int)
+
+    Raises:
+        -Should not raise any exceptions if used properly.
+        -Handles subprocess.CalledProcessError if return code 
+            of called function is non-zero.
+    """
+
+    ret_code = -1
+
     try:
-        subprocess.check_call([daemon, command])
+        ret_code = subprocess.check_call(arglist)
     except subprocess.CalledProcessError as e:
-        print "Subprocess Error in %s, exit code: %d" % (daemon, e.returncode)
+        print "Subprocess Error in %s, exit code: %d" % (arglist[0], e.returncode)
         print e.cmd
         print e.message
         print e.output
         return e.returncode
 
-    return 0
+    return ret_code
+
 
 def delete_folder_contents(path):
     """Delete entire contents of a folder, but not the actual folder.
@@ -264,12 +309,13 @@ def delete_folder_contents(path):
             Must begin with "/" to ensure full absolute path.
             e.g. "/gevol/published_dbs/stream_space"
 
+    Returns:
+        TODO
+
     Raises:
         ValueError: If path does not start with "/"
         OSError: on any os/shutil deletion errors
 
-    Returns:
-        TODO
     """
 
     if path[0] != "/":

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -72,7 +72,7 @@ def handle_input_args():
 
     parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
     parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
-    parser.add_argument("--dry-run", help="Test only - do not make any actual changes", action="store_true")
+    parser.add_argument("--dryrun", help="Test only - do not make any actual changes", action="store_true")
 
     # TODO is mutex group required or do we need to specify that??
     # TODO necessary to do default=False for store_trues?

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -4,24 +4,39 @@
 #
 # TODO insert appropriate license info
 
-# 
-# Tool to automate the necessary database changes after changing 
-# the Fusion hostname, to avoid having to delete/re-push/re-publish 
-# existing (already published) GEE databases
-#
-# Reference:
-# This tool automates the steps found in "Fusion Issues":
-# http://www.opengee.org/geedocs/answer/172780.html
-# 
-# The mode must be specified by the user:
-#    - GEE Server only (no Fusion)
-#    - Development System (both Fusion and GEE Server)
-# Both have similar steps with minor differences.
-#
-# Usage:
-# - user provides current hostname and the new hostname
-#    - and optionally, the Server hostname, if different
-# 
+"""Submitted as part of interview/Github Challenge for
+   Thermopylae Google Earth Enterprise Open Source Developer
+
+    by Douglas J. Brantner, December 2018
+    https://github.com/float13/earthenterprise
+
+    See also:
+        migrate_fusion_hostname_unittest.py
+
+    Forked from:
+    https://github.com/google/earthenterprise
+"""
+
+"""migrate_fusion_hostname.py
+
+Tool to automate the necessary database changes after changing
+the Fusion hostname, to avoid having to delete/re-push/re-publish
+existing (already published) GEE databases
+
+Reference:
+This tool automates the steps found in "Fusion Issues":
+http://www.opengee.org/geedocs/answer/172780.html
+
+The mode must be specified by the user:
+   - GEE Server only (no Fusion)
+   - Development System (both Fusion and GEE Server)
+Both have similar steps with minor differences.
+
+Usage:
+- user provides current hostname and the new hostname
+   - and optionally, the Server hostname, if different
+"""
+
 
 import os
 import sys
@@ -54,11 +69,11 @@ _RESET_DB_USER = "gepguser"
 _OLD_HOSTNAME = None    # Current hostname of Fusion machine
 _NEW_HOSTNAME = None    # New hostname to change to
 # TODO replace "MODE" with something like "_HAS_FUSION"?
-_MODE = None        # Server-only or Dev/Combo machine (Fusion + Server)
+_MODE = None    # Server-only or Dev/Combo machine (Fusion + Server)
 _VALID_MODES = ["SERVER", "DEV"]    # valid values for _MODE
     # SERVER: This is a GEE-Server-only machine
     # DEV: This machine has both Fusion and Server
-_DRYRUN = True  # Don't make any real changes, just test workflow/permissions
+_DRYRUN = True  # Test only - Skip all permanent/destructive changes
 
 
 def change_hostname_server_only():
@@ -66,7 +81,7 @@ def change_hostname_server_only():
 
     *** Requires root permissions. ***
 
-    Automates the instructions for changing the GEE Fusion 
+    Automates the instructions for changing the GEE Fusion
     hostname found at:
     http://www.opengee.org/geedocs/answer/172780.html
 
@@ -74,7 +89,7 @@ def change_hostname_server_only():
         For a Development machine (Server + Fusion), use
         change_hostname_dev_machine()
 
-    If global _DRYRUN is true, will test each step but 
+    If global _DRYRUN is true, will test each step but
     not execute any permanent changes.
 
     Args:
@@ -92,7 +107,7 @@ def change_hostname_server_only():
 
     # TODO confirm daemons stopped?
 
-    # TODO Update the hostname and IP address to the correct 
+    # TODO Update the hostname and IP address to the correct
     # entries for the machine.
 
     # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
@@ -107,8 +122,8 @@ def change_hostname_server_only():
     delete_folder_contents(_PUBLISHED_STREAM_FOLDER)
     delete_folder_contents(_PUBLISHED_SEARCH_FOLDER)
 
-    # TODO Change directory to /tmp 
-    # and execute 
+    # TODO Change directory to /tmp
+    # and execute
     # sudo -u gepguser /opt/google/bin/geresetpgdb.
     # TODO START HERE. CHECK ABOVE STUFF TOO!
 
@@ -124,7 +139,7 @@ def change_hostname_dev_machine():
 
     *** Requires root permissions. ***
 
-    Automates the instructions for changing the GEE Fusion 
+    Automates the instructions for changing the GEE Fusion
     hostname found at:
     http://www.opengee.org/geedocs/answer/172780.html
 
@@ -132,7 +147,7 @@ def change_hostname_dev_machine():
         For GEE Server-only machines, use
         change_hostname_server_only()
 
-    If global _DRYRUN is true, will test each step but 
+    If global _DRYRUN is true, will test each step but
     not execute any permanent changes.
 
     Args:
@@ -145,16 +160,18 @@ def change_hostname_dev_machine():
         TODO
     """
 
-    
     # Shut down both the gefusion and geserver daemons:
     daemon_start_stop(_FUSION_DAEMON, "stop")
     daemon_start_stop(_SERVER_DAEMON, "stop")
 
     # TODO confirm daemones stopped?
 
-    # TODO Update the hostname and IP address to the correct entries for the machines.
+    # TODO Update the hostname and IP address to the correct entries
+    # for the machines.
 
-    # TODO If needed, edit the /etc/hosts file to update the IP address and hostname entries for the production machine.
+    # TODO If needed, edit the /etc/hosts file to update the
+    # IP address
+    # and hostname entries for the production machine.
 
     # TODO Execute /opt/google/bin/geconfigureassetroot --fixmasterhost.
 
@@ -163,25 +180,29 @@ def change_hostname_dev_machine():
         # TODO /gevol/assets/.config/PacketLevel.taskrule
         # TODO /gevol/assets/.userdata/serverAssociations.xml
         # TODO /gevol/assets/.userdata/snippets.xml
-    # TODO Replace assets with the name of your asset root. For example, /gevol/tutorial.
+    # TODO Replace assets with the name of your asset root.
+    # For example, /gevol/tutorial.
 
-    # TODO Edit the /gevol/assets/.userdata/snippets.xml file 
-    # and 
-    # TODO update the hardcoded URLs to match the new hostname URL of the production machine.
+    # TODO Edit the /gevol/assets/.userdata/snippets.xml file
+    # and
+    # TODO update the hardcoded URLs to match the new hostname URL
+    # of the production machine.
 
-    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html 
+    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
     # and update any hardcoded URLs to the new machine URL.
 
-    # TODO Remove the contents of /gevol/published_dbs/stream_space 
+    # TODO Remove the contents of /gevol/published_dbs/stream_space
     # TODO and /gevol/published_dbs/search_space.
 
-    # TODO Change directory to /tmp and execute sudo -u gepguser /opt/google/bin/geresetpgdb.
+    # TODO Change directory to /tmp and execute
+    # sudo -u gepguser /opt/google/bin/geresetpgdb.
 
     # Start the geserver and gefusion services:
     daemon_start_stop(_FUSION_DAEMON, "start")
     daemon_start_stop(_SERVER_DAEMON, "start")
 
-    # TODO You can now change the server associations and publish the databases.
+    # TODO You can now change the server associations and publish
+    # the databases.
 
     # TODO return something?
 
@@ -192,20 +213,40 @@ def handle_input_args():
 
     global _MODE, _DRYRUN, _OLD_HOSTNAME, _NEW_HOSTNAME
 
-    parser = argparse.ArgumentParser(description="Update GEE Fusion Hostname andfix all existing published GEE databases")
+    parser = argparse.ArgumentParser(
+        description="Update GEE Fusion Hostname and fix all existing published GEE databases")
 
-    parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
-    parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
-    parser.add_argument("--dryrun", help="Test only - do not make any actual changes", action="store_true")
+    parser.add_argument(
+        "old_hostname",
+        help="Required - Current hostname of Fusion machine",
+        type=str)
+    parser.add_argument(
+        "new_hostname",
+        help="Required - New hostname for Fusion machine",
+        type=str)
+    parser.add_argument(
+        "--dryrun",
+        help="Test only - do not make any actual changes",
+        action="store_true")
     # TODO set defaults?
 
     # TODO is mutex group required or do we need to specify that??
     # TODO necessary to do default=False for store_trues?
+    # TODO change this to positional/required!
     mode_grp = parser.add_mutually_exclusive_group()
-    mode_grp.add_argument("-s", "--server_only", help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion", action="store_true")
-    mode_grp.add_argument("-c", "--dev_machine", help="Use -d if this is a Development Machine (Fusion AND GEE Server combined)", action="store_true")
+    mode_grp.add_argument(
+        "-s",
+        "--server_only",
+        help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion",
+        action="store_true")
+    mode_grp.add_argument(
+        "-c",
+        "--dev_machine",
+        help="Use -d if this is a Development Machine (Fusion AND GEE Server combined)",
+        action="store_true")
 
-    # TODO do we need the Server hostname? maybe good idea for -s mode even if only as a double check...
+    # TODO do we need the Server hostname? maybe good idea for -s mode
+    # even if only as a double check...
     args = parser.parse_args()
 
     if not args.dryrun:
@@ -222,7 +263,7 @@ def handle_input_args():
     elif args.dev_machine:
         _MODE = "DEV"
     else:
-        exit_early("Error: Must specify mode (Server/Dev)")    
+        exit_early("Error: Must specify mode (Server/Dev)")
         # TODO add "usage" message?
 
 
@@ -231,8 +272,8 @@ def handle_input_args():
 def daemon_start_stop(daemon, command):
     """Send start/stop command to a daemon service.
 
-    Sends the given command to an existing daemon.
-    Only "start" or "stop" are allowed, as stdout output is not checked.
+    Sends the given command to an existing daemon. Only "start" or
+    "stop" are allowed, as stdout output is not checked.
 
     *** Requires root privileges. ***
 
@@ -252,7 +293,8 @@ def daemon_start_stop(daemon, command):
     # TODO is service ok?
 
     if command not in ["start", "stop"]:
-        raise ValueError("Invalid argument for 'command': only 'start' and 'stop' are allowed.")
+        raise ValueError("Invalid arg for 'command': only 'start' and 'stop' are allowed.")
+
 
     if _DRYRUN:
         print "dryrun: skipping %s %s" % (daemon, command)
@@ -268,7 +310,7 @@ def subproc_check_call_wrapper(arglist):
     exception information if necessary.
 
     Args:
-        arglist: list of string arguments passed to 
+        arglist: list of string arguments passed to
             subprocess.check_call()
             See subprocess documentation for correct formatting
             of the 'args' input variable
@@ -278,7 +320,7 @@ def subproc_check_call_wrapper(arglist):
 
     Raises:
         -Should not raise any exceptions if used properly.
-        -Handles subprocess.CalledProcessError if return code 
+        -Handles subprocess.CalledProcessError if return code
             of called function is non-zero.
     """
 
@@ -286,12 +328,12 @@ def subproc_check_call_wrapper(arglist):
 
     try:
         ret_code = subprocess.check_call(arglist)
-    except subprocess.CalledProcessError as e:
-        print "Subprocess Error in %s, exit code: %d" % (arglist[0], e.returncode)
-        print e.cmd
-        print e.message
-        print e.output
-        return e.returncode
+    except subprocess.CalledProcessError as err:
+        print "Subprocess Error in %s, exit code: %d" % (arglist[0], err.returncode)
+        print err.cmd
+        print err.message
+        print err.output
+        return err.returncode
 
     return ret_code
 
@@ -324,10 +366,10 @@ def delete_folder_contents(path):
 
     if path[0] != "/":
         raise(ValueError, "path must be absolute and start with '/'")
-    
-    # TODO add try/catch 
-    for f in os.listdir(path):
-        full_path = os.path.join(path, f)
+
+    # TODO add try/catch
+    for f_name in os.listdir(path):
+        full_path = os.path.join(path, f_name)
         if os.path.isfile(full_path):
             if not _DRYRUN:
                 os.unlink(full_path)
@@ -337,7 +379,7 @@ def delete_folder_contents(path):
             if not _DRYRUN:
                 shutil.rmtree(full_path)
                 # TODO add ignore_errors?
-                # TODO add onerror? 
+                # TODO add onerror?
             else:
                 print "Dryrun: Skipping directory deletion %s" % full_path
 
@@ -345,9 +387,11 @@ def delete_folder_contents(path):
 
 def exit_early(msg="", errcode=1):
     """Print msg and exit with status code errcode.
-    
-    Convenience function to exit early. Set msg with useful error message
-    if exiting due to an error/exception.
+
+    Convenience function to end program with message and error code.
+    Message is optional but should be specified for user help/
+    troubleshooting.
+
     Change errcode to 0 if exiting normally.
 
     Args:
@@ -362,13 +406,15 @@ def exit_early(msg="", errcode=1):
 
 
 def main():
+    """Main Function."""
+
     handle_input_args()
 
     if os.geteuid() != 0:
         exit_early("Error: Requires Root Permission (try sudo)")
 
     if _MODE == "DEV":
-        if (_OLD_HOSTNAME != gethostname()):
+        if _OLD_HOSTNAME != gethostname():
             exit_early("Error: Incorrect current hostname - please double check and retry.")
         else:
             print "Old hostname matches... ok!"

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -42,49 +42,151 @@ _SERVER_DAEMON = "/etc/init.d/geserver"
 # TODO change non-consts to lowercase
 _OLD_HOSTNAME = None    # Current hostname of Fusion machine
 _NEW_HOSTNAME = None    # New hostname to change to
-_MODE = None        # Server-only or Dev/Combo machine (Fusion + Server)
 # TODO replace "MODE" with something like "_HAS_FUSION"?
-_DRYRUN = False        # Don't make any real changes, just test workflow/permissions
+_MODE = None        # Server-only or Dev/Combo machine (Fusion + Server)
+_VALID_MODES = ["SERVER", "DEV"]    # valid values for _MODE
+    # SERVER: This is a GEE-Server-only machine
+    # DEV: This machine has both Fusion and Server
+_DRYRUN = True  # Don't make any real changes, just test workflow/permissions
 
 
-def exit_early(msg="", errcode=1):
-    """Print msg and exit with status code errcode.
-    
-    Convenience function to exit early. Set msg with useful error message
-    if exiting due to an error/exception.
-    Change errcode to 0 if exiting normally.
+def change_hostname_server_only():
+    """Change the hostname for a GEE Server-only machine.
 
-    Args:
-        msg: Optional error message (string)
-        errcode: Status code to exit with (int)
+    *** Requires root permissions. ***
+
+    Automates the instructions for changing the GEE Fusion 
+    hostname found at:
+    http://www.opengee.org/geedocs/answer/172780.html
+
+    Note: This is for GEE Server-only machines.
+        For a Development machine (Server + Fusion), use
+        change_hostname_dev_machine()
+
+    If global _DRYRUN is true, will test each step but 
+    not execute any permanent changes.
+
+    Args: None
+
+    Raises:
+        TODO
+
+    Returns:
+        TODO
     """
 
-    if msg:
-        print msg
-    print "Exiting..."
-    sys.exit(errcode)
+    # Shut down the geserver daemon at /etc/init.d/geserver stop.
+    daemon_start_stop(_SERVER_DAEMON, "stop")
+    # TODO confirm daemones stopped?
+
+    # TODO Update the hostname and IP address to the correct 
+    # entries for the machine.
+
+    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
+    # and update any hardcoded URLs to the new machine URL.
+    # TODO What is the format for the * part?
+
+    # TODO Remove the contents of /gevol/published_dbs/stream_space
+    # and /gevol/published_dbs/search_space.
+
+    # TODO Change directory to /tmp and execute 
+    # sudo -u gepguser /opt/google/bin/geresetpgdb.
+
+    # Start the GEE Server: /etc/init.d/geserver start.
+    daemon_start_stop("_SERVER_DAEMON", "start")
+
+    # TODO return something?
+
+
+def change_hostname_dev_machine():
+    """Change the hostname for a Development machine
+        (contains both Fusion and GEE Server)
+
+    *** Requires root permissions. ***
+
+    Automates the instructions for changing the GEE Fusion 
+    hostname found at:
+    http://www.opengee.org/geedocs/answer/172780.html
+
+    Note: This is for machines with BOTH GEE Fusion and GEE Server
+        For GEE Server-only machines, use
+        change_hostname_server_only()
+
+    If global _DRYRUN is true, will test each step but 
+    not execute any permanent changes.
+
+    Args: None
+
+    Raises:
+        TODO
+
+    Returns:
+        TODO
+    """
+
+    
+    # Shut down both the gefusion and geserver daemons:
+    daemon_start_stop(_FUSION_DAEMON, "stop")
+    daemon_start_stop(_SERVER_DAEMON, "stop")
+
+    # TODO confirm daemones stopped?
+
+    # TODO Update the hostname and IP address to the correct entries for the machines.
+
+    # TODO If needed, edit the /etc/hosts file to update the IP address and hostname entries for the production machine.
+
+    # TODO Execute /opt/google/bin/geconfigureassetroot --fixmasterhost.
+
+    # TODO Back up the following files to /tmp or another archive folder:
+        # TODO /gevol/assets/.config/volumes.xml
+        # TODO /gevol/assets/.config/PacketLevel.taskrule
+        # TODO /gevol/assets/.userdata/serverAssociations.xml
+        # TODO /gevol/assets/.userdata/snippets.xml
+    # TODO Replace assets with the name of your asset root. For example, /gevol/tutorial.
+
+    # TODO Edit the /gevol/assets/.userdata/snippets.xml file and update the hardcoded URLs to match the new hostname URL of the production machine.
+
+    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html and update any hardcoded URLs to the new machine URL.
+
+    # TODO Remove the contents of /gevol/published_dbs/stream_space and /gevol/published_dbs/search_space.
+
+    # TODO Change directory to /tmp and execute sudo -u gepguser /opt/google/bin/geresetpgdb.
+
+    # Start the geserver and gefusion services:
+    daemon_start_stop(_FUSION_DAEMON, "start")
+    daemon_start_stop(_SERVER_DAEMON, "start")
+
+    # TODO You can now change the server associations and publish the databases.
+
+    # TODO return something?
+
+
 
 def handle_input_args():
     """Parse command line arguments and set global variables."""
 
-    global _MODE, _DRYRUN
+    global _MODE, _DRYRUN, _OLD_HOSTNAME, _NEW_HOSTNAME
+
     parser = argparse.ArgumentParser(description="Update GEE Fusion Hostname andfix all existing published GEE databases")
 
     parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
     parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
     parser.add_argument("--dryrun", help="Test only - do not make any actual changes", action="store_true")
+    # TODO set defaults?
 
     # TODO is mutex group required or do we need to specify that??
     # TODO necessary to do default=False for store_trues?
     mode_grp = parser.add_mutually_exclusive_group()
     mode_grp.add_argument("-s", "--server_only", help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion", action="store_true")
-    mode_grp.add_argument("-c", "--combo_machine", help="Use -d if this is a development machine (Fusion AND GEE Server combined)", action="store_true")
+    mode_grp.add_argument("-c", "--dev_machine", help="Use -d if this is a Development Machine (Fusion AND GEE Server combined)", action="store_true")
 
     # TODO do we need the Server hostname? maybe good idea for -s mode even if only as a double check...
     args = parser.parse_args()
 
-    # Test and Assign Globals:
+    if not args.dryrun:
+        _DRYRUN = False
 
+    # Test and Assign Globals:
     _OLD_HOSTNAME = args.old_hostname
 
     # TODO test that new hostname is a valid hostname, and not null?
@@ -92,10 +194,13 @@ def handle_input_args():
 
     if args.server_only:
         _MODE = "SERVER"
-    elif args.combo_machine:
+    elif args.dev_machine:
         _MODE = "DEV"
-    # else, it stays None
-    # TODO quit early if mode is not specified
+    else:
+        exit_early("Error: Must specify mode (Server/Dev)")    
+        # TODO add "usage" message?
+
+
 
 
 def daemon_start_stop(daemon, command):
@@ -123,6 +228,11 @@ def daemon_start_stop(daemon, command):
 
     if command not in ["start", "stop"]:
         raise ValueError("Invalid argument for 'command': only 'start' and 'stop' are allowed.")
+
+    if _DRYRUN:
+        print "dryrun: skipping %s %s" % (daemon, command)
+        return 0
+
     try:
         subprocess.check_call([daemon, command])
     except subprocess.CalledProcessError as e:
@@ -135,13 +245,26 @@ def daemon_start_stop(daemon, command):
     return 0
 
 
+def exit_early(msg="", errcode=1):
+    """Print msg and exit with status code errcode.
+    
+    Convenience function to exit early. Set msg with useful error message
+    if exiting due to an error/exception.
+    Change errcode to 0 if exiting normally.
+
+    Args:
+        msg: Optional error message (string)
+        errcode: Status code to exit with (int)
+    """
+
+    if msg:
+        print msg
+    print "Exiting..."
+    sys.exit(errcode)
+
+
 def main():
     handle_input_args()
-
-    # Test for valid inputs:
-    # TODO move to separate function?
-    if _MODE is None:
-        exit_early("Error: Must specify mode (Server/Dev)")    # TODO add "usage" message?
 
     # TODO check for root permission, if necessary?
 
@@ -150,14 +273,25 @@ def main():
             exit_early("Error: Incorrect current hostname - please double check and retry.")
         else:
             print "Old hostname matches... ok!"
-    # TODO check if in SERVER mode if hostname matches (need new input arg)
 
+        # TODO any more checks?
 
-    # **** Stop Daemons ****
-    # this requires root
-    #daemon_start_stop(_SERVER_DAEMON, "stop")
-    #if _MODE == "DEV":
-    #    daemon_start_stop(_FUSION_DAEMON, "stop")
+        change_hostname_dev_machine()
+
+    elif _MODE == "SERVER":
+        # TODO check if in SERVER mode if hostname matches (need new input arg)
+
+        change_hostname_server_only()
+
+    else:
+        # TODO raise exception instead?
+        exit_early("Error: Invalid mode option.")
+
+    # TODO print further instructions on changing server association?
+    # To change the server associations and publish the databases...
+
+    # TODO print extra helpful info (how to test, etc.)
+    # TODO print link to issue/help
 
 
 if __name__ == "__main__":

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -131,6 +131,8 @@ def migrate_hostname_server_only():
     # TODO confirm daemons stopped?
 
     # Update the hostname 
+    # TODO is this the correct thing to do on the SERVER?
+    # we want to change the FUSION hostname, not the SERVER hostname
     if prompt_user_confirm("Change hostname to: %s" % _NEW_HOSTNAME):
         change_hostname(_NEW_HOSTNAME)
     else:

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -55,6 +55,7 @@ from socket import gethostname    # preferred way to get hostname
 # TODO write logfile of errors; use logging module?
 # TODO make logfile useful for resuming starting after error?
 # TODO run pylint
+# TODO use return codes in main fn's
 
 #### GLOBALS: ####
 
@@ -131,10 +132,12 @@ def change_hostname_server_only():
     # TODO Update the hostname and IP address to the correct
     # entries for the machine.
 
-    # TODO Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
+    # Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
     # and update any hardcoded URLs to the new machine URL.
-    # TODO What is the format for the * part?
-    # does it include hostname? or just a unique id?
+    if prompt_user_confirm("Updating htdocs tips URLs"):
+        update_htdocs_urls()
+    else:
+        exit_early()    # TODO message?
 
     # Remove the contents of
     # /gevol/published_dbs/stream_space
@@ -151,7 +154,6 @@ def change_hostname_server_only():
         delete_folder_contents(_PUBLISHED_SEARCH_FOLDER)
     else:
         exit_early("Files must be deleted before continuing.")
-    # TODO use return codes?
 
     # Change directory to /tmp and execute
     # "sudo -u gepguser /opt/google/bin/geresetpgdb"
@@ -381,6 +383,34 @@ def subproc_check_call_wrapper(arglist):
         return err.returncode
 
     return ret_code
+
+
+def update_htdocs_urls():
+    """Update hardcoded URL's for documentation tips.
+
+    Edit /opt/google/gehttpd/htdocs/intl/en/tips/tip*.html
+    and update any hardcoded URLs to the new machine URL.
+
+    Args:
+        TODO
+
+    Returns:
+        TODO
+
+    Raises:
+        TODO
+    """
+
+    # TODO Not yet implemented - What is the format for the * part?
+    # does it include hostname? or just a unique id?
+
+    # pseudocode:
+    # loop over URLs in folder (glob?)
+    #   if not _DRYRUN:
+    #       rename file (try/catch)
+    #       track non-zero return codes?
+
+    print "WARNING: update_htdocs_urls not yet implemented."
 
 
 def delete_folder_contents(path):

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname.py
@@ -14,20 +14,20 @@
 # http://www.opengee.org/geedocs/answer/172780.html
 # 
 # The mode must be specified by the user:
-#	- GEE Server only (no Fusion)
-#	- Development System (both Fusion and GEE Server)
+#    - GEE Server only (no Fusion)
+#    - Development System (both Fusion and GEE Server)
 # Both have similar steps with minor differences.
 #
 # Usage:
 # - user provides current hostname and the new hostname
-#	- and optionally, the Server hostname, if different
+#    - and optionally, the Server hostname, if different
 # 
 
 import os
 import sys
 import argparse
 import subprocess
-from socket import gethostname	# preferred way to get hostname
+from socket import gethostname    # preferred way to get hostname
 
 
 # TODO fix tabs/spaces, use pylint to check
@@ -40,125 +40,125 @@ _SERVER_DAEMON = "/etc/init.d/geserver"
 
 
 # TODO change non-consts to lowercase
-_OLD_HOSTNAME = None	# Current hostname of Fusion machine
-_NEW_HOSTNAME = None	# New hostname to change to
-_MODE = None		# Server-only or Dev/Combo machine (Fusion + Server)
+_OLD_HOSTNAME = None    # Current hostname of Fusion machine
+_NEW_HOSTNAME = None    # New hostname to change to
+_MODE = None        # Server-only or Dev/Combo machine (Fusion + Server)
 # TODO replace "MODE" with something like "_HAS_FUSION"?
-_DRYRUN = False		# Don't make any real changes, just test workflow/permissions
+_DRYRUN = False        # Don't make any real changes, just test workflow/permissions
 
 
 def exit_early(msg="", errcode=1):
-	"""Print msg and exit with status code errcode.
-	
-	Convenience function to exit early. Set msg with useful error message
-	if exiting due to an error/exception.
-	Change errcode to 0 if exiting normally.
+    """Print msg and exit with status code errcode.
+    
+    Convenience function to exit early. Set msg with useful error message
+    if exiting due to an error/exception.
+    Change errcode to 0 if exiting normally.
 
-	Args:
-		msg: Optional error message (string)
-		errcode: Status code to exit with (int)
-	"""
+    Args:
+        msg: Optional error message (string)
+        errcode: Status code to exit with (int)
+    """
 
-	if msg:
-		print msg
-	print "Exiting..."
-	sys.exit(errcode)
+    if msg:
+        print msg
+    print "Exiting..."
+    sys.exit(errcode)
 
 def handle_input_args():
-	"""Parse command line arguments and set global variables."""
+    """Parse command line arguments and set global variables."""
 
-	global _MODE, _DRYRUN
-	parser = argparse.ArgumentParser(description="Update GEE Fusion Hostname andfix all existing published GEE databases")
+    global _MODE, _DRYRUN
+    parser = argparse.ArgumentParser(description="Update GEE Fusion Hostname andfix all existing published GEE databases")
 
-	parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
-	parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
-	parser.add_argument("--dry-run", help="Test only - do not make any actual changes", action="store_true")
+    parser.add_argument("old_hostname", help="Required - Current hostname of Fusion machine", type=str)
+    parser.add_argument("new_hostname", help="Required - New hostname for Fusion machine", type=str)
+    parser.add_argument("--dry-run", help="Test only - do not make any actual changes", action="store_true")
 
-	# TODO is mutex group required or do we need to specify that??
-	# TODO necessary to do default=False for store_trues?
-	mode_grp = parser.add_mutually_exclusive_group()
-	mode_grp.add_argument("-s", "--server_only", help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion", action="store_true")
-	mode_grp.add_argument("-c", "--combo_machine", help="Use -d if this is a development machine (Fusion AND GEE Server combined)", action="store_true")
+    # TODO is mutex group required or do we need to specify that??
+    # TODO necessary to do default=False for store_trues?
+    mode_grp = parser.add_mutually_exclusive_group()
+    mode_grp.add_argument("-s", "--server_only", help="Use -s if this machine is GEE Server ONLY, and not shared with Fusion", action="store_true")
+    mode_grp.add_argument("-c", "--combo_machine", help="Use -d if this is a development machine (Fusion AND GEE Server combined)", action="store_true")
 
-	# TODO do we need the Server hostname? maybe good idea for -s mode even if only as a double check...
-	args = parser.parse_args()
+    # TODO do we need the Server hostname? maybe good idea for -s mode even if only as a double check...
+    args = parser.parse_args()
 
-	# Test and Assign Globals:
+    # Test and Assign Globals:
 
-	_OLD_HOSTNAME = args.old_hostname
+    _OLD_HOSTNAME = args.old_hostname
 
-	# TODO test that new hostname is a valid hostname, and not null?
-	_NEW_HOSTNAME = args.new_hostname
+    # TODO test that new hostname is a valid hostname, and not null?
+    _NEW_HOSTNAME = args.new_hostname
 
-	if args.server_only:
-		_MODE = "SERVER"
-	elif args.combo_machine:
-		_MODE = "DEV"
-	# else, it stays None
-	# TODO quit early if mode is not specified
+    if args.server_only:
+        _MODE = "SERVER"
+    elif args.combo_machine:
+        _MODE = "DEV"
+    # else, it stays None
+    # TODO quit early if mode is not specified
 
 
 def daemon_start_stop(daemon, command):
-	"""Send start/stop command to a daemon service.
+    """Send start/stop command to a daemon service.
 
-	Sends the given command to an existing daemon.
-	Only "start" or "stop" are allowed, as stdout output is not checked.
+    Sends the given command to an existing daemon.
+    Only "start" or "stop" are allowed, as stdout output is not checked.
 
-	*** Requires root privileges. ***
+    *** Requires root privileges. ***
 
-	Args:
-		daemon: the full path to an existing system daemon (string)
-			eg. "/etc/init.d/gefusion"
-		command: either "start" or "stop" (string)
+    Args:
+        daemon: the full path to an existing system daemon (string)
+            eg. "/etc/init.d/gefusion"
+        command: either "start" or "stop" (string)
 
-	Returns:
-		Exit code of daemon call. (int)
+    Returns:
+        Exit code of daemon call. (int)
 
-	Raises:
-		ValueError: if given an invalid input for "command"
-		OSError: If "daemon" path is invalid or doesn't exist
-	"""
-	# TODO raise error on lack of root privelige?
-	# TODO is service ok?
+    Raises:
+        ValueError: if given an invalid input for "command"
+        OSError: If "daemon" path is invalid or doesn't exist
+    """
+    # TODO raise error on lack of root privelige?
+    # TODO is service ok?
 
-	if command not in ["start", "stop"]:
-		raise ValueError("Invalid argument for 'command': only 'start' and 'stop' are allowed.")
-	try:
-		subprocess.check_call([daemon, command])
-	except subprocess.CalledProcessError as e:
-		print "Subprocess Error in %s, exit code: %d" % (daemon, e.returncode)
-		print e.cmd
-		print e.message
-		print e.output
-		return e.returncode
+    if command not in ["start", "stop"]:
+        raise ValueError("Invalid argument for 'command': only 'start' and 'stop' are allowed.")
+    try:
+        subprocess.check_call([daemon, command])
+    except subprocess.CalledProcessError as e:
+        print "Subprocess Error in %s, exit code: %d" % (daemon, e.returncode)
+        print e.cmd
+        print e.message
+        print e.output
+        return e.returncode
 
-	return 0
+    return 0
 
 
 def main():
-	handle_input_args()
+    handle_input_args()
 
-	# Test for valid inputs:
-	# TODO move to separate function?
-	if _MODE is None:
-		exit_early("Error: Must specify mode (Server/Dev)")	# TODO add "usage" message?
+    # Test for valid inputs:
+    # TODO move to separate function?
+    if _MODE is None:
+        exit_early("Error: Must specify mode (Server/Dev)")    # TODO add "usage" message?
 
-	# TODO check for root permission, if necessary?
+    # TODO check for root permission, if necessary?
 
-	if _MODE == "DEV":
-		if (_OLD_HOSTNAME != gethostname()):
-			exit_early("Error: Incorrect current hostname - please double check and retry.")
-		else:
-			print "Old hostname matches... ok!"
-	# TODO check if in SERVER mode if hostname matches (need new input arg)
+    if _MODE == "DEV":
+        if (_OLD_HOSTNAME != gethostname()):
+            exit_early("Error: Incorrect current hostname - please double check and retry.")
+        else:
+            print "Old hostname matches... ok!"
+    # TODO check if in SERVER mode if hostname matches (need new input arg)
 
 
-	# **** Stop Daemons ****
-	# this requires root
-	#daemon_start_stop(_SERVER_DAEMON, "stop")
-	#if _MODE == "DEV":
-	#	daemon_start_stop(_FUSION_DAEMON, "stop")
+    # **** Stop Daemons ****
+    # this requires root
+    #daemon_start_stop(_SERVER_DAEMON, "stop")
+    #if _MODE == "DEV":
+    #    daemon_start_stop(_FUSION_DAEMON, "stop")
 
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
@@ -163,8 +163,15 @@ class TestMigrateFusionHostname(unittest.TestCase):
         self.assertEqual(gethostname(), old_hostname)
 
 
+    # TODO tests for change_IP()
 
+    # TODO tests for update_htdocs_urls()
 
+    # TODO tests for delete_folder_contents()
+    # dummy tests w/ dummy files already done in _unittest
+    # necessary to test live here? Or just in full program test?
+
+    # TODO tests for run_geresetpgdb()
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
@@ -152,15 +152,15 @@ class TestMigrateFusionHostname(unittest.TestCase):
         """Test & confirm hostname change, then revert to original."""
 
         old_hostname = gethostname()
-        new_hostname = "testinghost123"
+        new_hostname = "testhost123"
 
         mfh._DRYRUN = False
-        mfh.change_hostname(new_hostname)
+        self.assertEqual(mfh.change_hostname(new_hostname), 0)
         self.assertEqual(gethostname(), new_hostname)
 
         # change it back & test again
-        mfh.change_hostname(old_hostname)
-        self.assertEqual(gethostname(), new_hostname)
+        self.assertEqual(mfh.change_hostname(old_hostname), 0)
+        self.assertEqual(gethostname(), old_hostname)
 
 
 

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_destructive_tests.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+
+"""Submitted as part of interview/Github Challenge for
+   Thermopylae Google Earth Enterprise Open Source Developer
+
+    by Douglas J. Brantner, December 2018
+    https://github.com/float13/earthenterprise
+
+    See also:
+        migrate_fusion_hostname.py
+        migrate_fusion_hostname_unittest.py
+
+    Forked from:
+    https://github.com/google/earthenterprise
+"""
+
+"""DESTRUCTIVE UNIT TESTS for migrate_fusion_hostname.py
+
+    WARNING: Do NOT run these tests on a production machine.
+
+    These tests WILL MAKE PERMANENT CHANGES, DELETE FILES, ETC.
+    For non-destructive safe tests, see:
+        migrate_fusion_hostname_unittest.py
+    and note the use of the --dryrun flag.
+
+    WARNING: Writes and deletes some temporary files. Uses default
+        temp file directory as per Python tempfile specification:
+        https://docs.python.org/2/library/tempfile.html#tempfile.mkstemp
+
+        See the above link for changing default temp file directory.
+
+    Usage:
+        Most unit tests can be run as default user.
+
+        However, there are also some tests which require root
+        permission and must be run with sudo; otherwise
+        they are skipped.
+
+        Run as:
+        python migrate_fusion_hostname_destructive_tests.py
+            or optionally with sudo to run all tests.
+
+        (Using Python 2.7)
+    """
+
+import unittest
+import os
+import subprocess
+import tempfile
+from socket import gethostname
+import migrate_fusion_hostname as mfh   # Module to Test
+
+# Global Variables
+# TODO use argparse to set these?
+# TODO delete this:
+#_ALLOW_DAEMON_STARTSTOP = True      # this only applies to module tests
+                                    # to allow starting/stopping daemons
+                                    # and should only be used for
+                                    # @unittest.skip... decorators
+                                    # DO NOT rely on this for safety.
+                                    # Only the -dryrun flag is safe.
+
+# TODO implement _ALLOW_DRYRUN_OVERRIDE checks!
+# _ALLOW_DRYRUN_OVERRIDE = True     # Enable direct manipulation of
+                                    # mfh._DRYRUN flag for tests
+                                    # This should be reset in setUp and/or
+                                    # tearDown for safety.
+
+# TODO run full tests with --override flag?
+
+
+
+
+# Helper Functions:
+
+def check_root():
+    """Check for root permission.
+
+    Returns:
+        True if this unittest module is run as root,
+        otherwise returns False.
+    """
+    return os.geteuid() == 0
+
+# Unit Tests (WARNING - Will cause permanent changes to system!)
+
+class TestMigrateFusionHostname(unittest.TestCase):
+    """Unit tests for migrate_fusion_hostname.py
+
+    These tests should NOT be run on a production machine
+    and are all run in -dryrun mode for safety.
+
+    Perhaps a separate test class could be written for live tests,
+    with user confirmation (eg. command line flag).
+    """
+
+    # TODO add class variable for current hostname?
+    # this complicates things for testing...
+
+    _PYTHON_RUNTIME = "python"
+    _TEST_PROGRAM = "migrate_fusion_hostname.py"
+    _NEW_HOSTNAME = "newtesthost"
+    # TODO might not need _CURRENT_HOSTNAME - just get as part of each test?
+    _CURRENT_HOSTNAME = None   # get hostname of THIS machine at runtime
+    _base_arg_list = None   # Prefix for all full-program test
+                            # function calls (must include --dryrun)
+                            # for safety
+
+
+    """Setup/Teardown"""
+    @classmethod
+    def setUpClass(cls):
+        """Runs ONLY once at beginning."""
+
+        cls._CURRENT_HOSTNAME = gethostname()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Runs ONLY once at end."""
+        pass
+
+    def setUp(self):
+        """Runs once before every test."""
+
+        # Reset internal _DRYRUN variable just to be safe
+        # NOTE: some tests may change this (eg. file deletion)
+        # (for individual module/function tests)
+        mfh._DRYRUN = True
+
+        # Reset _OVERRIDE_USER_CONFIRM flag
+        mfh._OVERRIDE_USER_CONFIRM = False
+
+        # Reset basic arguments with --dryrun
+        # for safety before each test
+        # (for full-program tests called w/ subprocess)
+        self._base_arg_list = [self._PYTHON_RUNTIME,
+                               self._TEST_PROGRAM,
+                               "--dryrun",
+                              ]
+
+    def tearDown(self):
+        """Runs once after every test."""
+
+        mfh._DRYRUN = True  # double check just for safety
+
+
+    #### Individual Method Tests ####
+
+    # TODO move test_daemon_start_stop_live_test here from _unittest?
+
+    def test_change_hostname(self):
+        """Test & confirm hostname change, then revert to original."""
+
+        old_hostname = gethostname()
+        new_hostname = "testinghost123"
+
+        mfh._DRYRUN = False
+        mfh.change_hostname(new_hostname)
+        self.assertEqual(gethostname(), new_hostname)
+
+        # change it back & test again
+        mfh.change_hostname(old_hostname)
+        self.assertEqual(gethostname(), new_hostname)
+
+
+
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -9,47 +9,47 @@ import migrate_fusion_hostname as mfh
 
 class TestMigrateFusionHostname(unittest.TestCase):
 
-	"""Setup/Teardown"""
-	@classmethod
-	def setUpClass(cls):
-		"""Runs ONLY once at beginning."""
-		pass
+    """Setup/Teardown"""
+    @classmethod
+    def setUpClass(cls):
+        """Runs ONLY once at beginning."""
+        pass
 
-	@classmethod
-	def tearDownClass(cls):
-		"""Runs ONLY once at end."""
-		pass
+    @classmethod
+    def tearDownClass(cls):
+        """Runs ONLY once at end."""
+        pass
 
-	def setUp(self):
-		"""Runs once before every test."""
-		pass
+    def setUp(self):
+        """Runs once before every test."""
+        pass
 
-	def tearDown(self):
-		"""Runs once after every test."""
+    def tearDown(self):
+        """Runs once after every test."""
 
 
-	def testFullProgram(self):
-		# TODO big tests of full program as subprocess calls
-		# TODO test bad input, etc.
-		# *** run all of these ase DRYRUNS!
-		pass
+    def testFullProgram(self):
+        # TODO big tests of full program as subprocess calls
+        # TODO test bad input, etc.
+        # *** run all of these ase DRYRUNS!
+        pass
 
 
 # TODO split into smaller functions (1 per test?)
-	def testDaemonStartStop(self):
-		# Test Bad Input for daemon:
-		with self.assertRaises(OSError):
-			mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
+    def testDaemonStartStop(self):
+        # Test Bad Input for daemon:
+        with self.assertRaises(OSError):
+            mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
 
-		# Test Bad Input for command:
-		with self.assertRaises(ValueError):
-			mfh.daemon_start_stop("/etc/init.d/gefusion", None)
-			mfh.daemon_start_stop("/etc/init.d/gefusion", 1)
-			mfh.daemon_start_stop("/etc/init.d/gefusion", "")
-			mfh.daemon_start_stop("/etc/init.d/gefusion", "asdf")
+        # Test Bad Input for command:
+        with self.assertRaises(ValueError):
+            mfh.daemon_start_stop("/etc/init.d/gefusion", None)
+            mfh.daemon_start_stop("/etc/init.d/gefusion", 1)
+            mfh.daemon_start_stop("/etc/init.d/gefusion", "")
+            mfh.daemon_start_stop("/etc/init.d/gefusion", "asdf")
 
 
-			
+            
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -4,7 +4,8 @@
 # TODO fix tabs/spaces
 
 import unittest
-import migrate_fusion_hostname
+#import subprocess
+import migrate_fusion_hostname as mfh
 
 class TestMigrateFusionHostname(unittest.TestCase):
 
@@ -34,10 +35,21 @@ class TestMigrateFusionHostname(unittest.TestCase):
 		pass
 
 
+# TODO split into smaller functions (1 per test?)
 	def testDaemonStartStop(self):
-		with self.assertRaises(subprocess.CalledProcessError):
+		# Test Bad Input for daemon:
+		with self.assertRaises(OSError):
+			mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
 
-			# TODO test bad start/stop input (custom exception?)
+		# Test Bad Input for command:
+		with self.assertRaises(ValueError):
+			mfh.daemon_start_stop("/etc/init.d/gefusion", None)
+			mfh.daemon_start_stop("/etc/init.d/gefusion", 1)
+			mfh.daemon_start_stop("/etc/init.d/gefusion", "")
+			mfh.daemon_start_stop("/etc/init.d/gefusion", "asdf")
 
-			daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start"))
+
 			
+
+if __name__ == "__main__":
+	unittest.main()

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -1,5 +1,18 @@
 #!/usr/bin/python
 
+"""Submitted as part of interview/Github Challenge for
+   Thermopylae Google Earth Enterprise Open Source Developer
+
+    by Douglas J. Brantner, December 2018
+    https://github.com/float13/earthenterprise
+
+    See also:
+        migrate_fusion_hostname.py
+
+    Forked from:
+    https://github.com/google/earthenterprise
+"""
+
 """Unit tests for migrate_fusion_hostname.py
 
     WARNING: Do NOT run these tests on a production machine.

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -3,16 +3,29 @@
 # TODO docstring?
 
 import unittest
-#import subprocess
-import migrate_fusion_hostname as mfh
+import subprocess
+from socket import gethostname
+import migrate_fusion_hostname as mfh   # Module to Test
 
 class TestMigrateFusionHostname(unittest.TestCase):
+
+    # TODO add class variable for current hostname?
+    # this complicates things for testing...
+
+    _PYTHON_RUNTIME = "python"
+    _TEST_PROGRAM = "migrate_fusion_hostname.py"
+    _NEW_HOSTNAME = "newtesthost"
+    _CURRENT_HOSTNAME = None   # get hostname of THIS machine at runtime
+    _BASE_ARG_LIST = None   # Prefix for all full-program test
+                            # function calls (must include --dryrun)
+                            # for safety
 
     """Setup/Teardown"""
     @classmethod
     def setUpClass(cls):
         """Runs ONLY once at beginning."""
-        pass
+
+        cls._CURRENT_HOSTNAME = gethostname()
 
     @classmethod
     def tearDownClass(cls):
@@ -21,30 +34,68 @@ class TestMigrateFusionHostname(unittest.TestCase):
 
     def setUp(self):
         """Runs once before every test."""
-        pass
+        
+        # Reset basic arguments with --dryrun 
+        # for safety before each test
+        self._BASE_ARG_LIST = [self._PYTHON_RUNTIME,
+                               self._TEST_PROGRAM,
+                               "--dryrun",
+                               ]
 
     def tearDown(self):
         """Runs once after every test."""
+        pass
 
 
     #### Full Program Tests ####
     
     # All of these should be run with the --dryrun flag
 
-    def testFullProgram(self):
-        # TODO big tests of full program as subprocess calls
+    def test_full_program_dryrun_server_mode(self):
+        """Run tests of full program in DRYRUN mode.
+
+        Dryrun mode avoids any permanent changes to the host computer.
+
+        Successful test runs should exit with code 0.
+        """
+
         # TODO test bad commandline args, etc.
-        # *** run all of these ase DRYRUNS!
-        pass
+        
+        my_args = ["--server_only",
+                   self._CURRENT_HOSTNAME,
+                   self._NEW_HOSTNAME,
+                  ]
+        full_args = self._BASE_ARG_LIST + my_args
+        self.assertEquals(0, subprocess.check_call(full_args))
+
+    #def test_full_program_dryrun_dev_mode(self):
+    # TODO implement this
+
+    def test_full_program_missing_mode_arg(self):
+        my_args = [ # omitting the --server_only arg on purpose
+                   self._CURRENT_HOSTNAME,
+                   self._NEW_HOSTNAME,
+                  ]
+        full_args = self._BASE_ARG_LIST + my_args
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            subprocess.check_call(full_args)
+            # TODO check actual exit code? would have to catch, parse,
+            # and then re-throw exception...
+
+
+
 
     ### Individual Method Tests ####
 
-    def daemon_start_stop_badInput(self):
-        # Test Bad Input for daemon name:
-        with self.assertRaises(OSError):
-            mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
+    # TODO doesn't work with dryrun mode...
+    #def test_daemon_start_stop_bad_daemon(self):
+    #    """Test Bad Input for daemon name."""
+    #    with self.assertRaises(OSError):
+    #        mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
 
-        # Test Bad Input for command:
+    def test_daemon_start_stop_bad_daemon(self):
+        """Test Bad Input for command."""
         with self.assertRaises(ValueError):
             mfh.daemon_start_stop("/etc/init.d/gefusion", None)
             mfh.daemon_start_stop("/etc/init.d/gefusion", 1)

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -244,6 +244,9 @@ class TestMigrateFusionHostname(unittest.TestCase):
             0)
 
 
+    # TODO tests for update_htdocs_urls()
+
+
     def test_delete_folder_contents_startsWithSlash(self):
         """Omitting leading slash should throw ValueError."""
         with self.assertRaises(ValueError):

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+
+# TODO docstring?
+# TODO fix tabs/spaces
+
+import unittest
+import migrate_fusion_hostname
+
+class TestMigrateFusionHostname(unittest.TestCase):
+
+	"""Setup/Teardown"""
+	@classmethod
+	def setUpClass(cls):
+		"""Runs ONLY once at beginning."""
+		pass
+
+	@classmethod
+	def tearDownClass(cls):
+		"""Runs ONLY once at end."""
+		pass
+
+	def setUp(self):
+		"""Runs once before every test."""
+		pass
+
+	def tearDown(self):
+		"""Runs once after every test."""
+
+
+	def testFullProgram(self):
+		# TODO big tests of full program as subprocess calls
+		# TODO test bad input, etc.
+		# *** run all of these ase DRYRUNS!
+		pass
+
+
+	def testDaemonStartStop(self):
+		with self.assertRaises(subprocess.CalledProcessError):
+
+			# TODO test bad start/stop input (custom exception?)
+
+			daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start"))
+			

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -200,6 +200,13 @@ class TestMigrateFusionHostname(unittest.TestCase):
 
     ### Individual Method Tests ####
 
+    def test_change_hostname_dryrun(self):
+        """Check that hostname doesn't change in dryrun mode
+        and that return value is 0.
+        """
+        self.assertEqual(0, mfh.change_hostname("fakehostname"))
+        self.assertEqual(self._CURRENT_HOSTNAME, gethostname())
+
     def test_daemon_start_stop_bad_daemon(self):
         """Test Bad Input for daemon name."""
         mfh._DRYRUN = False

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 # TODO docstring?
-# TODO fix tabs/spaces
 
 import unittest
 #import subprocess
@@ -28,16 +27,20 @@ class TestMigrateFusionHostname(unittest.TestCase):
         """Runs once after every test."""
 
 
+    #### Full Program Tests ####
+    
+    # All of these should be run with the --dryrun flag
+
     def testFullProgram(self):
         # TODO big tests of full program as subprocess calls
-        # TODO test bad input, etc.
+        # TODO test bad commandline args, etc.
         # *** run all of these ase DRYRUNS!
         pass
 
+    ### Individual Method Tests ####
 
-# TODO split into smaller functions (1 per test?)
-    def testDaemonStartStop(self):
-        # Test Bad Input for daemon:
+    def daemon_start_stop_badInput(self):
+        # Test Bad Input for daemon name:
         with self.assertRaises(OSError):
             mfh.daemon_start_stop("/etc/init.d/fake_daemon_asdf", "start")
 

--- a/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
+++ b/earth_enterprise/src/fusion/tools/migrate_fusion_hostname_unittest.py
@@ -305,6 +305,12 @@ class TestMigrateFusionHostname(unittest.TestCase):
         # clean up:
         os.rmdir(tmpdir)
 
+    def test_run_geresetpgdb_dryrun(self):
+        """Check return value in dryrun mode."""
+        self.assertEqual(0, mfh.run_geresetpgdb())
+
+        # TODO other tests for run_geresetpgdb? Anything else requires
+        # running actual script (not safe)
 
     # TODO for prompt_user_confirm(...) testing actual user input
     # requires unittest.mocks 


### PR DESCRIPTION
migrate_fusion_hostname.py - A new script to automate the process of changing the Fusion hostname and fixing published databases.

*** THIS IS A WORK IN PROGRESS AND IS NOT COMPLETE YET. ***

Requires root permissions (sudo).

Reproduction Steps:
There is no specific bug or reproduction steps - this is a tool to automate the steps for changing the Fusion hostname. Thus, it performs many system changes and file deletions, so should only be used if necessary or on a test machine.

Unit tests can be run with migrate_fusion_hostname_unittest.py
These should be run with and without sudo. Some options are available in the unit tests to allow/disallow any permanent changes.
UNIT TESTS SHOULD NOT BE RUN ON A PRODUCTION MACHINE, ONLY ON A TEST MACHINE!

Tested on CentOS Linux 7 (Core), using the centos7geedev Virtualbox image.
Linux 3.10.0-862.14.4.el7.x86_64
with Python 2.7.5 

Fixes #782 (in progress)