### PR TITLE
Fix socket buildups

### DIFF
--- a/earth_enterprise/src/common/SConscript
+++ b/earth_enterprise/src/common/SConscript
@@ -187,5 +187,9 @@ env.test('performancelogger_unittest',
          'performancelogger_unittest.cpp',
          LIBS=['gecommon', 'gtest'])
 
+env.test('khThread_unittest',
+         'khThread_unittest.cpp',
+         LIBS=['gecommon', 'gtest'])
+
 env.install('common_lib', [gecommon])
 env.install('common_lib', [geutil])

--- a/earth_enterprise/src/common/SConscript
+++ b/earth_enterprise/src/common/SConscript
@@ -190,7 +190,7 @@ env.test('performancelogger_unittest',
 
 env.test('khThread_unittest',
          'khThread_unittest.cpp',
-         LIBS=['gecommon', 'gtest'])
+         LIBS=['gecommon', 'gtest', 'rt'])
 
 env.test('khconfigparser_unittest',
          'khconfigparser_unittest.cpp',

--- a/earth_enterprise/src/common/khConstants.cpp
+++ b/earth_enterprise/src/common/khConstants.cpp
@@ -163,3 +163,6 @@ const std::string kVirtualRasterFileExtension = ".khvr";
 
 // Geo Coordinate System Plate Carree Projection (EPGS:4326).
 const char* const kPlateCarreeGeoCoordSysName = "EPSG:4326";
+
+// Error message from SystemManager to clients querying current tasks
+const std::string sysManBusyMsg = "ERROR: Timed out waiting for lock";

--- a/earth_enterprise/src/common/khConstants.h
+++ b/earth_enterprise/src/common/khConstants.h
@@ -253,4 +253,6 @@ extern const std::string kVirtualRasterFileExtension;
 // Geo Coordinate System Plate Carree Projection (EPGS:4326).
 extern const char* const kPlateCarreeGeoCoordSysName;
 
+extern const std::string sysManBusyMsg;
+
 #endif  // GEO_EARTH_ENTERPRISE_SRC_COMMON_KHCONSTANTS_H_

--- a/earth_enterprise/src/common/khThread.cpp
+++ b/earth_enterprise/src/common/khThread.cpp
@@ -51,6 +51,14 @@ bool khMutexBase::TryLock(void) {
   return (err == 0);
 }
 
+bool khMutexBase::TimedTryLock(uint secToWait) {
+  timespec timeoutThreshold;
+  clock_gettime(CLOCK_REALTIME, &timeoutThreshold);
+  timeoutThreshold.tv_sec += secToWait;
+  int err = pthread_mutex_timedlock(&mutex, &timeoutThreshold);
+  return (err == 0);
+}
+
 khMutex::khMutex(void) {
   BEGIN_PERF_LOGGING(timingLogger, "khMutex::khMutex", "mutex");
   // always returns 0

--- a/earth_enterprise/src/common/khThread.h
+++ b/earth_enterprise/src/common/khThread.h
@@ -48,6 +48,8 @@ class khMutexBase {
   void Unlock(void);
   bool trylock(void) { return TryLock(); }
   bool TryLock(void);
+  bool timedTryLock(uint secToWait) { return TimedTryLock(secToWait); }
+  bool TimedTryLock(uint secToWait);
 };
 #define KH_MUTEX_BASE_INITIALIZER {PTHREAD_MUTEX_INITIALIZER}
 #define kH_MUTEX_BASE_RECURSIVE {PTHREAD_MUTEX_RECURSIVE}

--- a/earth_enterprise/src/common/khThread__port.cpp
+++ b/earth_enterprise/src/common/khThread__port.cpp
@@ -20,6 +20,7 @@
 
 void khMutexBase::Lock(void) {}
 void khMutexBase::Unlock(void) {}
+bool khMutexBase::TimedTryLock(uint) { return true; }
 khMutex::khMutex(void) {};
 khMutex::~khMutex() {};
 

--- a/earth_enterprise/src/common/khThread_unittest.cpp
+++ b/earth_enterprise/src/common/khThread_unittest.cpp
@@ -67,7 +67,7 @@ TEST_F(ThreadUnitTest, timedMutex_normal) {
   EXPECT_TRUE(info.start.tv_sec + waittime > info.stop.tv_sec);
 }
 
-// should wait atleast timeout time and then fail to create khLockGuard if mutex is already held
+// should wait at least timeout time and then fail to create khLockGuard if mutex is already held
 TEST_F(ThreadUnitTest, timedMutex_timeout) {
   uint waittime = 3; // seconds
 

--- a/earth_enterprise/src/common/khThread_unittest.cpp
+++ b/earth_enterprise/src/common/khThread_unittest.cpp
@@ -1,0 +1,137 @@
+// Copyright 2019 the Open GEE Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Unit tests for khThread 
+
+#include <string>
+#include <gtest/gtest.h>
+#include "common/khThread.h"
+
+namespace {
+
+class ThreadUnitTest : public testing::Test { };
+
+khNoDestroyMutex mutex;
+khMutex syncMutex;
+khCondVar condvar;
+
+static void holdTheMutex(uint holdSeconds) {
+  khLockGuard lock(mutex);
+  condvar.broadcast_all();
+  sleep(holdSeconds);
+}
+
+typedef struct mutex_acquire_info {
+  bool acquired = false;
+  timespec start = {0,0};
+  timespec stop = {0,0};
+  bool timeoutExceptionCaught = false;
+  bool otherExceptionCaught = false;
+} mutex_acquire_info;
+
+void testMutexAcquire(mutex_acquire_info& info, uint timetowait) {
+  try {
+    clock_gettime(CLOCK_REALTIME, &info.start);
+    khLockGuard timedTryLock(mutex, timetowait);
+    info.acquired = true;
+  }
+  catch (khTimedMutexException e) {
+    info.timeoutExceptionCaught = true;
+  }
+  catch (...) {
+    info.otherExceptionCaught = true;
+  }
+
+  clock_gettime(CLOCK_REALTIME, &info.stop);
+}
+
+// should acquire the mutex if nothing else is holding it
+TEST_F(ThreadUnitTest, timedMutex_normal) {
+  uint waittime = 5;
+  mutex_acquire_info info;
+  testMutexAcquire(info, waittime);
+  EXPECT_TRUE(info.acquired);
+  // shouldn't have taken wait time since mutex was free already
+  EXPECT_TRUE(info.start.tv_sec + waittime > info.stop.tv_sec);
+}
+
+// should wait atleast timeout time and then fail to create khLockGuard if mutex is already held
+TEST_F(ThreadUnitTest, timedMutex_timeout) {
+  uint waittime = 3; // seconds
+
+  mutex.Lock();
+
+  mutex_acquire_info info;
+  testMutexAcquire(info, waittime);
+
+  mutex.Unlock();
+
+  EXPECT_TRUE(info.start.tv_sec + waittime <= info.stop.tv_sec);
+  EXPECT_TRUE(info.timeoutExceptionCaught);
+  EXPECT_FALSE(info.otherExceptionCaught);
+}
+
+TEST_F(ThreadUnitTest, timedMutex_waitSuccess) {
+  uint holdTime = 4; // seconds
+  khThread thread1(khFunctor<void>(std::ptr_fun(&holdTheMutex), holdTime));
+  thread1.run();
+  khLockGuard syncLock(syncMutex);
+  condvar.wait(syncMutex); // wait until thread1 is holding the mutex;
+
+  // allow slightly more time than the other thread is holding
+  uint waittime = holdTime+2;
+  mutex_acquire_info info;
+  testMutexAcquire(info, waittime);
+
+  EXPECT_TRUE(info.acquired);
+  EXPECT_TRUE(info.start.tv_sec + waittime > info.stop.tv_sec);
+  EXPECT_FALSE(info.timeoutExceptionCaught);
+  EXPECT_FALSE(info.otherExceptionCaught);
+}
+
+void reallyBadFunction() {
+  throw std::runtime_error("You really shouldn't have done that!");
+}
+
+void throwAnExceptionUsingTimedMutex() {
+  khLockGuard(mutex, 10); // time doesn't matter since mutex should be free
+  reallyBadFunction();
+
+  // we're never getting here
+  sleep(100);
+}
+
+TEST_F(ThreadUnitTest, timedMutex_guardUnlock) {
+  bool exceptionCaught = false;
+  // make sure that some abnormal behavior can't leave the timed mutex locked if using the guard
+  try {
+    throwAnExceptionUsingTimedMutex();
+  }
+  catch (...) {
+    exceptionCaught = true;
+  }
+  EXPECT_TRUE(exceptionCaught);
+  EXPECT_TRUE(mutex.TryLock());
+  mutex.Unlock();
+}
+
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
+++ b/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
@@ -32,6 +32,8 @@ class MiscConfigStorage {
 
   bool        ConsolidateListenerNotifications = false;
 
+  uint        MutexTimedWaitSec = uint(30);
+
 #pragma LoadAndSave
 
 #hquote

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
@@ -1260,8 +1260,8 @@ std::string khAssetManager::RetrieveTasking(const FusionConnection::RecvPacket& 
 	  }
   }
   else {
-    notify(NFY_WARN, "Timed out waiting for lock on current task request");
-    replyPayload = "ERROR: Timed out waiting for lock";
+    // Replying with a string beginning "ERROR:" passes an exception message back to the caller
+    replyPayload = sysManBusyMsg;
   }
   }
   return replyPayload;

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
@@ -213,6 +213,7 @@ class khAssetManager
   static const std::string ASSET_STATUS;
   static const std::string PUSH_DATABASE;
   static const std::string PUBLISH_DATABASE;
+  static const std::string GET_TASKS;
 
  /**
   * Get build status of each version of an asset and return as a
@@ -240,6 +241,8 @@ class khAssetManager
   */
   // TODO: receive and return results as serialized protobufs.
   std::string PublishDatabase(const std::string arguments_string);
+
+  std::string RetrieveTasking(const FusionConnection::RecvPacket& msg);
 };
 
 extern khAssetManager theAssetManager;

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
@@ -242,6 +242,11 @@ class khAssetManager
   // TODO: receive and return results as serialized protobufs.
   std::string PublishDatabase(const std::string arguments_string);
 
+  /**
+   * Retrieve the current System Manager tasking
+   * @param msg Received request message from client
+   * @return serialized tasks list or error message beginning with "ERROR:"
+   */
   std::string RetrieveTasking(const FusionConnection::RecvPacket& msg);
 };
 

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -26,6 +26,8 @@
 // global for convenience
 int numcols = 80;
 
+static const std::string SYS_MGR_BUSY_MSG = "GetCurrTasks: " + sysManBusyMsg;
+
 void
 outline(const char *format, ...)
 {
@@ -118,7 +120,7 @@ main(int argc, char *argv[])
                                              error, timeout)) {
       	if (error.compare("GetCurrTasks: socket recvall: Resource temporarily unavailable") == 0)
           outline("No data received from gesystemmanager\nStarting new request");
-        else if (error.compare("GetCurrTasks: ERROR: Timed out waiting for lock") == 0)
+        else if (error.compare(SYS_MGR_BUSY_MSG) == 0)
           outline("System Manager is busy.  Retrying in %d seconds", delay);
         else
           notify(NFY_FATAL, "%s", error.latin1());

--- a/earth_enterprise/src/fusion/fusionui/SystemManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/SystemManager.cpp
@@ -148,7 +148,8 @@ SystemManager::updateTasks(void)
   TaskLists taskLists;
   if (!khAssetManagerProxy::GetCurrTasks("dummy", taskLists, error)) {
     QString errorMsg;
-    if (error.compare("GetCurrTasks: ERROR: Timed out waiting for lock") == 0)
+    static const QString BUSY_MSG = "GetCurrTasks: " + sysManBusyMsg;
+    if (error.compare(BUSY_MSG) == 0)
       errorMsg = tr("--- System Manager is busy ---");
     else
       errorMsg = tr("--- Unable to contact System Manager ---");

--- a/earth_enterprise/src/fusion/fusionui/SystemManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/SystemManager.cpp
@@ -147,14 +147,19 @@ SystemManager::updateTasks(void)
   QString error;
   TaskLists taskLists;
   if (!khAssetManagerProxy::GetCurrTasks("dummy", taskLists, error)) {
+    QString errorMsg;
+    if (error.compare("GetCurrTasks: ERROR: Timed out waiting for lock") == 0)
+      errorMsg = tr("--- System Manager is busy ---");
+    else
+      errorMsg = tr("--- Unable to contact System Manager ---");
+    
     // Can't get TaskList...
     // clean top panes and display message about
     // being unable to connect to asset manager
     waitingList->clear();
     activeList->clear();
-    (void) new WaitingItem(waitingList,
-                           tr("--- Unable to contact System Manager ---"));
-    activeList->insertItem(tr("--- Unable to contact System Manager ---"));
+    (void) new WaitingItem(waitingList, errorMsg);
+    activeList->insertItem(errorMsg);
 
   } else {
     // Waiting list


### PR DESCRIPTION
Fixes #1194. Adds a new timed wait mutex wrapper which will only block on mutex acquisition for a specified amount of time before giving up.

Verification steps:

1. Build and run unit tests (`perl src/NATIVE-REL-x86_64/bin/tests/RunAllTests.pl`).  Verify they all pass (`khThread_unittest` is the new test) 
1. Build and install opengee-common and opengee-fusion
1. Create a large project which will cause System Manager to spend several minutes planning out how it will be built
1. Open the "System Manager" fusion UI dialog and leave it open
1. Open a terminal window and run `getop --delay 1`
1. Command a build (or rebuild) of the large project
1. While System Manager is planning the build, verify both getop and System Manager dialog update to communicate that System Manager is busy.  They should update approximately every 30 seconds.
1. Once System Manager planning is done, edit `/gevol/assets/.config/misc.xml` to add the line `<MutexTimedWaitSec>5</MutexTimedWaitSec>`.  Save the file and then restart gefusion.
1. With getop and System Manager dialog still running execute `geclean <Project>`
1. Verify that getop and System Manager dialog again indicate System Manager is busy and update approximately every 5 seconds.
1. Execute a new command `getop --delay 1 --timeout 1` while System Manager is still planning
1. Execute `sudo lsof | grep CLOSE | wc -l` repeatedly and ensure the returned number remains < 5.