### PR TITLE
Fixes #1093 geselectpublishroot offers no help, appears to take some action when --help flag is specified

### DIFF
--- a/docs/geedocs/5.3.0/answer/3481558.html
+++ b/docs/geedocs/5.3.0/answer/3481558.html
@@ -598,6 +598,6 @@ geserveradmin --garbagecollect
 <p><i>Optional</i>. Perform the upgrade without prompting the user for any input. This option requires that some commands have arguments specified on the command line.</p>
 <p> </p>
 </p>
-<p class="copyright">&copy;2018 Google, Open GEE Contributors</p>
+<p class="copyright">&copy;2018 Google, 2018-2019 Open GEE Contributors</p>
 </body>
 </html>

--- a/docs/geedocs/5.3.0/answer/3481558.html
+++ b/docs/geedocs/5.3.0/answer/3481558.html
@@ -330,7 +330,7 @@ geselectassetroot --assetroot /gevol/assets --role slave --numcpus 3</code></pre
 <p><i>Optional. </i>Specify the number of CPUs on this machine to use for processing. The default will be the maximum number of CPUs detected on the machine during installation. This command is available only in combination with --<code>assetroot</code>.</p>
 <h2>geselectpublishroot</h2>
 <pre>
-<code>geselectpublishroot <i>path</i></code> [--<strong>noprompt</strong>]</pre>
+<code>geselectpublishroot <i>path</i></code></pre>
 <h3>Purpose</h3>
 <p>To specify a different publish root. The specified path must exist. If you want to create a publish root, see <a href="#geconfigurepublishroot"><code>geconfigurepublishroot</code></a>.</p>
 <h3>Example</h3>
@@ -339,10 +339,6 @@ geselectassetroot --assetroot /gevol/assets --role slave --numcpus 3</code></pre
 <h3>Arguments</h3>
 <p><code><i>path</i></code></p>
 <p><i>Required</i>. Specify the path to the desired publish root.</p>
-<h3>Options</h3>
-<pre>
-<code><b>--noprompt</b></code></pre>
-<p><i>Optional</i>. Perform the command without prompting the user for any input. This option requires that some commands have arguments specified on the command line.</p>
 <h2><a name="#geserveradmin"></a>geserveradmin</h2>
 <pre>
 <code><b>geserveradmin</b> [<i>options</i>] <i>commands</i></code></pre>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -97,6 +97,13 @@ gtag('config', 'UA-108632131-2');
               Symlinked portable globe directories are not modified during geserver upgrades
             </td>
           </tr>
+          <tr>
+            <td>1093</td>
+            <td>The <code>geselectpublishroot</code> server command line tool offers no help, and appears to take some action when the <code>--help</code> flag is specified</td>
+            <td>
+              Help has been added through the <code>--help</code> option, or if any invalid parameter is given
+            </td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/src/server/geselectpublishroot
+++ b/earth_enterprise/src/server/geselectpublishroot
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+use warnings;
 use strict;
 use Getopt::Long qw(:config no_ignore_case no_auto_abbrev);
 use FindBin qw($Script);

--- a/earth_enterprise/src/server/geselectpublishroot
+++ b/earth_enterprise/src/server/geselectpublishroot
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc., 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/geselectpublishroot
+++ b/earth_enterprise/src/server/geselectpublishroot
@@ -15,12 +15,31 @@
 # limitations under the License.
 #
 
+use strict;
+use Getopt::Long qw(:config no_ignore_case no_auto_abbrev);
+use FindBin qw($Script);
 
-# make sure we're running as root
-die "You must run as root\n" unless $> == 0;
+my $cmd_args_good = 0;
+my $help = 0;
+my $no_prompt = 1;
 
-if ($#ARGV < 0) {
-  die "Usage: geselectpublishroot <publish_root_dir>\n";
+sub usage {
+  warn "usage: $Script [-h] <publish_root_dir>\n";
+  warn "   Update the GE http server to point to the given\n";
+  warn "   published databases directory\n";
+  warn "Valid options are:\n";
+  warn "  -h, --help             Display this message\n";
+
+  exit(1);
+}
+
+# The --noprompt option is always implied due to requiring the dir arg on the
+# command line. Nothing different has to happen if specified. It is here for
+# consistency to avoid errors/confusion if it is specified.
+$cmd_args_good = GetOptions('help|h'   => \$help,
+                            'noprompt' => \$no_prompt);
+if (not $cmd_args_good or $help or $#ARGV < 0) {
+  usage();
 }
 
 my $dest_path = $ARGV[0];
@@ -32,12 +51,18 @@ my $confd_dir = "$ge_root/gehttpd/conf.d";
 my $stream_dir = "$dest_path/stream_space";
 my $search_dir = "$dest_path/search_space";
 
+# make sure we're running as root
+die "You must run as root\n" unless $> == 0;
+
+# require the given directory to exist before continuing
+die "$dest_path does not exist, no changes made\n" unless -d $dest_path;
+
 # Create the stream_space and search_space conf files
 write_conf_file('stream_space', $stream_dir);
 write_conf_file('search_space', $search_dir);
 print "Please restart your server to apply the change.\n";
 
-
+# Writes an Alias configuration for the given type and corresponding directory
 sub write_conf_file {
   my $type = shift @_;
   my $dir = shift @_;
@@ -48,6 +73,4 @@ sub write_conf_file {
   print CONF "Alias /$type $dir\n";
   close CONF;
 }
-
-
 

--- a/earth_enterprise/src/server/geselectpublishroot
+++ b/earth_enterprise/src/server/geselectpublishroot
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/perl
 #
 # Copyright 2017 Google Inc.
 #
@@ -19,13 +19,11 @@ use strict;
 use Getopt::Long qw(:config no_ignore_case no_auto_abbrev);
 use FindBin qw($Script);
 
-my $cmd_args_good = 0;
 my $help = 0;
-my $no_prompt = 1;
 
 sub usage {
   warn "usage: $Script [-h] <publish_root_dir>\n";
-  warn "   Update the GE http server to point to the given\n";
+  warn "   Update the OpenGEE server to point to the given\n";
   warn "   published databases directory\n";
   warn "Valid options are:\n";
   warn "  -h, --help             Display this message\n";
@@ -33,14 +31,8 @@ sub usage {
   exit(1);
 }
 
-# The --noprompt option is always implied due to requiring the dir arg on the
-# command line. Nothing different has to happen if specified. It is here for
-# consistency to avoid errors/confusion if it is specified.
-$cmd_args_good = GetOptions('help|h'   => \$help,
-                            'noprompt' => \$no_prompt);
-if (not $cmd_args_good or $help or $#ARGV < 0) {
-  usage();
-}
+GetOptions('help|h' => \$help) || usage();
+usage() if $help or $#ARGV != 0;
 
 my $dest_path = $ARGV[0];
 $dest_path =~ s/\/$//;


### PR DESCRIPTION
Fixes #1093
Improved help for geselectpublishroot. Passing -h, or --help, or any invalid options will print usage then exit.

Other fixes:
- sudo is only checked when actually doing the configuration change, not when showing usage
- if an invalid directory is given the script will exit with no changes

For verification, execute the script from the command line with or without the help argument, and with or without a valid directory. Verify the output is as expected.

Tested on CentOS 7 and Ubuntu 16.04.
