### PR TITLE
Progress messages for state updates always say they're on iteration 1

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -127,6 +127,8 @@ AssetVersionImplD::StateChangeNotifier::SendNotifications(
       notify(NFY_WARN, "'%s' has broken %s '%s'",
              assetVersion->GetRef().c_str(), typeName.c_str(), ref.c_str());
     }
+
+    i++;
   }
   toNotify->clear();
 }


### PR DESCRIPTION
Added a statement to increment the iteration counter when iterating through the parents and children of an asset.
To test, build an asset and monitor the /var/opt/google/log/gesystemmanager.log file to make sure the iteration count in the log message increases if there is more than one iteration.
Tested on Ubuntu 16.
Fixes #1143 