### PR TITLE
#686 Add C++ compiler check & update build instructions

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -75,12 +75,14 @@ sudo yum install git-lfs
 
 ## GCC 4.8
 
-### CentOS 7 and RHEL 7
+For all flavors, install the standard development/build tools:
 
 ```bash
 yum install ant bzip2 doxygen gcc-c++ patch python-argparse python-setuptools \
   swig tar
 ```
+
+For CentOS 6 and RHEL 6, also install the devtoolset toolchain.
 
 ### CentOS 6
 
@@ -163,6 +165,7 @@ the rest of the GEE build process.
 To clone this Git repository and build the RPM on RHEL6, execute the following:
 
 ```bash
+sudo yum install -y cmake gettext rpm-build
 mkdir -p ~/opengee/rpm-build/
 cd ~/opengee/rpm-build/
 

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -480,6 +480,10 @@ gee_version_number = env.get_open_gee_version().get_short()
 
 
 # Check if the version of the default compiler is at least 4.8:
+if not env['CXX']:
+    print "Please install the default C++ compiler for your distribution."
+    Exit(1)
+
 version = opengee.c_compiler.get_cc_version(env['CXX'])
 if not opengee.version.is_version_ge(version, [4, 8]):
     # Check for GCC 4.8 from an alternative toolchain installation on RHEL 6:


### PR DESCRIPTION
`/usr/bin/g++` not being installed causes a couple of issues:

* env['CXX'] will be None, and the version check will throw an exception
* third_party g++ has /usr/bin/g++ hard-coded (e.g. in ./src/NATIVE-REL-x86_64/third_party/bin/g++)

Also, on a clean CentOS 6 install, the gtest RPM will not build because of a missing dependency.

I updated the documentation to add the default development tools, and also put a compiler check into the SConstruct file.

As long as all these requirements are met, libpng is detected and there are no problems building; I tested on both CentOS 6.8 and CentOS 6.10.  