### PR TITLE
Use POSIX file API to support large files on 32-bit Android

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.cpp
@@ -105,7 +105,7 @@ bool PortableGlcReader::ReadData(
 
   try {
     lseek64(glc_file_, offset, SEEK_SET);
-    read(reinterpret_cast<char*>(buffer), size, 1, glc_file_);
+    read(glc_file_, buffer, size);
     return true;
   } catch(...) {
     return false;

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.cpp
@@ -25,12 +25,17 @@
 #include <string>
 #include "./khTypes.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
 /**
  * Constructor.
  */
 PortableGlcReader::PortableGlcReader(const char* path)
   : path_(path) {
-  glc_file_ = fopen(path_.c_str(), "rb");
+  glc_file_ = open(path_.c_str(), O_RDONLY);
 
   auto last_sep = path_.find_last_of('/');
   if (last_sep == std::string::npos) {
@@ -60,8 +65,7 @@ PortableGlcReader::PortableGlcReader(const char* path)
   // Set file size (important for negative offsets).
   glc_file_size_ = 0;
   if (glc_file_) {
-    fseek(glc_file_, 0, SEEK_END);
-    glc_file_size_ = ftell(glc_file_);
+    glc_file_size_ = lseek64(glc_file_, 0, SEEK_END);
   } else {
     std::cerr << "GlcReader stream is not open." << std::endl;
   }
@@ -69,7 +73,7 @@ PortableGlcReader::PortableGlcReader(const char* path)
 
 PortableGlcReader::~PortableGlcReader() {
   if (glc_file_) {
-    fclose(glc_file_);
+    close(glc_file_);
   }
 }
 
@@ -100,8 +104,8 @@ bool PortableGlcReader::ReadData(
   }
 
   try {
-    fseek(glc_file_, offset, SEEK_SET);
-    fread(reinterpret_cast<char*>(buffer), size, 1, glc_file_);
+    lseek64(glc_file_, offset, SEEK_SET);
+    read(reinterpret_cast<char*>(buffer), size, 1, glc_file_);
     return true;
   } catch(...) {
     return false;

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/portable_glc_reader.h
@@ -77,7 +77,7 @@ class PortableGlcReader : public GlcReader {
   virtual std::string Filename() const { return filename_nosuffix_; }
 
  private:
-  mutable FILE* glc_file_;
+  mutable int glc_file_;
   uint64 glc_file_size_;
   const std::string path_;
   std::string filename_nosuffix_;


### PR DESCRIPTION
Address issue: #1190. The C library functions (fopen/ftell/fseek/...) that were used to read GLC files don't support files larger than 2 Gb on 32-bit Android.  This change uses the Posix API which does support large files on 32-bit Android.

Needs testing on Windows.