### PR TITLE
Fixes #1105:  turn world-writable files back into symlinks (#1107)

### DIFF
--- a/docs/geedocs/5.2.5/answer/7160006.html
+++ b/docs/geedocs/5.2.5/answer/7160006.html
@@ -123,6 +123,11 @@ gtag('config', 'UA-108632131-2');
                case of a naming collision. Flat databases can still only use flat imagery 
                projects.</td>
           </tr>
+          <tr>
+            <td>1105</td>
+            <td>Symlinks are incorrectly world-writable files after installation from RPM or Deb</td>
+            <td>Symlinks are now detected during the building of RPMs and Debs and are copied into the package correctly.</td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
+++ b/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeDeb.groovy
@@ -15,6 +15,8 @@
 import com.netflix.gradle.plugins.deb.Deb
 import org.gradle.api.tasks.TaskAction
 import org.opengee.shell.GeeCommandLine
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class GeeDeb extends com.netflix.gradle.plugins.deb.Deb {
     // Get the name of the Deb package that provides a given file path:
@@ -134,6 +136,10 @@ class GeeDeb extends com.netflix.gradle.plugins.deb.Deb {
         packageDescription = formattedDescription
     }
 
+    // Variable to autodetect symlinks. Detected symlinks are fixed, so they
+    // are not created as files.
+    boolean preserveSymlinks = true
+
     // Override the @TaskAction from the base class, so we can run a few fixes
     // first.
     @Override
@@ -153,7 +159,16 @@ class GeeDeb extends com.netflix.gradle.plugins.deb.Deb {
             each {
                 requires(it)
             }
-
+        
+        if (preserveSymlinks) {
+            eachFile {
+                if (it.getFile().isFile() && Files.isSymbolicLink(it.getFile().toPath())) {
+                    link("/" + it.getRelativePath().toString(), Files.readSymbolicLink(it.getFile().toPath()).toString())
+                    it.exclude()
+                }
+            }
+        }
+        
         super.copy()
     }
 }

--- a/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeRpm.groovy
+++ b/earth_enterprise/rpms/buildSrc/src/main/groovy/GeeRpm.groovy
@@ -1,5 +1,6 @@
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
+import java.nio.file.Files
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import org.gradle.api.tasks.TaskAction
@@ -175,6 +176,10 @@ RequiresEND
         }
     }
 
+    // Variable to autodetect symlinks. Detected symlinks are fixed, so they
+    // are not created as files.
+    boolean preserveSymlinks = true
+
     // Override the @TaskAction from the base class, so we can run automatic
     // depedency detection, first.
     @Override
@@ -195,6 +200,15 @@ RequiresEND
             each {
                 requires(it)
             }
+
+        if (preserveSymlinks) {
+            eachFile {
+                if (it.getFile().isFile() && Files.isSymbolicLink(it.getFile().toPath())) {
+                    link("/" + it.getRelativePath().toString(), Files.readSymbolicLink(it.getFile().toPath()).toString())
+                    it.exclude()
+                }
+            }
+        }
 
         super.copy()
 


### PR DESCRIPTION
* Initial commit. Most symlinks are fixed.

* Add fixes for the remaining files in Ubuntu.

* Fix symlinks as they are copied.

* Remove fix in post install script.

* Update post-install.sh

Revert post install script to original state.

* Update GeeRpm.groovy

Typo

* Fixed up flag for fixing symlinks.

* Update GeeDeb.groovy

Typos

* Update GeeRpm.groovy

Missing dependency

* Better name for the symlink flags.

* Add change to release notes.