### PR TITLE
Updated release notes to include undocumented updates including 5.2.5.1 changes

### DIFF
--- a/docs/geedocs/5.3.0/answer/176738.html
+++ b/docs/geedocs/5.3.0/answer/176738.html
@@ -281,6 +281,12 @@ PURGE=0
 # default is 3
 PURGE_LEVEL=3
 </code>
+<h2 id="status_request_timeout">Status request timeout</h2>
+<p>Status requests to the system manager from clients like <code>getop</code> must wait to be fulfilled if the system manager
+   is already engaged in another task. The system manager has a timeout that specifies the maximum amount of time it should
+   spend waiting to fulfill a status request before it times out. This timeout can be configured manually by setting
+   <code>MutexTimedWaitSec</code> in <code>/gevol/assets/.config/misc.xml</code></p>
+<code>&lt;MutexTimedWaitSec&gt;60&lt;/MutexTimedWaitSec&gt;</code>
 <h2>Learn more</h2>
 <ul>
 <li><a href="../answer/6033487.html">Benchmarking outcomes for applying task rules</a></li>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -44,7 +44,7 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5.3.0">New Features</p>
   </h5>
-    <p><strong>Added the ability to control the XML cache size . </strong>
+    <p><strong>Added the ability to control the XML cache size. </strong>
       The size can be modified by configuring the <code>INIT_HEAP_SIZE</code>, <code>MAX_HEAP_SIZE</code>, and <code>BLOCK_SIZE</code> settings in
     <code>/etc/opt/google/XMLparams</code>. This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
     <p><strong>Users can now force the XML cache to purge periodically. </strong>
@@ -120,7 +120,7 @@ gtag('config', 'UA-108632131-2');
           <tr>
             <td>1194</td>
             <td>Sockets build up during large project builds</td>
-            <td>The Fusion UI and <code>getop</code> will now timeout when attempting to communicate with System Manager in order to avoid keeping sockets open indefinitely. The timeout is configurable.</td>
+            <td>gesystemmanager now has a timeout when trying to respond to a request for status. This prevents a backlog of requests that could build up while it is busy handling a long-running request. The timeout is configurable.</td>
           </tr>
         </tbody>
       </table>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -44,7 +44,13 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5.3.0">New Features</p>
   </h5>
-    <p><strong>Example feature</strong> replace with real feature description.</p>
+    <p><strong>Added the ability to control the XML cache size . </strong>
+      The size can be modified by configuring the <code>INIT_HEAP_SIZE</code>, <code>MAX_HEAP_SIZE</code>, and <code>BLOCK_SIZE</code> settings in
+    <code>/etc/opt/google/XMLparams</code>. This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
+    <p><strong>Users can now force the XML cache to purge periodically. </strong>
+      This can be done by configuring the <code>PURGE</code> and <code>PURGE_LEVEL</code> settings in <code>/etc/opt/google/XMLparams</code>. 
+      This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
+    <p><strong>Added a <code>long_version</code> parameter to the SCons build. </strong>This will allow the user to override the long version string.</p>
   <h5>
     <p id="supported_5.3.0">Supported Platforms</p>
   </h5>
@@ -110,6 +116,11 @@ gtag('config', 'UA-108632131-2');
             <td>
               Help has been added through the <code>--help</code> option, or if any invalid parameter is given
             </td>
+          </tr>
+          <tr>
+            <td>1194</td>
+            <td>Sockets build up during large project builds</td>
+            <td>The Fusion UI and <code>getop</code> will now timeout when attempting to communicate with System Manager in order to avoid keeping sockets open indefinitely. The timeout is configurable.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Included so far are:
- Controlling the XML cache size
- XML cache purging
- The addition of the `long_version` parameter to the SCons build command
- The fix for the socket build-up issue (#1194)