### PR TITLE
google#127: remove prompt on reinstall with -u

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -127,11 +127,6 @@ gtag('config', 'UA-108632131-2');
           <td>No current work around. The created backup can be deleted.</td>
         </tr>
         <tr>
-          <td>127</td>
-          <td>Incorrect error messages from Fusion installer</td>
-          <td>No current work around.</td>
-        </tr>
-        <tr>
           <td>190</td>
           <td>Hostname mismatch check in installers doesn't work as expected</td>
           <td>No current work around.</td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -69,6 +69,13 @@ gtag('config', 'UA-108632131-2');
             <th>Resolution</th>
           </tr>
           <tr>
+            <td>127</td>
+            <td>Incorrect error messages from Fusion installer</td>
+            <td>
+              Stop incorrect error from showing when re-installing with<code> -u </code>flag
+            </td>
+          </tr>
+          <tr>
             <td>200</td>
             <td><code>stage_install</code> fails on the tutorial files when <code>/home</code>
               and <code>/tmp</code> are on different file systems</td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8"/>
-<title>Release notes: Open GEE 5.2.5</title>
+<title>Release notes: Open GEE 5.3.0</title>
 <link rel="stylesheet" href="../css/styles.css" type="text/css" media="all" />
 <link rel="stylesheet" href="../css/containers.css" type="text/css" media="all" />
 <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -383,7 +383,7 @@ gtag('config', 'UA-108632131-2');
 
     <hr />
     </p>
-    <p class="copyright">&copy;2018 Open GEE Contributors</p>
+    <p class="copyright">&copy;2018-2019 Open GEE Contributors</p>
   </div>
 </div>
 </body>

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -418,6 +418,9 @@ parse_arguments()
 				if [ $IS_NEWINSTALL == false ]; then
 					echo -e "\nYou cannot modify the fusion user name using the installer because Fusion is already installed on this server."
 					parse_arguments_retval=1
+					# Don't show the User Group dialog since it is invalid to change the fusion
+					# username once fusion is installed on the server
+					show_user_group_recommendation=false
 					break
 				else
 					shift
@@ -485,9 +488,9 @@ parse_arguments()
 	    echo -e "Selected Fusion User Group: \t\t\t$GROUPNAME"
     
         # START WORK HERE
-        if ! prompt_to_quit "X (Exit) the installer and change the asset root location - C (Continue) to use the asset root that you have specified."; then
+        if ! prompt_to_quit "X (Exit) the installer and use the default username - C (Continue) to use the username that you have specified."; then
             parse_arguments_retval=1
-        fi  
+        fi
     fi
 	
 	return $parse_arguments_retval;
@@ -744,7 +747,7 @@ check_asset_root_volume_size()
         echo -e "We recommend that an asset root directory have a minimum of $MIN_ASSET_ROOT_VOLUME_SIZE_IN_GB GB of free disk space."
         echo ""
 
-        if ! prompt_to_quit "X (Exit) the installer and change the asset root location - C (Continue) to use the asset root that you have specified."; then
+        if ! prompt_to_quit "X (Exit) the installer and change the asset root location with larger volume - C (Continue) to use the asset root that you have specified."; then
             check_asset_root_volume_size_retval=1
         fi
     fi

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2017 Google Inc.
+# Copyright 2018-2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -441,6 +442,9 @@ parse_arguments()
 				if [ $IS_NEWINSTALL == false ]; then
 					echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
 					parse_arguments_retval=1
+					# Don't show the User Group dialog since it is invalid to change the fusion
+					# username once fusion is installed on the server
+					show_user_group_recommendation=false
 					break
 				else
 					shift


### PR DESCRIPTION
Stops erroneous message from appearing when installing again
with `-u` flag. This flag is only valid for first install.
However the warning about not using the default username would
appear anytime you used it. This ensures that the message will
only show on first time installs.

Also update prompts for accuracy

see #127 