### PR TITLE
Adding "v" parameter to portable server json requests; v=2 produces proper JSON. (#799)

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -83,6 +83,13 @@ gtag('config', 'UA-108632131-2');
               Files are linked in <code>/tmp</code> using symbolic links back to original locations.
             </td>
           </tr>
+          <tr>
+            <td>799</td>
+            <td>The GEE Portable Server does not return valid JSON when queried with <code>http://&lt;server&gt;/&lt;map&gt;/query?request=Json</code>.</td>
+            <td>
+              Added a <code>v</code> parameter to the query; when its value is above 1, the GEE Portable Server will return proper JSON.  Currently, it defaults to 1 if not specified.
+            </td>
+          </tr> 
            <tr>
             <td>1158</td>
             <td><code>geeServerDefs</code> are not returned by Portable Server after being requested, once the globe has been viewed by a client. It is not possible to request <code>geeServerDefs</code> for globes other than the current <code>selectedGlobe</code>.</td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -87,7 +87,7 @@ gtag('config', 'UA-108632131-2');
             <td>799</td>
             <td>The GEE Portable Server does not return valid JSON when queried with <code>http://&lt;server&gt;/&lt;map&gt;/query?request=Json</code>.</td>
             <td>
-              Added a <code>v</code> parameter to the query; when its value is above 1, the GEE Portable Server will return proper JSON.  Currently, it defaults to 1 if not specified.
+              Added a <code>v</code> parameter to the query; when its value is 2, the GEE Portable Server will return proper JSON.  Currently, it defaults to 1 if not specified.
             </td>
           </tr> 
            <tr>

--- a/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local_server.py
@@ -520,7 +520,7 @@ class LocalServer(object):
     json_text = "%s/%s%s" % (
       json_start, tornado.web.globe_.GlobeShortName(), json_end)
 
-    if json_version > 1:
+    if json_version == 2:
       json_text = self.JStoJson(json_text)
 
     handler.write(json_text)

--- a/earth_enterprise/src/fusion/portableglobe/servers/portable_server.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/portable_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc, 2019 Open GEE Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change fixes issue #799 by adding a 'v' parameter to the GEE Portable Server's server definitions query; when it is set to 2, the result will be proper JSON.  Currently it defaults to version 1 (the previous behavior) if no version is specified.

Tested on the CentOS 7 dev environment by building the portable server and accessing tutorial_glm with both the old version and the current version, as well as with no version specified.  tutorial_glm should produce old-style output with no value or a v of 1 (starting with a variable definition, keys unquoted), and proper JSON with a v of 2.

Fixes #799 