### PR TITLE
1154 add overlay cli

### DIFF
--- a/earth_enterprise/src/common/khGetopt.h
+++ b/earth_enterprise/src/common/khGetopt.h
@@ -455,6 +455,17 @@ class khGetopt {
           << min << " and <= " << max;
     }
   }
+  template <class T, T min, T max>
+  static void IsEvenNumberInRange(const T &arg) {
+    if (arg < min || arg > max) {
+      throw khSimpleException("Out of range >= ")
+          << min << " and <= " << max;
+    }
+    else if (arg % 2 != 0){
+      throw khSimpleException("Not an even number");
+    }
+  }
+
 
 
   // Process all options, permuting non-options to the end

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -641,6 +641,24 @@ void RasterProjectAssetImplD::HandleAddToRequest(
     project->config.is_timemachine_project_ = is_timemachine_project;
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
+
+    // By default keep is_overlay_terrain_project_ the same unless directed
+    // otherwise.
+    bool is_overlay_terrain_project = project->config.is_overlay_terrain_project_;
+    if (req.enable_terrain_overlay){
+      is_overlay_terrain_project = true;
+    }
+    else if (req.disable_terrain_overlay){
+      is_overlay_terrain_project = false;
+    }
+    if (is_overlay_terrain_project) {
+      // Set start level and/or resources min level if specified
+      if (req.overlay_terrain_start_level != 0)
+        project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
+      if (req.overlay_terrain_resources_min_level != 0)
+        project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
+    }
+    project->config.is_overlay_terrain_project_ = is_overlay_terrain_project;
   } else {
     throw khException(kh::tr("No %1 project named %2")
                       .arg(ToQString(req.type), ToQString(req.assetname)));

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -544,6 +544,8 @@ void RasterProjectAssetImplD::HandleNewRequest(
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
     project->config.is_overlay_terrain_project_ = req.enable_terrain_overlay;
+    project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
+    project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
   }
 }
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -584,20 +584,22 @@ void RasterProjectAssetImplD::HandleModifyRequest(
     project->config.is_timemachine_project_ = is_timemachine_project;
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
-           
+
     // By default keep is_overlay_terrain_project_ the same unless directed
     // otherwise.
     bool is_overlay_terrain_project = project->config.is_overlay_terrain_project_;
     if (req.enable_terrain_overlay){
       is_overlay_terrain_project = true;
+    }
+    else if (req.disable_terrain_overlay){
+      is_overlay_terrain_project = false;
+    }
+    if (is_overlay_terrain_project) {
       // Set start level and/or resources min level if specified
       if (req.overlay_terrain_start_level != 0)
         project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
       if (req.overlay_terrain_resources_min_level != 0)
         project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
-    }
-    else if (req.disable_terrain_overlay){
-      is_overlay_terrain_project = false;
     }
     project->config.is_overlay_terrain_project_ = is_overlay_terrain_project;
   } else {

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -543,9 +543,14 @@ void RasterProjectAssetImplD::HandleNewRequest(
     project->config.is_timemachine_project_ = is_timemachine_project;
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
+
     project->config.is_overlay_terrain_project_ = req.enable_terrain_overlay;
-    project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
-    project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
+    if (req.enable_terrain_overlay){
+      if (req.overlay_terrain_start_level != 0)
+        project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
+      if (req.overlay_terrain_resources_min_level != 0)
+        project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
+    }
   }
 }
 
@@ -579,6 +584,22 @@ void RasterProjectAssetImplD::HandleModifyRequest(
     project->config.is_timemachine_project_ = is_timemachine_project;
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
+           
+    // By default keep is_overlay_terrain_project_ the same unless directed
+    // otherwise.
+    bool is_overlay_terrain_project = project->config.is_overlay_terrain_project_;
+    if (req.enable_terrain_overlay){
+      is_overlay_terrain_project = true;
+      // Set start level and/or resources min level if specified
+      if (req.overlay_terrain_start_level != 0)
+        project->config.overlay_terrain_start_level_ = req.overlay_terrain_start_level;
+      if (req.overlay_terrain_resources_min_level != 0)
+        project->config.overlay_terrain_resources_min_level_ = req.overlay_terrain_resources_min_level;
+    }
+    else if (req.disable_terrain_overlay){
+      is_overlay_terrain_project = false;
+    }
+    project->config.is_overlay_terrain_project_ = is_overlay_terrain_project;
   } else {
     throw khException(kh::tr("No %1 project named %2")
                       .arg(ToQString(req.type), ToQString(req.assetname)));

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -539,9 +539,11 @@ void RasterProjectAssetImplD::HandleNewRequest(
       project->ThrowIfAnyInvalidDates();
       is_timemachine_project = true;
     }
+
     project->config.is_timemachine_project_ = is_timemachine_project;
     notify(NFY_DEBUG, "TimeMachine: %s for %s\n", req.assetname.c_str(),
            is_timemachine_project ? "on" : "off");
+    project->config.is_overlay_terrain_project_ = req.enable_terrain_overlay;
   }
 }
 

--- a/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
@@ -188,11 +188,14 @@ class RasterProjectModifyRequest {
   bool enable_timemachine;
   bool disable_timemachine;
   bool enable_terrain_overlay;
+  uint overlay_terrain_start_level;
+  uint overlay_terrain_resources_min_level;
 #pragma StrLoadAndSave
 #hquote
   RasterProjectModifyRequest(AssetDefs::Type t)
   : type(t), enable_timemachine(false), disable_timemachine(false), 
-    enable_terrain_overlay(false) { }
+    enable_terrain_overlay(false), overlay_terrain_start_level(4),
+    overlay_terrain_resources_min_level(12) { }
 #/hquote
 
 };

--- a/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
@@ -187,10 +187,12 @@ class RasterProjectModifyRequest {
   std::vector<Item> items;
   bool enable_timemachine;
   bool disable_timemachine;
+  bool enable_terrain_overlay;
 #pragma StrLoadAndSave
 #hquote
   RasterProjectModifyRequest(AssetDefs::Type t)
-  : type(t), enable_timemachine(false), disable_timemachine(false) { }
+  : type(t), enable_timemachine(false), disable_timemachine(false), 
+    enable_terrain_overlay(false) { }
 #/hquote
 
 };

--- a/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/RasterProjectConfig.idl
@@ -188,14 +188,15 @@ class RasterProjectModifyRequest {
   bool enable_timemachine;
   bool disable_timemachine;
   bool enable_terrain_overlay;
+  bool disable_terrain_overlay;
   uint overlay_terrain_start_level;
   uint overlay_terrain_resources_min_level;
 #pragma StrLoadAndSave
 #hquote
   RasterProjectModifyRequest(AssetDefs::Type t)
   : type(t), enable_timemachine(false), disable_timemachine(false), 
-    enable_terrain_overlay(false), overlay_terrain_start_level(4),
-    overlay_terrain_resources_min_level(12) { }
+    enable_terrain_overlay(false), disable_terrain_overlay(false),
+    overlay_terrain_start_level(0), overlay_terrain_resources_min_level(0) { }
 #/hquote
 
 };

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -139,9 +139,10 @@ main(int argc, char *argv[]) {
       usage(argv[0], "--historical_imagery is not a valid option for mercator "
           "imagery projects.");
     }
-    if ((enable_terrain_overlay || disable_terrain_overlay) && AssetDefs::Terrain != AssetType){
-      usage(argv[0], "--terrain_overlay and --no_terrain_overlay are not valid options for "
-          "imagery projects.");
+    if ((enable_terrain_overlay || disable_terrain_overlay || start_level != 0 ||
+         resource_min_level != 0) && AssetDefs::Terrain != AssetType){
+      usage(argv[0], "--terrain_overlay, --no_terrain_overlay, --start_level, and "
+          "--resource_min_level are only valid for terrain projects.");
     }
 
 
@@ -188,10 +189,15 @@ printf("resource_min_level = %u\n", resource_min_level);
         notify(NFY_WARN,
                "No insets specified. Project will be empty.");
       } else if (mercator ||
-            !(enable_historical_imagery || disable_historical_imagery) ||
-            !(AssetDefs::Terrain == AssetType && 
+        !( (AssetDefs::Imagery == AssetType && (enable_historical_imagery || disable_historical_imagery)) ||
+           (AssetDefs::Terrain == AssetType && 
               (enable_terrain_overlay || disable_terrain_overlay || 
-              start_level != 0 || resource_min_level != 0))) {
+              start_level != 0 || resource_min_level != 0))
+        )){
+            // !(AssetDefs::Imagery == AssetType && (enable_historical_imagery || disable_historical_imagery)) ||
+            // !(AssetDefs::Terrain == AssetType && 
+            //   (enable_terrain_overlay || disable_terrain_overlay || 
+            //   start_level != 0 || resource_min_level != 0))) {
         // For adding/modifying, we always need insets when:
         // - It's a mercator project
         // - OR it's a non-mercator project and the historical imagery flag is NOT being modified

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -50,8 +50,8 @@ usage(const std::string &progn, const char *msg = 0, ...)
           " unless --historical_imagery is specified.\n"
           "      --terrain_overlay : make this terrain project an overlay project\n"
           "      --no_terrain_overlay : make this terrain project a normal project\n"
-          "      --start_level : specify the start level of this terrain overlay project\n"
-          "      --resource_min_level : specify the resources minimum level for this terrain overlay project\n"
+          "      --start_level : the level from which to start building the terrain overlay project\n"
+          "      --resource_min_level : the threshold level that separates fill terrain from overlay terrain\n"
           "   By default, new terrain projects are NOT overlay projects"
           " unless --terrain_overlay is specified.\n",
           progn.c_str());

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -139,8 +139,8 @@ main(int argc, char *argv[]) {
       usage(argv[0], "--historical_imagery is not a valid option for mercator "
           "imagery projects.");
     }
-    if (enable_terrain_overlay && AssetDefs::Terrain != AssetType){
-      usage(argv[0], "--enable_terrain_overlay is not a valid option for "
+    if ((enable_terrain_overlay || disable_terrain_overlay) && AssetDefs::Terrain != AssetType){
+      usage(argv[0], "--terrain_overlay and --no_terrain_overlay are not valid options for "
           "imagery projects.");
     }
 

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -45,8 +45,10 @@ usage(const std::string &progn, const char *msg = 0, ...)
             "      --flat : use flat(Plate Carre) projection (default)\n"
             "      --terrain_overlay : make this terrain project an overlay project\n"
             "      --no_terrain_overlay : make this terrain project a normal project\n"
-            "      --start_level : the level from which to start building the terrain overlay project\n"
-            "      --resource_min_level : the threshold level that separates fill terrain from overlay terrain\n"
+            "      --start_level : the level from which to start building the\n"
+            "                      terrain overlay project\n"
+            "      --resource_min_level : the threshold level that separates\n"
+            "                             fill terrain from overlay terrain\n"
             "   By default, new terrain projects are NOT overlay projects"
             " unless --terrain_overlay is specified.\n",
             progn.c_str());
@@ -163,12 +165,6 @@ main(int argc, char *argv[]) {
       usage(argv[0], "--historical_imagery is not a valid option for mercator "
           "imagery projects.");
     }
-    if ((enable_terrain_overlay || disable_terrain_overlay || start_level != 0 ||
-         resource_min_level != 0) && AssetDefs::Terrain != AssetType){
-      usage(argv[0], "--terrain_overlay, --no_terrain_overlay, --start_level, and "
-          "--resource_min_level are only valid for terrain projects.");
-    }
-
 
     // Process the request items, which are a variable length list of strings.
     for(uint i = 0; i < request_items.size(); ++i) {

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -188,10 +188,15 @@ printf("resource_min_level = %u\n", resource_min_level);
         notify(NFY_WARN,
                "No insets specified. Project will be empty.");
       } else if (mercator ||
-            !(enable_historical_imagery || disable_historical_imagery)) {
-        // For adding/modifying, we always need insets except:
-        // non-mercator when historical_imagery/no_historical_imagery is
-        // specified.
+            !(enable_historical_imagery || disable_historical_imagery) ||
+            !(AssetDefs::Terrain == AssetType && 
+              (enable_terrain_overlay || disable_terrain_overlay || 
+              start_level != 0 || resource_min_level != 0))) {
+        // For adding/modifying, we always need insets when:
+        // - It's a mercator project
+        // - OR it's a non-mercator project and the historical imagery flag is NOT being modified
+        // - OR it's a terrain project and no overlay-related options are being modified
+        // In those cases, show the usage text and exit.
         usage(progname, "No insets specified");
       }
     }

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -21,6 +21,54 @@
 #include <autoingest/khAssetManagerProxy.h>
 #include <autoingest/plugins/RasterProjectAsset.h>
 
+const char * NEW_TERRAIN_USAGE = "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --terrain_overlay : make this terrain project an overlay project\n"
+            "      --start_level : the level from which to start building the\n"
+            "                      terrain overlay project\n"
+            "      --resource_min_level : the threshold level that separates\n"
+            "                             fill terrain from overlay terrain\n"
+            "   By default, new terrain projects are NOT overlay projects"
+            " unless --terrain_overlay is specified.\n";
+
+const char * MODIFY_TERRAIN_USAGE = "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --terrain_overlay : make this terrain project an overlay project\n"
+            "      --no_terrain_overlay : make this terrain project a normal project\n"
+            "      --start_level : the level from which to start building the\n"
+            "                      terrain overlay project\n"
+            "      --resource_min_level : the threshold level that separates\n"
+            "                             fill terrain from overlay terrain\n";
+
+const char * NEW_IMAGERY_USAGE = "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --historical_imagery : change this project to be a historical\n"
+            "                             imagery project\n"
+            "   By default, new projects are NOT time machine projects"
+            " unless --historical_imagery is specified.\n";
+
+const char * MODIFY_IMAGERY_USAGE = "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --historical_imagery : change this project to be a historical\n"
+            "                             imagery project\n"
+            "      --no_historical_imagery : make this a normal project\n"
+            "                         (i.e., not a historical imagery project)\n";
 
 AssetDefs::Type AssetType = AssetDefs::Invalid;
 
@@ -35,38 +83,16 @@ usage(const std::string &progn, const char *msg = 0, ...)
     fprintf(stderr, "\n");
   }
 
+  bool is_new_project_command = progn.find("new") != std::string::npos;
   if (AssetDefs::Terrain == AssetType){
+    char * 
     fprintf(stderr,
-            "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
-            "<insetresource>}...\n"
-            "   Supported options are:\n"
-            "      --help | -?:      Display this usage message\n"
-            "      --mercator : use mercator projection\n"
-            "      --flat : use flat(Plate Carre) projection (default)\n"
-            "      --terrain_overlay : make this terrain project an overlay project\n"
-            "      --no_terrain_overlay : make this terrain project a normal project\n"
-            "      --start_level : the level from which to start building the\n"
-            "                      terrain overlay project\n"
-            "      --resource_min_level : the threshold level that separates\n"
-            "                             fill terrain from overlay terrain\n"
-            "   By default, new terrain projects are NOT overlay projects"
-            " unless --terrain_overlay is specified.\n",
+            is_new_project_command ? NEW_TERRAIN_USAGE : MODIFY_TERRAIN_USAGE,
             progn.c_str());
   }
   else {
     fprintf(stderr,
-            "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
-            "<insetresource>}...\n"
-            "   Supported options are:\n"
-            "      --help | -?:      Display this usage message\n"
-            "      --mercator : use mercator projection\n"
-            "      --flat : use flat(Plate Carre) projection (default)\n"
-            "      --historical_imagery : change this project to be a historical\n"
-            "                             imagery project\n"
-            "      --no_historical_imagery : make this a normal project\n"
-            "                         (i.e., not a historical imagery project)\n"
-            "   By default, new projects are NOT time machine projects"
-            " unless --historical_imagery is specified.\n",
+            is_new_project_command ? NEW_IMAGERY_USAGE : MODIFY_IMAGERY_USAGE,
             progn.c_str());
   }
   exit(1);

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -75,6 +75,8 @@ main(int argc, char *argv[]) {
     
     uint peergroup = 0;
     uint overridemax = 0;
+    uint start_level = 4;           // Applicable only when enable_terrain_overlay is true
+    uint resource_min_level = 12;   // Applicable only when enable_terrain_overlay is true
 
     RasterProjectModifyRequest req(AssetType);
 
@@ -91,6 +93,9 @@ main(int argc, char *argv[]) {
     options.opt("historical_imagery", enable_historical_imagery);
     options.opt("no_historical_imagery", disable_historical_imagery);
     options.opt("enable_terrain_overlay", enable_terrain_overlay);
+    options.opt("start_level", start_level);
+    options.opt("resource_min_level", resource_min_level);
+
 
     // While processing the command line args, we must record the request items
     // which are a variable length list of strings.
@@ -166,6 +171,8 @@ main(int argc, char *argv[]) {
 
     if (AssetDefs::Terrain == AssetType){
       req.enable_terrain_overlay = enable_terrain_overlay;
+      req.overlay_terrain_start_level = start_level;
+      req.overlay_terrain_resources_min_level = resource_min_level;
     }
 
     if (req.items.empty()) {

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -85,7 +85,6 @@ usage(const std::string &progn, const char *msg = 0, ...)
 
   bool is_new_project_command = progn.find("new") != std::string::npos;
   if (AssetDefs::Terrain == AssetType){
-    char * 
     fprintf(stderr,
             is_new_project_command ? NEW_TERRAIN_USAGE : MODIFY_TERRAIN_USAGE,
             progn.c_str());

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -47,7 +47,13 @@ usage(const std::string &progn, const char *msg = 0, ...)
           "      --no_historical_imagery : make this a normal project\n"
           "                         (i.e., not a historical imagery project)\n"
           "   By default, new projects are NOT time machine projects"
-          " unless --historical_imagery is specified.\n",
+          " unless --historical_imagery is specified.\n"
+          "      --terrain_overlay : make this terrain project an overlay project\n"
+          "      --no_terrain_overlay : make this terrain project a normal project\n"
+          "      --start_level : specify the start level of this terrain overlay project\n"
+          "      --resource_min_level : specify the resources minimum level for this terrain overlay project\n"
+          "   By default, new terrain projects are NOT overlay projects"
+          " unless --terrain_overlay is specified.\n",
           progn.c_str());
   exit(1);
 }
@@ -172,11 +178,8 @@ main(int argc, char *argv[]) {
       req.disable_timemachine = disable_historical_imagery;
     }
 
+    // Only pass along the overlay-related options if it's a terrain project
     if (AssetDefs::Terrain == AssetType){
-printf("enable_terrain_overlay = %s\n", enable_terrain_overlay ? "true" : "false");
-printf("disable_terrain_overlay = %s\n", disable_terrain_overlay ? "true" : "false");
-printf("start_level = %u\n", start_level);
-printf("resource_min_level = %u\n", resource_min_level);
       req.enable_terrain_overlay = enable_terrain_overlay;
       req.disable_terrain_overlay = disable_terrain_overlay;
       req.overlay_terrain_start_level = start_level;

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -75,8 +75,8 @@ main(int argc, char *argv[]) {
     
     uint peergroup = 0;
     uint overridemax = 0;
-    uint start_level = 4;           // Applicable only when enable_terrain_overlay is true
-    uint resource_min_level = 12;   // Applicable only when enable_terrain_overlay is true
+    uint start_level = 0;           // Applicable only when enable_terrain_overlay is true
+    uint resource_min_level = 0;   // Applicable only when enable_terrain_overlay is true
 
     RasterProjectModifyRequest req(AssetType);
 
@@ -93,8 +93,8 @@ main(int argc, char *argv[]) {
     options.opt("historical_imagery", enable_historical_imagery);
     options.opt("no_historical_imagery", disable_historical_imagery);
     options.opt("enable_terrain_overlay", enable_terrain_overlay);
-    options.opt("start_level", start_level);
-    options.opt("resource_min_level", resource_min_level);
+    options.opt("start_level", start_level, &khGetopt::IsEvenNumberInRange<uint, 4, 24>); 
+    options.opt("resource_min_level", resource_min_level, &khGetopt::RangeValidator<uint, 4, 24>);
 
 
     // While processing the command line args, we must record the request items
@@ -169,6 +169,9 @@ main(int argc, char *argv[]) {
       req.disable_timemachine = disable_historical_imagery;
     }
 
+printf("enable_terrain_overlay = %s\n", enable_terrain_overlay ? "true" : "false");
+printf("start_level = %u\n", start_level);
+printf("resource_min_level = %u\n", resource_min_level);
     if (AssetDefs::Terrain == AssetType){
       req.enable_terrain_overlay = enable_terrain_overlay;
       req.overlay_terrain_start_level = start_level;

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -71,6 +71,8 @@ main(int argc, char *argv[]) {
     bool mercator = false;
     bool enable_historical_imagery = false;
     bool disable_historical_imagery = false;
+    bool enable_terrain_overlay = false;
+    
     uint peergroup = 0;
     uint overridemax = 0;
 
@@ -88,6 +90,7 @@ main(int argc, char *argv[]) {
     options.opt("maxlevel", overridemax);
     options.opt("historical_imagery", enable_historical_imagery);
     options.opt("no_historical_imagery", disable_historical_imagery);
+    options.opt("enable_terrain_overlay", enable_terrain_overlay);
 
     // While processing the command line args, we must record the request items
     // which are a variable length list of strings.
@@ -129,6 +132,11 @@ main(int argc, char *argv[]) {
       usage(argv[0], "--historical_imagery is not a valid option for mercator "
           "imagery projects.");
     }
+    if (enable_terrain_overlay && AssetDefs::Terrain != AssetType){
+      usage(argv[0], "--enable_terrain_overlay is not a valid option for "
+          "imagery projects.");
+    }
+
 
     // Process the request items, which are a variable length list of strings.
     for(uint i = 0; i < request_items.size(); ++i) {
@@ -151,9 +159,13 @@ main(int argc, char *argv[]) {
         (mercator? kMercatorProjectSubtype : kProjectSubtype));
 
     // TimeMachine only applies to non-mercator
-     if (!mercator) {
+    if (!mercator) {
       req.enable_timemachine = enable_historical_imagery;
       req.disable_timemachine = disable_historical_imagery;
+    }
+
+    if (AssetDefs::Terrain == AssetType){
+      req.enable_terrain_overlay = enable_terrain_overlay;
     }
 
     if (req.items.empty()) {

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -72,11 +72,12 @@ main(int argc, char *argv[]) {
     bool enable_historical_imagery = false;
     bool disable_historical_imagery = false;
     bool enable_terrain_overlay = false;
+    bool disable_terrain_overlay = false;
     
     uint peergroup = 0;
     uint overridemax = 0;
-    uint start_level = 0;           // Applicable only when enable_terrain_overlay is true
-    uint resource_min_level = 0;   // Applicable only when enable_terrain_overlay is true
+    uint start_level = 0;          
+    uint resource_min_level = 0;  
 
     RasterProjectModifyRequest req(AssetType);
 
@@ -92,7 +93,8 @@ main(int argc, char *argv[]) {
     options.opt("maxlevel", overridemax);
     options.opt("historical_imagery", enable_historical_imagery);
     options.opt("no_historical_imagery", disable_historical_imagery);
-    options.opt("enable_terrain_overlay", enable_terrain_overlay);
+    options.opt("terrain_overlay", enable_terrain_overlay);
+    options.opt("no_terrain_overlay", disable_terrain_overlay);
     options.opt("start_level", start_level, &khGetopt::IsEvenNumberInRange<uint, 4, 24>); 
     options.opt("resource_min_level", resource_min_level, &khGetopt::RangeValidator<uint, 4, 24>);
 
@@ -169,11 +171,13 @@ main(int argc, char *argv[]) {
       req.disable_timemachine = disable_historical_imagery;
     }
 
+    if (AssetDefs::Terrain == AssetType){
 printf("enable_terrain_overlay = %s\n", enable_terrain_overlay ? "true" : "false");
+printf("disable_terrain_overlay = %s\n", disable_terrain_overlay ? "true" : "false");
 printf("start_level = %u\n", start_level);
 printf("resource_min_level = %u\n", resource_min_level);
-    if (AssetDefs::Terrain == AssetType){
       req.enable_terrain_overlay = enable_terrain_overlay;
+      req.disable_terrain_overlay = disable_terrain_overlay;
       req.overlay_terrain_start_level = start_level;
       req.overlay_terrain_resources_min_level = resource_min_level;
     }

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtoimageryproject.cpp
@@ -35,26 +35,38 @@ usage(const std::string &progn, const char *msg = 0, ...)
     fprintf(stderr, "\n");
   }
 
-  fprintf(stderr,
-          "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
-          "<insetresource>}...\n"
-          "   Supported options are:\n"
-          "      --help | -?:      Display this usage message\n"
-          "      --mercator : use mercator projection\n"
-          "      --flat : use flat(Plate Carre) projection (default)\n"
-          "      --historical_imagery : change this project to be a historical\n"
-          "                             imagery project\n"
-          "      --no_historical_imagery : make this a normal project\n"
-          "                         (i.e., not a historical imagery project)\n"
-          "   By default, new projects are NOT time machine projects"
-          " unless --historical_imagery is specified.\n"
-          "      --terrain_overlay : make this terrain project an overlay project\n"
-          "      --no_terrain_overlay : make this terrain project a normal project\n"
-          "      --start_level : the level from which to start building the terrain overlay project\n"
-          "      --resource_min_level : the threshold level that separates fill terrain from overlay terrain\n"
-          "   By default, new terrain projects are NOT overlay projects"
-          " unless --terrain_overlay is specified.\n",
-          progn.c_str());
+  if (AssetDefs::Terrain == AssetType){
+    fprintf(stderr,
+            "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --terrain_overlay : make this terrain project an overlay project\n"
+            "      --no_terrain_overlay : make this terrain project a normal project\n"
+            "      --start_level : the level from which to start building the terrain overlay project\n"
+            "      --resource_min_level : the threshold level that separates fill terrain from overlay terrain\n"
+            "   By default, new terrain projects are NOT overlay projects"
+            " unless --terrain_overlay is specified.\n",
+            progn.c_str());
+  }
+  else {
+    fprintf(stderr,
+            "\nusage: %s [options] -o <projectname> {[--maxlevel <level>] "
+            "<insetresource>}...\n"
+            "   Supported options are:\n"
+            "      --help | -?:      Display this usage message\n"
+            "      --mercator : use mercator projection\n"
+            "      --flat : use flat(Plate Carre) projection (default)\n"
+            "      --historical_imagery : change this project to be a historical\n"
+            "                             imagery project\n"
+            "      --no_historical_imagery : make this a normal project\n"
+            "                         (i.e., not a historical imagery project)\n"
+            "   By default, new projects are NOT time machine projects"
+            " unless --historical_imagery is specified.\n",
+            progn.c_str());
+  }
   exit(1);
 }
 
@@ -69,6 +81,10 @@ main(int argc, char *argv[]) {
       AssetType = AssetDefs::Terrain;
     else
       AssetType = AssetDefs::Imagery;
+    
+    // constants
+    const uint MINIMUM_LEVEL = 4;
+    const uint MAXIMUM_LEVEL = 24;
 
     // process commandline options
     bool help = false;
@@ -101,8 +117,10 @@ main(int argc, char *argv[]) {
     options.opt("no_historical_imagery", disable_historical_imagery);
     options.opt("terrain_overlay", enable_terrain_overlay);
     options.opt("no_terrain_overlay", disable_terrain_overlay);
-    options.opt("start_level", start_level, &khGetopt::IsEvenNumberInRange<uint, 4, 24>); 
-    options.opt("resource_min_level", resource_min_level, &khGetopt::RangeValidator<uint, 4, 24>);
+    options.opt("start_level", start_level, 
+      &khGetopt::IsEvenNumberInRange<uint, MINIMUM_LEVEL, MAXIMUM_LEVEL>); 
+    options.opt("resource_min_level", resource_min_level, 
+      &khGetopt::RangeValidator<uint, MINIMUM_LEVEL, MAXIMUM_LEVEL>);
 
 
     // While processing the command line args, we must record the request items
@@ -197,10 +215,6 @@ main(int argc, char *argv[]) {
               (enable_terrain_overlay || disable_terrain_overlay || 
               start_level != 0 || resource_min_level != 0))
         )){
-            // !(AssetDefs::Imagery == AssetType && (enable_historical_imagery || disable_historical_imagery)) ||
-            // !(AssetDefs::Terrain == AssetType && 
-            //   (enable_terrain_overlay || disable_terrain_overlay || 
-            //   start_level != 0 || resource_min_level != 0))) {
         // For adding/modifying, we always need insets when:
         // - It's a mercator project
         // - OR it's a non-mercator project and the historical imagery flag is NOT being modified


### PR DESCRIPTION
Fixes #1154 
Adds 4 new options to `genewterrainproject` and `gemodifyterrainproject`. The new options are as follows:

- `--terrain_overlay` (enables the "terrain overlay" flag for a terrain project)
- `--no_terrain_overlay` (disables the "terrain overlay" flag for a terrain project)
- `--start_level` (even integer between 4 and 24 inclusive)
- `--resource_min_level` (integer between 4 and 24 inclusive)

For verification, call `genewterrainproject` and `gemodifyterrainproject` with different combinations of these options (including none of them), and verify that the values appear as expected when viewing the project in question in the Fusion UI.

Verify `geaddtoterrainproject` supports the newly added options like `genewterrainproject` does.
