### PR TITLE
Allow cross compilation of GEE common code for android

### DIFF
--- a/earth_enterprise/src/common/base/port.h
+++ b/earth_enterprise/src/common/base/port.h
@@ -27,6 +27,8 @@
 #include <unistd.h>         // for getpagesize() on mac
 #elif defined(OS_CYGWIN)
 #include <malloc.h>         // for memalign()
+#elif defined(ANDROID)
+#include "khTypes.h"        // for uint64 definition
 #endif
 
 #include "base/integral_types.h"
@@ -45,7 +47,7 @@
 /* We use SIGPWR since that seems unlikely to be used for other reasons. */
 #define GOOGLE_OBSCURE_SIGNAL  SIGPWR
 
-#if defined OS_LINUX || defined OS_CYGWIN
+#if defined OS_LINUX || defined OS_CYGWIN || defined ANDROID
 
 // _BIG_ENDIAN
 #include <endian.h>
@@ -127,7 +129,7 @@ typedef uint16_t u_int16_t;
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
-#elif defined(__GLIBC__)
+#elif defined(__GLIBC__) || defined(ANDROID)
 #include <byteswap.h>  // IWYU pragma: export
 
 #else

--- a/earth_enterprise/src/common/notify.cpp
+++ b/earth_enterprise/src/common/notify.cpp
@@ -222,7 +222,7 @@ std::string khstrerror(int err) {
   auto retval = strerror_r(err, buf, sizeof(buf));
   char* msg = strerror_wrapper(retval, buf);
   if (msg)
-      return msg;
+    return msg;
   else
-      return "Unknown error";
+    return "Unknown error";
 }

--- a/earth_enterprise/src/common/notify.cpp
+++ b/earth_enterprise/src/common/notify.cpp
@@ -200,11 +200,29 @@ void HexDump(FILE* out, const void* data, uint32 size) {
   }
 }
 
+/* strerror_r behaves differently between POSIX and non-POSIX implementations
+ * the compiler will select the appropriate wrapper to utilize and return the error message pointer as expected
+ */
+char* strerror_wrapper(int strerr_ret, char* buf) {
+  if (strerr_ret) {
+    // POSIX strerr_r encountered a problem, khstrerror expects a null pointer in this case
+    return nullptr;
+  }
+  // no error returned so the local buffer pointer is returned
+  return buf;
+}
+
+// non-POSIX implementation wrapper may or may not write anything into local buffer so ignore it
+char* strerror_wrapper(char* strerr_ret, char*) {
+  return strerr_ret;
+}
+
 std::string khstrerror(int err) {
   char buf[256];
-  char* msg = strerror_r(err, buf, sizeof(buf));
+  auto retval = strerror_r(err, buf, sizeof(buf));
+  char* msg = strerror_wrapper(retval, buf);
   if (msg)
-    return msg;
+      return msg;
   else
-    return "Unknown error";
+      return "Unknown error";
 }


### PR DESCRIPTION
Addresses #1163 

Verification steps:

1. Verify source still successfully compiles on any supported platform for GEE
1. Install gefusion with default asset root
1. Modify `/gevol/assets/.config/.fusionversion` to have a version of 5.1.0 and save
1. Execute `sudo touch /gevol/assets/.state/badfile.task`
1. Execute `sudo /opt/google/bin/geupgradeassetroot --assetroot /gevol/assets`
1. Verify that output from the command above contains **Fusion Warning: Unable to readlink(/gevol/assets/.state/badfile.task): Invalid argument**  The important part being "Invalid argument"
1. Delete `badfile.task` and reset the asset root fusion version if it wasn't upgraded.
