### PR TITLE
Fix for issue #1155 -- GlcUnpacker::Id() returns empty string on every other call

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
@@ -561,9 +561,9 @@ const char* GlcUnpacker::Id() {
       sstream << "-" << std::hex << InfoCrc();
     }
     sstream << "-" << std::hex << length_;
+    id_ = sstream.str();
   }
 
-  id_ = sstream.str();
   return id_.c_str();
 }
 


### PR DESCRIPTION
Test the fix by verifying that GlcUnpacker::Id() returns the correct Id string every time when called multiple times for the same cutfile.