### PR TITLE
#1169: Add option to strip historical imagery in Cutter

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -247,14 +247,22 @@ class GlobeBuilder(object):
     postgis_polygon = "POLYGON((%s))" % postgis_polygon
     return postgis_polygon
 
-  def RewriteDbRoot(self, source):
+  def RewriteDbRoot(self, source, include_historical):
     """Executes command to rewrite the dbroot and extract the icons it uses."""
     self.Status("Rewrite dbroot ...")
+
+    historical_flag = '--disable_historical'
+    if include_historical:
+      historical_flag = ''
+
     os_cmd = ("%s/gerewritedbroot --source=\"%s\" --icon_directory=\"%s\" "
               "--dbroot_file=\"%s\" --search_service=\"%s\" "
-              "--kml_map_file=\"%s\""
+              "--kml_map_file=\"%s\" "
+              "%s"
               % (COMMAND_DIR, source, self.icons_dir, self.dbroot_file,
-                 self.search_service, self.kml_map_file))
+                 self.search_service, self.kml_map_file,
+                 historical_flag))
+
     common.utils.ExecuteCmd(os_cmd, self.logger)
     self.Status("%d icons" % len(os.listdir(self.icons_dir)))
 
@@ -834,7 +842,8 @@ if __name__ == "__main__":
 
     elif cgi_cmd == "REWRITE_DB_ROOT":
       globe_builder.CheckArgs(["globe_name", "source"], FORM)
-      globe_builder.RewriteDbRoot(FORM.getvalue_url("source"))
+      include_historic = FORM.getvalue("include_historical_imagery") is not None
+      globe_builder.RewriteDbRoot(FORM.getvalue_url("source"), include_historic)
 
     elif cgi_cmd == "GRAB_KML":
       globe_builder.CheckArgs(["globe_name", "source"], FORM)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
@@ -124,7 +124,7 @@
       <input id="useAlternateMethod_radio" type="radio" name="useAlternateMethod">Yes
     </div>
     <div id="IncludeHistoricalHolder" style="display:none;">
-      <label>Include Historical Imagery</label>
+      <label>Include Links to Historical Imagery</label>
       <input type="radio" name="includeHistorical" checked>No
       <input id="includeHistorical_radio" type="radio" name="includeHistorical">Yes
     </div>

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/index.html
@@ -123,6 +123,11 @@
       <input type="radio" name="useAlternateMethod" checked>No
       <input id="useAlternateMethod_radio" type="radio" name="useAlternateMethod">Yes
     </div>
+    <div id="IncludeHistoricalHolder" style="display:none;">
+      <label>Include Historical Imagery</label>
+      <input type="radio" name="includeHistorical" checked>No
+      <input id="includeHistorical_radio" type="radio" name="includeHistorical">Yes
+    </div>
   </div>
   <h2></h2>
   <div class="ContentBlock" id="CutButtonDiv">

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
@@ -500,7 +500,9 @@ function updateOuterZoom(inner_zoom) {
 
 function toggleAdvancedZoom() {
   toggleElementDisplay(gees.dom.get('polyZoomHolder'));
-  toggleElementDisplay(gees.dom.get('IncludeHistoricalHolder'));
+  if (isServing == '3D') {
+    toggleElementDisplay(gees.dom.get('IncludeHistoricalHolder'));
+  }
   if (isServing == '2D') {
     toggleElementDisplay(gees.dom.get('UseAlternateMethodHolder'));
   }

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_tools.js
@@ -500,6 +500,7 @@ function updateOuterZoom(inner_zoom) {
 
 function toggleAdvancedZoom() {
   toggleElementDisplay(gees.dom.get('polyZoomHolder'));
+  toggleElementDisplay(gees.dom.get('IncludeHistoricalHolder'));
   if (isServing == '2D') {
     toggleElementDisplay(gees.dom.get('UseAlternateMethodHolder'));
   }

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_utils.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/cutter_utils.js
@@ -189,6 +189,14 @@ function geeUseAlternateMethod() {
 }
 
 /**
+ * Checks flag for including historical imagery in cut globe.
+ * @return {bool} whether historical imagery should be included.
+ */
+function geeIncludeHistoricalImagery() {
+  return gees.dom.isChecked('includeHistorical_radio');
+}
+
+/**
  * Get description of the globe.
  * @return {string} Description of the globe.
  */

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/map_cutter.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/map_cutter.js
@@ -75,6 +75,7 @@ function geeCheckMapParameters() {
 function checkAndBuild() {
   var allowOverwriting = geeAllowOverwrite();
   var useAlternateMethod = geeUseAlternateMethod();
+  var includeHistorical = geeIncludeHistoricalImagery();
 
   // Refresh the list of databases to be sure information is up to date.
   gees.initialize.databases();
@@ -97,7 +98,7 @@ function checkAndBuild() {
   }
 
   // If no published items are being overwritten, build the map.
-  geeBuildMap(allowOverwriting, useAlternateMethod);
+  geeBuildMap(allowOverwriting, useAlternateMethod, includeHistorical);
 }
 
 /**
@@ -118,7 +119,7 @@ function overwritingPublishedItemsMessage() {
  * Use a series of AJAX calls to cut a portable Map and make it available
  * for downloading. The AJAX calls provide some feedback along the way.
  */
-function geeBuildMap(allowOverwriting, useAlternateMethod) {
+function geeBuildMap(allowOverwriting, useAlternateMethod, includeHistorical) {
   hideBuildComplete();
   geeSetResponse('Building portable map ...');
   var msg = geeCheckMapParameters();
@@ -131,6 +132,7 @@ function geeBuildMap(allowOverwriting, useAlternateMethod) {
   }
 
   var useAlternateMethodStr = '';
+  var includeHistoricalStr = '';
   var url = '/cgi-bin/globe_cutter_app.py?cmd=UID&globe_name=' + geeGlobeName();
 
   if (isServing == '2D') {
@@ -143,6 +145,10 @@ function geeBuildMap(allowOverwriting, useAlternateMethod) {
 
   if (useAlternateMethod) {
     useAlternateMethodStr = '&ignore_imagery_depth=t';
+  }
+
+  if (includeHistorical) {
+    includeHistoricalStr = '&include_historical_imagery=t';
   }
 
   jQuery.get(url,
@@ -228,7 +234,7 @@ function geeBuildMap(allowOverwriting, useAlternateMethod) {
                    sequence[1] = front + base_url + 'POLYGON_TO_QTNODES&' +
                        globe_name + '&' + polygon + '&' + polygon_level + back1;
                    sequence[2] = front + base_url + 'REWRITE_DB_ROOT&' +
-                       globe_name + '&' + source + back1;
+                       globe_name + '&' + source + includeHistoricalStr + back1;
                    sequence[3] = front + base_url + 'GRAB_KML&' +
                        globe_name + '&' + source + back1;
                    sequence[4] = front + base_url + 'BUILD_GLOBE&' +


### PR DESCRIPTION
Added an Advanced option to enable or disable (the default) embedded links to historical imagery in cut globes.