### PR TITLE
1158 return gee server defs

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8"/>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -1,4 +1,12 @@
-<!DOCTYPE html>
+<        <tr>
+            <td>200</td>
+            <td><code>stage_install</code> fails on the tutorial files when <code>/home</code>
+              and <code>/tmp</code> are on different file systems</td>
+            <td>
+              Files are linked in <code>/tmp</code> using symbolic links back to original locations.
+            </td>
+          </tr>
+   !DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8"/>
@@ -74,6 +82,13 @@ gtag('config', 'UA-108632131-2');
               and <code>/tmp</code> are on different file systems</td>
             <td>
               Files are linked in <code>/tmp</code> using symbolic links back to original locations.
+            </td>
+          </tr>
+           <tr>
+            <td>1158</td>
+            <td><code>geeServerDefs</code> are not returned by Portable Server after being requested, once the globe has been viewed by a client. It is not possible to request <code>geeServerDefs</code> for globes other than the current <code>selectedGlobe</code>.</td>
+            <td>
+              <code>geeServerDefs</code> are returned correctly and can be requested for any valid globe at any time.
             </td>
           </tr>
         </tbody>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -383,7 +383,7 @@ gtag('config', 'UA-108632131-2');
 
     <hr />
     </p>
-    <p class="copyright">&copy;2018 Open GEE Contributors</p>
+    <p class="copyright">&copy;2018-2019 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -1,12 +1,3 @@
-<        <tr>
-            <td>200</td>
-            <td><code>stage_install</code> fails on the tutorial files when <code>/home</code>
-              and <code>/tmp</code> are on different file systems</td>
-            <td>
-              Files are linked in <code>/tmp</code> using symbolic links back to original locations.
-            </td>
-          </tr>
-   !DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8"/>

--- a/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
@@ -389,22 +389,25 @@ class LocalServer(object):
         handler.write(tornado.web.globe_.search_db_.JsonSearch(search_term, cb))
 
   def ParseGlobeReqName(self, req):
+    """Ascertain whether requested globe name exists in data directory."""
     globe_name = ""
     if "/" in req:
       try:
         globe_name = req.split("/")[1]
       except:
         globe_name = req.split("/")[0]
+
+    # If the globe requested is not already selected
     if globe_name != tornado.web.globe_.GlobeName():
       if globe_name in portable_web_interface.SetUpHandler.GlobeNameList(
           tornado.web.globe_.GlobeBaseDirectory(),[".glc", ".glb", ".glm"]):
-        print "found globe name in the list" 
+        # Globe requested is in the list of globes
         return globe_name
       else:
-        #invalid globe name
+        # Invalid globe name
         return -1
     else:
-      #globe requested is the current selectedGlobe
+      # Globe requested is the current selectedGlobe
       return 1
     
 
@@ -415,12 +418,11 @@ class LocalServer(object):
 
     globe_request_name = self.ParseGlobeReqName(handler.request.uri)
     if globe_request_name != -1 and globe_request_name != 1:
-      # Select the requested globe name, as it is a legit globe name
+      # Requested globe name is valid, so select it
       globe_path = "%s%s%s" % (
           tornado.web.globe_.GlobeBaseDirectory(),
           os.sep, globe_request_name)
       tornado.web.globe_.ServeGlobe(globe_path)
-    print tornado.web.globe_.GlobeName() 
 
     # Get to end of serverUrl so we can add globe name.
     # This will fail if serverDefs are requested for a glc file
@@ -430,6 +432,9 @@ class LocalServer(object):
         if tornado.web.globe_.IsMbtiles():
           json = MBTILES_JSON
         else:
+          # Portable seems to believe that 2D files are 3D when they
+          # are not actively being viewed by a client, so handle
+          # both possibilities in either case.
           try:
             json = tornado.web.globe_.ReadFile("maps/map.json")
           except:

--- a/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
@@ -416,9 +416,11 @@ class LocalServer(object):
     if not handler.IsValidRequest():
       raise tornado.web.HTTPError(404)
 
+    current_globe = ""
     globe_request_name = self.ParseGlobeReqName(handler.request.uri)
     if globe_request_name != -1 and globe_request_name != 1:
       # Requested globe name is valid, so select it
+      current_globe = tornado.web.globe_.GlobeName()
       globe_path = "%s%s%s" % (
           tornado.web.globe_.GlobeBaseDirectory(),
           os.sep, globe_request_name)
@@ -506,6 +508,13 @@ class LocalServer(object):
     # Adding globe name helps ensure clearing of cache for new globes.
     handler.write("%s/%s%s" % (
         json_start, tornado.web.globe_.GlobeShortName(), json_end))
+
+    # If we switched globes, switch back
+    if len(current_globe):
+      globe_path = "%s%s%s" % (
+          tornado.web.globe_.GlobeBaseDirectory(),
+          os.sep, globe_request_name)
+      tornado.web.globe_.ServeGlobe(globe_path)
 
   def ConvertToQtNode(self, col, row, level):
     """Converts col, row, and level to corresponding qtnode string."""

--- a/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc, 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #1158, changing selected globe and returning geeServerDefs from Portable Server (when they are requested for a valid, existing globe file of type glm or glb).  Server defs are only returned for a currently selected globe, so if they are requested for a currently unselected globe, first switch to that globe, request the server defs, then switch back so that it does not interfere with any users.

The syntax in the server defs request needs to include the full file name (with extension) of the globe for which the defs are being requested.  Syntax for a request is:
`http://localhost:9335/${filename}/query?request=Json&var=geeServerDefs`

For verification, this needs to be tested on an instance of Portable with multiple cut globes in the data directory. Request server defs for the different files and make sure the data returned looks accurate. View the globes/maps in a web browser and/or Google Earth Enterprise Client and make sure the server defs do not disappear after a map is viewed, and also that the globe displayed in the client does not change after server defs for a different globe are requested and returned.