### PR TITLE
171 adv params geserver installer

### DIFF
--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -446,29 +446,22 @@ get_default_group()
 # directory, size, available, and mount point
 get_volume_info()
 {
-	local DF_K
-	local SIZE
-	local AVAIL
-	local MP
+	local info=()
 	local DIR=$1
 
 	# Check if dir exists.  If so, do a df at this point
 	while true; do
 		if [ -d "$DIR" ] ; then
-			DF_K=$(df -k $DIR | tail -1)
+			info=($1 $(df -k $DIR --output=size,avail,target | tail -1))
 			break
 		fi
 
 		#Drop last part of path retry
 		DIR=${DIR%/*}
 		if [ -z $DIR ]; then
-			DF_K=$(df -k / | tail -1)
+			info=($1 $(df -k / --output=size,avail,target | tail -1))
 			break
 		fi
 	done
-	SIZE=$(echo $DF_K | awk '{print $2}')
-	AVAIL=$(echo $DF_K | awk '{print $4}')
-	MP=$(echo $DF_K | awk '{print $6}')
-	local info=( $1 $SIZE $AVAIL $MP )
 	echo "${info[@]}"
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -427,7 +427,7 @@ get_default_user()
 {
 	# $1 -- is file/directory from which to obtain user
 	# $2 -- user to return if file/directory does not exist (or unable to stat file)
-	local USER=`stat --printf="%U" $1 2> /dev/null`
+	local USER=$(stat --printf="%U" $1 2> /dev/null)
 	[ -z "$USER" ] && USER=$2
 	echo "$USER"
 }
@@ -437,7 +437,38 @@ get_default_group()
 {
 	# $1 -- is file/directory from which to obtain group
 	# $2 -- group to return if file/directory does not exist (or unable to stat file)
-	local GRP=`stat --printf="%G" $1 2> /dev/null`
+	local GRP=$(stat --printf="%G" $1 2> /dev/null)
 	[ -z "$GRP" ] && GRP=$2
 	echo "$GRP"
+}
+
+# For given absolute directory (must start with /) array containing
+# directory, size, available, and mount point
+get_volume_info()
+{
+	local DF_K
+	local SIZE
+	local AVAIL
+	local MP
+	local DIR=$1
+
+	# Check if dir exists.  If so, do a df at this point
+	while true; do
+		if [ -d "$DIR" ] ; then
+			DF_K=$(df -k $DIR | tail -1)
+			break
+		fi
+
+		#Drop last part of path retry
+		DIR=${DIR%/*}
+		if [ -z $DIR ]; then
+			DF_K=$(df -k / | tail -1)
+			break
+		fi
+	done
+	SIZE=$(echo $DF_K | awk '{print $2}')
+	AVAIL=$(echo $DF_K | awk '{print $4}')
+	MP=$(echo $DF_K | awk '{print $6}')
+	local info=( $1 $SIZE $AVAIL $MP )
+	echo "${info[@]}"
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -110,7 +110,7 @@ software_check()
         if [ "$MACHINE_OS" == "$UBUNTUKEY" ] && [ ! -z "$2" ]; then
             echo -e "\nInstall $2 and restart the $1."
             software_check_retval=1
-        elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then 
+        elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then
             echo -e "\nInstall $3 and restart the $1."
             software_check_retval=1
         else
@@ -420,4 +420,24 @@ prompt_to_quit()
     fi
 
     return $prompt_to_quit_retval
+}
+
+# Returns the default user
+get_default_user()
+{
+	# $1 -- is file/directory from which to obtain user
+	# $2 -- user to return if file/directory does not exist (or unable to stat file)
+	local USER=`stat --printf="%U" $1 2> /dev/null`
+	[ -z "$USER" ] && USER=$2
+	echo "$USER"
+}
+
+# Returns the default group
+get_default_group()
+{
+	# $1 -- is file/directory from which to obtain group
+	# $2 -- group to return if file/directory does not exist (or unable to stat file)
+	local GRP=`stat --printf="%G" $1 2> /dev/null`
+	[ -z "$GRP" ] && GRP=$2
+	echo "$GRP"
 }

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -442,8 +442,7 @@ get_default_group()
 	echo "$GRP"
 }
 
-# For given absolute directory (must start with /) array containing
-# directory, size, available, and mount point
+# For given directory, array containing directory, size, available, and mount point
 get_volume_info()
 {
 	local info=()
@@ -456,8 +455,9 @@ get_volume_info()
 			break
 		fi
 
-		#Drop last part of path retry
+		# Drop last part of path and retry
 		DIR=${DIR%/*}
+		# Check if reached the root
 		if [ -z $DIR ]; then
 			info=($1 $(df -k / --output=size,avail,target | tail -1))
 			break

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -53,150 +53,160 @@ PRODUCT_NAME="$GEE"
 START_SERVER_DAEMON=1
 PROMPT_FOR_START="n"
 
+# addition variables
+IS_NEWINSTALL=false
+
 #-----------------------------------------------------------------
 # Main Functions
 #-----------------------------------------------------------------
 main_preinstall()
 {
-  # 3) Introduction
-  show_intro
+	# 3) Introduction
+	show_intro
 
-  # 2) Root/Sudo check
-  if [ "$EUID" != "0" ]; then
-    show_need_root
-    exit 1
-  fi
+	# 2) Root/Sudo check
+	if [ "$EUID" != "0" ]; then
+		show_need_root
+		exit 1
+	fi
 
-  # Argument check
-  if ! parse_arguments "$@"; then
-    exit 1
-  fi
+	if [ -f "$GESERVERBININSTALL" ]; then
+		IS_NEWINSTALL=false
+	else
+		IS_NEWINSTALL=true
+		BACKUPSERVER=false
+	fi
 
-  if ! determine_os; then
-    exit 1
-  fi
+	# Argument check
+	if ! parse_arguments "$@"; then
+		exit 1
+	fi
 
-  if is_package_installed "opengee-common" "opengee-common"; then
-    show_opengee_package_installed "install" "$GEES"
-    exit 1
-  fi
+	if ! determine_os; then
+		exit 1
+	fi
 
-  # 7) Check prerequisite software
-  if ! check_prereq_software; then
-    exit 1
-  fi
+	if is_package_installed "opengee-common" "opengee-common"; then
+		show_opengee_package_installed "install" "$GEES"
+		exit 1
+	fi
 
-  # check to see if GE Server processes are running
-  if check_server_processes_running; then
-    show_server_running_message
-    exit 1
-  fi
+	# 7) Check prerequisite software
+	if ! check_prereq_software; then
+		exit 1
+	fi
 
-  # tmp dir check
-  if [ ! -d "$TMPINSTALLDIR" ]; then
-    show_no_tmp_dir_message $TMPINSTALLDIR
-    exit 1
-  fi
+	# check to see if GE Server processes are running
+	if check_server_processes_running; then
+		show_server_running_message
+		exit 1
+	fi
 
-  # 64 bit check
-  if [[ "$(uname -i)" != "x86_64" ]]; then
-    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
-    exit 1
-  fi
+	# tmp dir check
+	if [ ! -d "$TMPINSTALLDIR" ]; then
+		show_no_tmp_dir_message $TMPINSTALLDIR
+		exit 1
+	fi
+
+	# 64 bit check
+	if [[ "$(uname -i)" != "x86_64" ]]; then
+		echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
+		exit 1
+	fi
 
 	if ! prompt_install_confirmation; then
 		exit 1
 	fi
 
-  # 5b) Perform backup
-  if [ "$BACKUPSERVER" = true ]; then
-    # Backing up current Server Install...
-    backup_server
-  fi
+	# 5b) Perform backup
+	if [ "$BACKUPSERVER" = true ]; then
+		# Backing up current Server Install...
+		backup_server
+	fi
 
-  # Backup PGSQL data
-  if [ -d "$PGSQL_DATA" ]; then
-    backup_pgsql_data
-  fi
+	# Backup PGSQL data
+	if [ -d "$PGSQL_DATA" ]; then
+		backup_pgsql_data
+	fi
 
-  # 6) Check valid host properties
-  if ! check_bad_hostname; then
-    exit 1
-  fi
+	# 6) Check valid host properties
+	if ! check_bad_hostname; then
+		exit 1
+	fi
 
-  if ! check_mismatched_hostname; then
-    exit 1
-  fi
+	if ! check_mismatched_hostname; then
+		exit 1
+	fi
 
-  # 8) Check if group and users exist
-  check_group
+	# 8) Check if group and users exist
+	check_group
 
-  check_username "$GEAPACHEUSER_NAME"
-  check_username "$GEPGUSER_NAME"
+	check_username "$GEAPACHEUSER_NAME"
+	check_username "$GEPGUSER_NAME"
 
-  # 10) Configure Publish Root
-  configure_publish_root
+	# 10) Configure Publish Root
+	configure_publish_root
 }
 
 check_prereq_software()
 {
-  local check_prereq_software_retval=0
-  local script_name="$GEES $LONG_VERSION installer"
+	local check_prereq_software_retval=0
+	local script_name="$GEES $LONG_VERSION installer"
 
-  if ! software_check "$script_name" "libxml2-utils" "libxml2.*x86_64"; then
-    check_prereq_software_retval=1
-  fi
+	if ! software_check "$script_name" "libxml2-utils" "libxml2.*x86_64"; then
+		check_prereq_software_retval=1
+	fi
 
-  if ! software_check "$script_name" "python2.[67]" "python-2.[67].*"; then
-    check_prereq_software_retval=1
-  fi
+	if ! software_check "$script_name" "python2.[67]" "python-2.[67].*"; then
+		check_prereq_software_retval=1
+	fi
 
-  return $check_prereq_software_retval
+	return $check_prereq_software_retval
 }
 
 main_install()
 {
-  copy_files_to_target
-  create_links
+	copy_files_to_target
+	create_links
 }
 
 main_postinstall()
 {
-  # 1) Modify files
-  modify_files
+	# 1) Modify files
+	modify_files
 
-  # 2) Set Permissions Before Server Start/Stop
-  fix_postinstall_filepermissions
+	# 2) Set Permissions Before Server Start/Stop
+	fix_postinstall_filepermissions
 
-  # 3) PostGres DB config
-  postgres_db_config
+	# 3) PostGres DB config
+	postgres_db_config
 
-  # 4) Creating Daemon thread for geserver
-  setup_geserver_daemon
+	# 4) Creating Daemon thread for geserver
+	setup_geserver_daemon
 
-  # 5) Add the server to services
-  # For RedHat and SuSE
-  test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
+	# 5) Add the server to services
+	# For RedHat and SuSE
+	test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
 
-  # 6) Register publish root
-  "$BASEINSTALLDIR_OPT/bin/geconfigurepublishroot" --noprompt --path="$PUBLISHER_ROOT"
+	# 6) Register publish root
+	"$BASEINSTALLDIR_OPT/bin/geconfigurepublishroot" --noprompt --path="$PUBLISHER_ROOT"
 
-  # 7) Install the GEPlaces and SearchExample Databases
-  install_search_databases
+	# 7) Install the GEPlaces and SearchExample Databases
+	install_search_databases
 
-  # 8) Set permissions after geserver Start/Stop.
-  fix_postinstall_filepermissions
+	# 8) Set permissions after geserver Start/Stop.
+	fix_postinstall_filepermissions
 
-  # TODO - verify
-  # 9) Run geecheck config script
-  # If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
-  if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
-    cd "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin"
-    python ./set_geecheck_config.py
-  fi
+	# TODO - verify
+	# 9) Run geecheck config script
+	# If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
+	if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
+		cd "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin"
+		python ./set_geecheck_config.py
+	fi
 
-  # 10)
-  show_final_success_message
+	# 10)
+	show_final_success_message
 }
 
 #-----------------------------------------------------------------
@@ -205,100 +215,121 @@ main_postinstall()
 
 show_intro()
 {
-  echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
+	echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
 }
 
 # TODO: Add additional parameters for GEE Server
 show_help()
 {
-  echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf]\n"
+	echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf]\n"
 
-  echo -e "-h --help \tHelp - display this help screen"
-  echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
-  echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
-  echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
+	echo -e "-h --help \tHelp - display this help screen"
+	echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
+	echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
+	echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
+	echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tthe setup before installing."
 }
 
 # TODO convert to common function
 show_need_root()
 {
-  echo -e "\nYou must have root privileges to install $GEES.\n"
-  echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
-  echo -e "The installer must exit."
+	echo -e "\nYou must have root privileges to install $GEES.\n"
+	echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
+	echo -e "The installer must exit."
 }
 
 # TODO Add additional parameters for server
 parse_arguments()
 {
-  local parse_arguments_retval=0
+	local parse_arguments_retval=0
 
-  while [ $# -gt 0 ]
-  do
-    case "${1,,}" in
-      -h|-help|--help)
-        show_help
-        parse_arguments_retval=1
-        break
-        ;;
-      -hnf)
-        BADHOSTNAMEOVERRIDE=true;
-        ;;
-      -hnmf)
-        MISMATCHHOSTNAMEOVERRIDE=true
-        ;;
-      -dir)
-        shift
-        if [ -d "$1" ]; then
-          TMPINSTALLDIR="$1"
-        else
-          show_no_tmp_dir_message "$1"
-          parse_arguments_retval=-1
+	while [ $# -gt 0 ]
+	do
+		case "${1,,}" in
+			-h|-help|--help)
+				show_help
+				parse_arguments_retval=1
+				break
+				;;
+			-nobk)
+				BACKUPSERVER=false
+				;;
+			-hnf)
+				BADHOSTNAMEOVERRIDE=true;
+				;;
+			-hnmf)
+				MISMATCHHOSTNAMEOVERRIDE=true
+				;;
+			-dir)
+				shift
+				if [ -d "$1" ]; then
+					TMPINSTALLDIR="$1"
+				else
+					show_no_tmp_dir_message "$1"
+					parse_arguments_retval=-1
+					break
+				fi
+				;;
+      -pgu)
+        if [ $IS_NEWINSTALL == false ]; then
+					echo -e "\nYou cannot modify the postgres user name using the installer because $GEES is already installed on this server."
+					parse_arguments_retval=1
           break
+        else
+          shift
+          if is_valid_alphanumeric ${1// }; then
+            GEPGUSER_NAME=${1// }
+          else
+            echo -e "\nThe fusion user name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
         fi
         ;;
-      *)
-        echo -e "\nArgument Error: $1 is not a valid argument."
-        show_help
-        parse_arguments_retval=1
-        break
-        ;;
-    esac
+			*)
+				echo -e "\nArgument Error: $1 is not a valid argument."
+				show_help
+				parse_arguments_retval=1
+				break
+				;;
+		esac
 
-    if [ $# -gt 0 ]
-    then
-      shift
-    fi
-  done
+		if [ $# -gt 0 ]
+		then
+			shift
+		fi
+	done
 
-  return $parse_arguments_retval;
+	return $parse_arguments_retval;
 }
 
 show_server_running_message()
 {
-  echo -e "\n$GEES has active running processes."
-  echo -e "To use this installer to upgrade, you must stop all geserver services.\n"
+	echo -e "\n$GEES has active running processes."
+	echo -e "To use this installer to upgrade, you must stop all geserver services.\n"
 }
 
 configure_publish_root()
 {
-  # Update PUBLISHER_ROOT if geserver already installed
-  local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
-  if [ -e "$STREAM_SPACE" ]; then
-    PUBLISHER_ROOT=`cat $STREAM_SPACE | cut -d" " -f3 | sed 's/.\{13\}$//'`
-  fi
+	# Update PUBLISHER_ROOT if geserver already installed
+	local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
+	if [ -e "$STREAM_SPACE" ]; then
+		PUBLISHER_ROOT=`cat $STREAM_SPACE | cut -d" " -f3 | sed 's/.\{13\}$//'`
+	fi
 }
 
 backup_pgsql_data()
 {
-  # Make the temporary data backup directory
-  mkdir -p "$BACKUP_DATA_DIR"
-  chown "$GEPGUSER_NAME" "$BACKUP_DATA_DIR"
+	# Make the temporary data backup directory
+	mkdir -p "$BACKUP_DATA_DIR"
+	chown "$GEPGUSER_NAME" "$BACKUP_DATA_DIR"
 
-  # Dump PGSQL data
-  RESET_DB_SCRIPT=$TMPINSTALLDIR/server/opt/google/bin/geresetpgdb
+	# Dump PGSQL data
+	RESET_DB_SCRIPT=$TMPINSTALLDIR/server/opt/google/bin/geresetpgdb
 
-  echo 2 | run_as_user "$GEPGUSER_NAME" \
-    "$(printf '%q' "$RESET_DB_SCRIPT") backup $(printf '%q' "$BACKUP_DATA_DIR")"
+	echo 2 | run_as_user "$GEPGUSER_NAME" \
+		"$(printf '%q' "$RESET_DB_SCRIPT") backup $(printf '%q' "$BACKUP_DATA_DIR")"
 }
 
 #-----------------------------------------------------------------
@@ -306,112 +337,112 @@ backup_pgsql_data()
 #-----------------------------------------------------------------
 copy_files_to_target()
 {
-  printf "\nCopying files from source to target directories..."
+	printf "\nCopying files from source to target directories..."
 
-  mkdir -p "$BASEINSTALLDIR_OPT/share/doc"
-  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
-  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
-  mkdir -p "$BASEINSTALLDIR_OPT/search"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
-  mkdir -p "$BASEINSTALLDIR_ETC/openldap"
-  mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
+	mkdir -p "$BASEINSTALLDIR_OPT/share/doc"
+	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
+	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
+	mkdir -p "$BASEINSTALLDIR_OPT/search"
+	mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
+	mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
+	mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
+	mkdir -p "$BASEINSTALLDIR_ETC/openldap"
+	mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
 
-  local error_on_copy=0
-  cp -rf "$TMPINSTALLDIR/common/opt/google/bin" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/common/opt/google/share" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/common/opt/google/qt" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/common/opt/google/qt/lib" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/common/opt/google/lib" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/common/opt/google/gepython" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/postgis/opt/google/share" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/postgis/opt/google/bin" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/postgis/opt/google/lib" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/share" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/bin" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/searchexample/opt/google/share" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/geplaces/opt/google/share" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/AppacheSupport/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
+	local error_on_copy=0
+	cp -rf "$TMPINSTALLDIR/common/opt/google/bin" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/common/opt/google/share" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/common/opt/google/qt" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/common/opt/google/qt/lib" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/common/opt/google/lib" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/common/opt/google/gepython" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/postgis/opt/google/share" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/postgis/opt/google/bin" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/postgis/opt/google/lib" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/share" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/bin" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/searchexample/opt/google/share" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/geplaces/opt/google/share" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/AppacheSupport/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-  cp -rf "$TMPINSTALLDIR/server/etc/init.d/geserver" "$BININSTALLROOTDIR"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.sh" "$BININSTALLPROFILEDIR"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.csh" "$BININSTALLPROFILEDIR"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/etc/init.d/geserver" "$BININSTALLROOTDIR"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.sh" "$BININSTALLPROFILEDIR"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.csh" "$BININSTALLPROFILEDIR"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-  cp -rf "$TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd" "$BASEINSTALLLOGROTATEDIR"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/" "$BASEINSTALLDIR_VAR/pgsql"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/manual/opt/google/share/doc/manual" "$BASEINSTALLDIR_OPT/share/doc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd" "$BASEINSTALLLOGROTATEDIR"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/" "$BASEINSTALLDIR_VAR/pgsql"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/manual/opt/google/share/doc/manual" "$BASEINSTALLDIR_OPT/share/doc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-  TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
 
-  cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/CA.sh" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_name" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_issuer" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_info" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_hash" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/CA.sh" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/c_name" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/c_issuer" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/c_info" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENSSLPATH/misc/c_hash" "$BASEINSTALLDIR_VAR/openssl/misc"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-  TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
+	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
 
-  cp -f "$TMPOPENLDAPPATH/ldap.conf" "$BASEINSTALLDIR_ETC/openldap"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENLDAPPATH/ldap.conf.default" "$BASEINSTALLDIR_ETC/openldap"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENLDAPPATH/ldap.conf" "$BASEINSTALLDIR_ETC/openldap"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f "$TMPOPENLDAPPATH/ldap.conf.default" "$BASEINSTALLDIR_ETC/openldap"
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-  # TODO: final step: copy uninstall script
-  # cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
+	# TODO: final step: copy uninstall script
+	# cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
 
-  if [ "$error_on_copy" -ne 0 ]
-  then
-    show_corrupt_tmp_dir_message "$TMPINSTALLDIR" "$INSTALL_LOG"
-    exit 1
-  fi
+	if [ "$error_on_copy" -ne 0 ]
+	then
+		show_corrupt_tmp_dir_message "$TMPINSTALLDIR" "$INSTALL_LOG"
+		exit 1
+	fi
 
-  printf "DONE\n"
+	printf "DONE\n"
 }
 
 #-----------------------------------------------------------------
@@ -420,219 +451,220 @@ copy_files_to_target()
 
 postgres_db_config()
 {
-  # a) PostGres folders and configuration
-  chmod -R 700 /var/opt/google/pgsql/
-  chown -R "$GEPGUSER_NAME:$GRPNAME" /var/opt/google/pgsql/
-  reset_pgdb
+	# a) PostGres folders and configuration
+	chmod -R 700 /var/opt/google/pgsql/
+	chown -R "$GEPGUSER_NAME:$GRPNAME" /var/opt/google/pgsql/
+	reset_pgdb
 }
 
 reset_pgdb()
 {
-  # TODO check if correct
-  # a) Always do an upgrade of the psql db
-  echo 2 | run_as_user "$GEPGUSER_NAME" "/opt/google/bin/geresetpgdb upgrade $(printf '%q' "$BACKUP_DATA_DIR")"
-  echo -e "upgrade done"
+	# TODO check if correct
+	# a) Always do an upgrade of the psql db
+	echo 2 | run_as_user "$GEPGUSER_NAME" "/opt/google/bin/geresetpgdb upgrade $(printf '%q' "$BACKUP_DATA_DIR")"
+	echo -e "upgrade done"
 
-  # b) Check for Success of PostGresDb
-  #  If file ‘/var/opt/google/pgsql/data’ doesn’t exist:
+	# b) Check for Success of PostGresDb
+	#  If file ‘/var/opt/google/pgsql/data’ doesn’t exist:
 
-  echo "pgsql_data"
-  echo "$PGSQL_DATA"
-  if [ -d "$PGSQL_DATA" ]; then
-    # PostgreSQL install Success.
-    echo -e "The PostgreSQL component is successfully installed."
-  else
-    # postgress reset/install failed.
-    echo -e "Failed to create PostGresDb."
-    echo -e "The PostgreSQL component of the installation failed
-         to install."
-  fi
+	echo "pgsql_data"
+	echo "$PGSQL_DATA"
+	if [ -d "$PGSQL_DATA" ]; then
+		# PostgreSQL install Success.
+		echo -e "The PostgreSQL component is successfully installed."
+	else
+		# postgress reset/install failed.
+		echo -e "Failed to create PostGresDb."
+		echo -e "The PostgreSQL component of the installation failed
+				 to install."
+	fi
 }
 
 # 4) Creating Daemon thread for geserver
 setup_geserver_daemon()
 {
-  # setup geserver daemon
-  # For Ubuntu
-  printf "Setting up the geserver daemon...\n"
-  test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
-  test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" -f geserver remove
-  test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" geserver start 90 2 3 4 5 . stop 10 0 1 6 .
-  printf "GEE Server daemon setup ... DONE\n"
+	# setup geserver daemon
+	# For Ubuntu
+	printf "Setting up the geserver daemon...\n"
+	test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
+	test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" -f geserver remove
+	test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" geserver start 90 2 3 4 5 . stop 10 0 1 6 .
+	printf "GEE Server daemon setup ... DONE\n"
 }
 
 # 6) Install the GEPlaces and SearchExample Databases
 install_search_databases()
 {
-  # a) Start the PSQL Server
-  echo "# a) Start the PSQL Server "
-  run_as_user "$GEPGUSER_NAME" "$(printf '%q' "$PGSQL_PROGRAM") -D $(printf '%q' "$PGSQL_DATA") -l $(printf '%q' "$PGSQL_LOGS/pg.log") start -w"
+	# a) Start the PSQL Server
+	echo "# a) Start the PSQL Server "
+	run_as_user "$GEPGUSER_NAME" "$(printf '%q' "$PGSQL_PROGRAM") -D $(printf '%q' "$PGSQL_DATA") -l $(printf '%q' "$PGSQL_LOGS/pg.log") start -w"
 
-  echo "# b) Install GEPlaces Database"
-  # b) Install GEPlaces Database
-  run_as_user "$GEPGUSER_NAME" "/opt/google/share/geplaces/geplaces create"
+	echo "# b) Install GEPlaces Database"
+	# b) Install GEPlaces Database
+	run_as_user "$GEPGUSER_NAME" "/opt/google/share/geplaces/geplaces create"
 
-  echo "# c) Install SearchExample Database "
-  # c) Install SearchExample Database
-  run_as_user "$GEPGUSER_NAME" "/opt/google/share/searchexample/searchexample create"
+	echo "# c) Install SearchExample Database "
+	# c) Install SearchExample Database
+	run_as_user "$GEPGUSER_NAME" "/opt/google/share/searchexample/searchexample create"
 
-  # d) Stop the PSQL Server
-  echo "# d) Stop the PSQL Server"
-  run_as_user "$GEPGUSER_NAME" "$PGSQL_PROGRAM -D $PGSQL_DATA stop"
+	# d) Stop the PSQL Server
+	echo "# d) Stop the PSQL Server"
+	run_as_user "$GEPGUSER_NAME" "$PGSQL_PROGRAM -D $PGSQL_DATA stop"
 }
 
 modify_files()
 {
-  # Replace IA users in a file if they are found.
-  # this step not requied for the OSS installs, however
-  # if there are non-OSS installs in the system, it might help cleanup those.
+	# Replace IA users in a file if they are found.
+	# this step not requied for the OSS installs, however
+	# if there are non-OSS installs in the system, it might help cleanup those.
 
-  # a) Search and replace the below variables in /etc/init.d/geserver.
-  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" "$BININSTALLROOTDIR/geserver"
-  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" "$BININSTALLROOTDIR/geserver"
+	# a) Search and replace the below variables in /etc/init.d/geserver.
+	sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" "$BININSTALLROOTDIR/geserver"
+	sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" "$BININSTALLROOTDIR/geserver"
 
-  # b) Search and replace the file ‘/opt/google/gehttpd/conf/gehttpd.conf’
-  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
-  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
-  sed -i "s/IA_GEGROUP/$GRPNAME/" /opt/google/gehttpd/conf/gehttpd.conf
+	# b) Search and replace the file ‘/opt/google/gehttpd/conf/gehttpd.conf’
+	sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+	sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+	sed -i "s/IA_GEGROUP/$GRPNAME/" /opt/google/gehttpd/conf/gehttpd.conf
 
-  # c) Create a new file ‘/etc/opt/google/fusion_server_version’ and
-  # add the below text to it.
-  echo "$LONG_VERSION" > /etc/opt/google/fusion_server_version
+	# c) Create a new file ‘/etc/opt/google/fusion_server_version’ and
+	# add the below text to it.
+	echo "$LONG_VERSION" > /etc/opt/google/fusion_server_version
 
-  # d) Create a new file ‘/etc/init.d/gevars.sh’ and prepend the below lines.
-  echo -e "GEAPACHEUSER=$GEAPACHEUSER_NAME\nGEPGUSER=$GEPGUSER_NAME\nGEFUSIONUSER=$GEFUSIONUSER_NAME\nGEGROUP=$GRPNAME" > $BININSTALLROOTDIR/gevars.sh
+	# d) Create a new file ‘/etc/init.d/gevars.sh’ and prepend the below lines.
+	echo -e "GEAPACHEUSER=$GEAPACHEUSER_NAME\nGEPGUSER=$GEPGUSER_NAME\nGEFUSIONUSER=$GEFUSIONUSER_NAME\nGEGROUP=$GRPNAME" > $BININSTALLROOTDIR/gevars.sh
 }
 
 fix_postinstall_filepermissions()
 {
-  # PostGres
-  chown -R "$GEPGUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_VAR/pgsql/"
+	# PostGres
+	chown -R "$GEPGUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_VAR/pgsql/"
 
-  # Apache
-  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime"
-  chmod -R 755 "$BASEINSTALLDIR_OPT/gehttpd"
-  chmod -R 775 "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/"
-  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/"
-  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/"
-  chmod -R 700 "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/"
-  chown "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess"
-  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/logs"
+	# Apache
+	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime"
+	chmod -R 755 "$BASEINSTALLDIR_OPT/gehttpd"
+	chmod -R 775 "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/"
+	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/"
+	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/"
+	chmod -R 700 "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/"
+	chown "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess"
+	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/logs"
 
-  # Publish Root
-  chmod 775 "$PUBLISHER_ROOT/stream_space"
-  # TODO - Not Found
-  # chmod 644 $PUBLISHER_ROOT/stream_space/.config
-  chmod 644 "$PUBLISHER_ROOT/.config"
-  chmod 755 "$PUBLISHER_ROOT"
-  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/stream_space"
-  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/search_space"
+	# Publish Root
+	chmod 775 "$PUBLISHER_ROOT/stream_space"
+	# TODO - Not Found
+	# chmod 644 $PUBLISHER_ROOT/stream_space/.config
+	chmod 644 "$PUBLISHER_ROOT/.config"
+	chmod 755 "$PUBLISHER_ROOT"
+	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/stream_space"
+	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/search_space"
 
-  # Etc
-  chmod 755 /etc/opt/google/
-  chmod 755 "$BASEINSTALLDIR_OPT/etc/"
-  chmod 755 "$BININSTALLROOTDIR/gevars.sh"
-  chmod 755 "$BININSTALLROOTDIR/geserver"
+	# Etc
+	chmod 755 /etc/opt/google/
+	chmod 755 "$BASEINSTALLDIR_OPT/etc/"
+	chmod 755 "$BININSTALLROOTDIR/gevars.sh"
+	chmod 755 "$BININSTALLROOTDIR/geserver"
 
-  # Run
-  chmod 775 "$BASEINSTALLDIR_OPT/run/"
-  chmod 775 "$BASEINSTALLDIR_VAR/run/"
-  chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/run/"
-  chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/run/"
+	# Run
+	chmod 775 "$BASEINSTALLDIR_OPT/run/"
+	chmod 775 "$BASEINSTALLDIR_VAR/run/"
+	chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/run/"
+	chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/run/"
 
-  # Logs
-  chmod 775 "$BASEINSTALLDIR_VAR/log/"
-  chmod 775 "$BASEINSTALLDIR_OPT/log/"
-  chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/log"
-  chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/log"
+	# Logs
+	chmod 775 "$BASEINSTALLDIR_VAR/log/"
+	chmod 775 "$BASEINSTALLDIR_OPT/log/"
+	chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/log"
+	chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/log"
 
-  # Other folders
-  chmod 755 "$BASEINSTALLDIR_OPT"
-  chmod 755 "$BASEINSTALLDIR_VAR"
-  chmod -R 755 /opt/google/lib/
-  chmod -R 555 /opt/google/bin/
-  chmod 755 /opt/google/bin
-  chmod +s /opt/google/bin/gerestartapache /opt/google/bin/geresetpgdb /opt/google/bin/geserveradmin
-  chmod -R 755 /opt/google/qt/
-  # TODO: there is not such directory
-  # chmod 755 /etc/opt/google/installed_products/
-  chmod 755 /etc/opt/google/openldap/
+	# Other folders
+	chmod 755 "$BASEINSTALLDIR_OPT"
+	chmod 755 "$BASEINSTALLDIR_VAR"
+	chmod -R 755 /opt/google/lib/
+	chmod -R 555 /opt/google/bin/
+	chmod 755 /opt/google/bin
+	chmod +s /opt/google/bin/gerestartapache /opt/google/bin/geresetpgdb /opt/google/bin/geserveradmin
+	chmod -R 755 /opt/google/qt/
+	# TODO: there is not such directory
+	# chmod 755 /etc/opt/google/installed_products/
+	chmod 755 /etc/opt/google/openldap/
 
-  # Tutorial and Share
-  find /opt/google/share -type d -exec chmod 755 {} \;
-  find /opt/google/share -type f -exec chmod 644 {} \;
-  chmod ugo+x /opt/google/share/searchexample/searchexample
-  chmod ugo+x /opt/google/share/geplaces/geplaces
-  chmod ugo+x /opt/google/share/support/geecheck/geecheck.pl
-  chmod ugo+x /opt/google/share/support/geecheck/convert_to_kml.pl
-  chmod ugo+x /opt/google/share/support/geecheck/find_terrain_pixel.pl
-  chmod ugo+x /opt/google/share/support/geecheck/pg_check.pl
-  # Note: this is installed in install_fusion.sh, but needs setting here too.
-  chmod ugo+x "$BASEINSTALLDIR_OPT/share/tutorials/fusion/download_tutorial.sh"
-  chown -R root:root /opt/google/share
+	# Tutorial and Share
+	find /opt/google/share -type d -exec chmod 755 {} \;
+	find /opt/google/share -type f -exec chmod 644 {} \;
+	chmod ugo+x /opt/google/share/searchexample/searchexample
+	chmod ugo+x /opt/google/share/geplaces/geplaces
+	chmod ugo+x /opt/google/share/support/geecheck/geecheck.pl
+	chmod ugo+x /opt/google/share/support/geecheck/convert_to_kml.pl
+	chmod ugo+x /opt/google/share/support/geecheck/find_terrain_pixel.pl
+	chmod ugo+x /opt/google/share/support/geecheck/pg_check.pl
+	# Note: this is installed in install_fusion.sh, but needs setting here too.
+	chmod ugo+x "$BASEINSTALLDIR_OPT/share/tutorials/fusion/download_tutorial.sh"
+	chown -R root:root /opt/google/share
 
-  #TODO
-  # Set context (needed for SELINUX support) for shared libs
-  # chcon -t texrel_shlib_t /opt/google/lib/*so*
-  # Restrict permissions to uninstaller and installer logs
-  chmod -R go-rwx /opt/google/install
+	#TODO
+	# Set context (needed for SELINUX support) for shared libs
+	# chcon -t texrel_shlib_t /opt/google/lib/*so*
+	# Restrict permissions to uninstaller and installer logs
+	chmod -R go-rwx /opt/google/install
 
-  # Disable cutter (default) during installation.
-  /opt/google/bin/geserveradmin --disable_cutter
+	# Disable cutter (default) during installation.
+	/opt/google/bin/geserveradmin --disable_cutter
 
-  # Restrict permissions to uninstaller and installer logs
-  chmod -R go-rwx "$INSTALL_LOG_DIR"
+	# Restrict permissions to uninstaller and installer logs
+	chmod -R go-rwx "$INSTALL_LOG_DIR"
 }
 
 show_final_success_message(){
  # Install complete
-  INSTALLED_OR_UPGRADED="installed"
-  # TODO check for "UPGRADE" or case insensitive "upgrade"
-  if  [[ "$SERVER_INSTALL_OR_UPGRADE" = *upgrade* ]]; then
-    INSTALLED_OR_UPGRADED="upgraded"
-  fi
+	INSTALLED_OR_UPGRADED="installed"
+	# TODO check for "UPGRADE" or case insensitive "upgrade"
+	if  [[ "$SERVER_INSTALL_OR_UPGRADE" = *upgrade* ]]; then
+		INSTALLED_OR_UPGRADED="upgraded"
+	fi
 
-  # Ask the user to start the GEES service
-  if [ "$START_SERVER_DAEMON" == 1 ]; then
-    while true; do
-      echo -e "Do you want to start the $GEES Service(y/n)?"
-      read PROMPT_FOR_START
-      case "$PROMPT_FOR_START" in
-        [Yy]* )
-          "$BININSTALLROOTDIR/geserver" start
-          check_server_running; break;;
-        [Nn]* )
-          echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
-                   /opt/google \n
-                   Start Google Earth Enterprise Server with the following command:
-                   $BININSTALLROOTDIR/geserver start"
-          exit;;
-        * ) echo "Please answer yes or no.";;
-    esac
-    done
-  else
-    echo -e  " $GEES could not start properly."
-  fi
+	# Ask the user to start the GEES service
+	if [ "$START_SERVER_DAEMON" == 1 ]; then
+		while true; do
+			echo -e "Do you want to start the $GEES Service(y/n)?"
+			read PROMPT_FOR_START
+			case "$PROMPT_FOR_START" in
+				[Yy]* )
+					"$BININSTALLROOTDIR/geserver" start
+					check_server_running; break;;
+				[Nn]* )
+					echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
+									 /opt/google \n
+									 Start Google Earth Enterprise Server with the following command:
+									 $BININSTALLROOTDIR/geserver start"
+					exit;;
+				* ) echo "Please answer yes or no.";;
+		esac
+		done
+	else
+		echo -e  " $GEES could not start properly."
+	fi
 
-  echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
-          /opt/google \n
-          Start Google Earth Enterprise Server with the following command:
-          $BININSTALLROOTDIR/geserver start"
+	echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
+					/opt/google \n
+					Start Google Earth Enterprise Server with the following command:
+					$BININSTALLROOTDIR/geserver start"
 
 }
 
 check_server_running()
 {
-  # Check that server is setup properly
+	# Check that server is setup properly
 
-  if ! check_server_processes_running; then
-    echo -e "$GEES service is not running properly. Check the logs in
-             /opt/google/gehttpd/logs \n
-             /var/opt/google/pgsql/logs \n
-             for more details. "
-  fi
+	if ! check_server_processes_running; then
+		echo -e "$GEES service is not running properly. Check the logs in
+						 /opt/google/gehttpd/logs \n
+						 /var/opt/google/pgsql/logs \n
+						 for more details. "
+	fi
 }
 
+# Show config values and prompt user for confirmation to continue install
 prompt_install_confirmation()
 {
 	local backupStringValue=""
@@ -652,11 +684,11 @@ prompt_install_confirmation()
 	fi
 	echo -e "Install Location: \t$BASEINSTALLDIR_OPT"
 	echo -e "Asset Root: \t\t$ASSET_ROOT"
-  echo -e "Source Volume: \t\t$SOURCE_VOLUME"
+	echo -e "Source Volume: \t\t$SOURCE_VOLUME"
 	echo -e "Fusion User: \t\t$GEFUSIONUSER_NAME"
 	echo -e "Fusion User Group: \t$GROUPNAME"
 	echo -e "Apache User: \t\t$GEAPACHEUSER_NAME"
-  echo -e "Disk Space:\n"
+	echo -e "Disk Space:\n"
 
 #	GRPNAME="gegroup"
 #	GEPGUSER_NAME="gepguser"
@@ -669,9 +701,9 @@ prompt_install_confirmation()
 	if ! prompt_to_quit "X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade."; then
 		return 1
 	else
-        echo -e "\nProceeding with installation..."
+				echo -e "\nProceeding with installation..."
 		return 0
-    fi
+		fi
 }
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -46,18 +46,17 @@ START_SERVER_DAEMON=1
 PROMPT_FOR_START="n"
 
 # user names
-DEFAULTGROUPNAME=`get_default_group "$PUBLISHER_ROOT/stream_space" "gegroup"`
-GROUPNAME=$DEFAULTGROUPNAME
+DEFAULTGROUPNAME="gegroup"
 GRPNAME=$DEFAULTGROUPNAME
-GEAPACHEUSER_NAME=`get_default_user "$PUBLISHER_ROOT/stream_space" "geapacheuser"`
-GEPGUSER_NAME=`get_default_user "/var/opt/google/pgsql" "gepguser"`
-DEFAULTGEFUSIONUSER_NAME=`get_default_user $FUSIONBININSTALL "gefusionuser"`
+GEAPACHEUSER_NAME="geapacheuser"
+GEPGUSER_NAME="gepguser"
+DEFAULTGEFUSIONUSER_NAME="gefusionuser"
 GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
 
 # addition variables
 IS_NEWINSTALL=false
+FUSION_INSTALLED=false
 PUBLISHER_ROOT_VOLUME_INFO=()
-ASSET_ROOT_VOLUME_INFO=()
 MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB=1048576
 
 #-----------------------------------------------------------------
@@ -65,160 +64,167 @@ MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB=1048576
 #-----------------------------------------------------------------
 main_preinstall()
 {
-	# 3) Introduction
-	show_intro
+  # 3) Introduction
+  show_intro
 
-	# 2) Root/Sudo check
-	if [ "$EUID" != "0" ]; then
-		show_need_root
-		exit 1
-	fi
+  # 2) Root/Sudo check
+  if [ "$EUID" != "0" ]; then
+    show_need_root
+    exit 1
+  fi
 
-	if [ -f "$GESERVERBININSTALL" ]; then
-		IS_NEWINSTALL=false
-	else
-		IS_NEWINSTALL=true
-		BACKUPSERVER=false
-	fi
+  # Check if a new install
+  if [ -f "$GESERVERBININSTALL" ]; then
+    # Get usernames that were used in previous installation
+    IS_NEWINSTALL=false
+    get_server_installation_info
+  else
+    IS_NEWINSTALL=true
+    BACKUPSERVER=false
+    # If fusion has been installed, get fusion user and group name used in fusion install
+    if [ -f "$FUSIONBININSTALL" ] && [ -f "$SYSTEMRC" ]; then
+      GRPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
+      GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+      FUSION_INSTALLED=true
+    fi
+  fi
 
-	# Argument check
-	if ! parse_arguments "$@"; then
-		exit 1
-	fi
+  # Argument check
+  if ! parse_arguments "$@"; then
+    exit 1
+  fi
 
-	if ! determine_os; then
-		exit 1
-	fi
+  if ! determine_os; then
+    exit 1
+  fi
 
-	if is_package_installed "opengee-common" "opengee-common"; then
-		show_opengee_package_installed "install" "$GEES"
-		exit 1
-	fi
+  if is_package_installed "opengee-common" "opengee-common"; then
+    show_opengee_package_installed "install" "$GEES"
+    exit 1
+  fi
 
-	# 7) Check prerequisite software
-	if ! check_prereq_software; then
-		exit 1
-	fi
+  # 7) Check prerequisite software
+  if ! check_prereq_software; then
+    exit 1
+  fi
 
-	# check to see if GE Server processes are running
-	if check_server_processes_running; then
-		show_server_running_message
-		exit 1
-	fi
+  # check to see if GE Server processes are running
+  if check_server_processes_running; then
+    show_server_running_message
+    exit 1
+  fi
 
-	# tmp dir check
-	if [ ! -d "$TMPINSTALLDIR" ]; then
-		show_no_tmp_dir_message $TMPINSTALLDIR
-		exit 1
-	fi
+  # tmp dir check
+  if [ ! -d "$TMPINSTALLDIR" ]; then
+    show_no_tmp_dir_message $TMPINSTALLDIR
+    exit 1
+  fi
 
-	# 64 bit check
-	if [[ "$(uname -i)" != "x86_64" ]]; then
-		echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
-		exit 1
-	fi
+  # 64 bit check
+  if [[ "$(uname -i)" != "x86_64" ]]; then
+    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
+    exit 1
+  fi
 
-	# 10) Configure Publish Root
-	configure_publish_root
+  # 10) Configure Publish Root
+  configure_publish_root
 
   # Check publisher root volume size
-	if ! check_publisher_root_volume; then
-		exit 1
-	fi
+  if ! check_publisher_root_volume; then
+    exit 1
+  fi
 
-#	ASSEST_ROOT_VOLUME_INFO=($(get_volume_info "$ASSET_ROOT"))
+  if ! prompt_install_confirmation; then
+    exit 1
+  fi
 
-	if ! prompt_install_confirmation; then
-		exit 1
-	fi
+  # 5b) Perform backup
+  if [ "$BACKUPSERVER" = true ]; then
+    # Backing up current Server Install...
+    backup_server
 
-	# 5b) Perform backup
-	if [ "$BACKUPSERVER" = true ]; then
-		# Backing up current Server Install...
-		backup_server
-	fi
+    # Backup PGSQL data
+    if [ -d "$PGSQL_DATA" ]; then
+      backup_pgsql_data
+    fi
+  fi
 
-	# Backup PGSQL data
-	if [ -d "$PGSQL_DATA" ]; then
-		backup_pgsql_data
-	fi
+  # 6) Check valid host properties
+  if ! check_bad_hostname; then
+    exit 1
+  fi
 
-	# 6) Check valid host properties
-	if ! check_bad_hostname; then
-		exit 1
-	fi
+  if ! check_mismatched_hostname; then
+    exit 1
+  fi
 
-	if ! check_mismatched_hostname; then
-		exit 1
-	fi
+  # 8) Check if group and users exist
+  check_group
 
-	# 8) Check if group and users exist
-	check_group
-
-	check_username "$GEAPACHEUSER_NAME"
-	check_username "$GEPGUSER_NAME"
+  check_username "$GEAPACHEUSER_NAME"
+  check_username "$GEPGUSER_NAME"
 
 }
 
 check_prereq_software()
 {
-	local check_prereq_software_retval=0
-	local script_name="$GEES $LONG_VERSION installer"
+  local check_prereq_software_retval=0
+  local script_name="$GEES $LONG_VERSION installer"
 
-	if ! software_check "$script_name" "libxml2-utils" "libxml2.*x86_64"; then
-		check_prereq_software_retval=1
-	fi
+  if ! software_check "$script_name" "libxml2-utils" "libxml2.*x86_64"; then
+    check_prereq_software_retval=1
+  fi
 
-	if ! software_check "$script_name" "python2.[67]" "python-2.[67].*"; then
-		check_prereq_software_retval=1
-	fi
+  if ! software_check "$script_name" "python2.[67]" "python-2.[67].*"; then
+    check_prereq_software_retval=1
+  fi
 
-	return $check_prereq_software_retval
+  return $check_prereq_software_retval
 }
 
 main_install()
 {
-	copy_files_to_target
-	create_links
+  copy_files_to_target
+  create_links
 }
 
 main_postinstall()
 {
-	# 1) Modify files
-	modify_files
+  # 1) Modify files
+  modify_files
 
-	# 2) Set Permissions Before Server Start/Stop
-	fix_postinstall_filepermissions
+  # 2) Set Permissions Before Server Start/Stop
+  fix_postinstall_filepermissions
 
-	# 3) PostGres DB config
-	postgres_db_config
+  # 3) PostGres DB config
+  postgres_db_config
 
-	# 4) Creating Daemon thread for geserver
-	setup_geserver_daemon
+  # 4) Creating Daemon thread for geserver
+  setup_geserver_daemon
 
-	# 5) Add the server to services
-	# For RedHat and SuSE
-	test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
+  # 5) Add the server to services
+  # For RedHat and SuSE
+  test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
 
-	# 6) Register publish root
-	"$BASEINSTALLDIR_OPT/bin/geconfigurepublishroot" --noprompt --path="$PUBLISHER_ROOT"
+  # 6) Register publish root
+  "$BASEINSTALLDIR_OPT/bin/geconfigurepublishroot" --noprompt --path="$PUBLISHER_ROOT"
 
-	# 7) Install the GEPlaces and SearchExample Databases
-	install_search_databases
+  # 7) Install the GEPlaces and SearchExample Databases
+  install_search_databases
 
-	# 8) Set permissions after geserver Start/Stop.
-	fix_postinstall_filepermissions
+  # 8) Set permissions after geserver Start/Stop.
+  fix_postinstall_filepermissions
 
-	# TODO - verify
-	# 9) Run geecheck config script
-	# If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
-	if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
-		cd "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin"
-		python ./set_geecheck_config.py
-	fi
+  # TODO - verify
+  # 9) Run geecheck config script
+  # If file ‘/opt/google/gehttpd/cgi-bin/set_geecheck_config.py’ exists:
+  if [ -f "$GEE_CHECK_CONFIG_SCRIPT" ]; then
+    cd "$BASEINSTALLDIR_OPT/gehttpd/cgi-bin"
+    python ./set_geecheck_config.py
+  fi
 
-	# 10)
-	show_final_success_message
+  # 10)
+  show_final_success_message
 }
 
 #-----------------------------------------------------------------
@@ -227,71 +233,71 @@ main_postinstall()
 
 show_intro()
 {
-	echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
+  echo -e "\nWelcome to the $GEES $LONG_VERSION installer."
 }
 
 # TODO: Add additional parameters for GEE Server
 show_help()
 {
-	echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf] [-pgu gepguser]"
+  echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf] [-pgu gepguser]"
   echo -e "\t\t[-au geapacheuser] [-g gegroup] [-nobk]"
   echo -e "\n"
-	echo -e "-h --help \tHelp - display this help screen"
-	echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
-	echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
-	echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname."
+  echo -e "-h --help \tHelp - display this help screen"
+  echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
+  echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
+  echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname."
   echo -e "-au \t\tApache user name. Default is [$GEAPACHEUSER_NAME]. \n\t\tNote: this is only used for new installations."
   echo -e "-pgu \t\tPostgres user name. Default is [$GEPGUSER_NAME]. \n\t\tNote: this is only used for new installations."
-	echo -e "-g \t\tUser Group Name - the group name to use for the Server, Postgress, and Apache user. Default is [$GROUPNAME]. \n\t\tNote: this is only used for new installations."
-	echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tthe setup before installing."
+  echo -e "-g \t\tUser Group Name - the group name to use for the Server, Postgress, and Apache user. Default is [$GRPNAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tserver before installing."
   echo -e "\n"
 }
 
 # TODO convert to common function
 show_need_root()
 {
-	echo -e "\nYou must have root privileges to install $GEES.\n"
-	echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
-	echo -e "The installer must exit."
+  echo -e "\nYou must have root privileges to install $GEES.\n"
+  echo -e "Log in as the $ROOT_USERNAME user or use the 'sudo' command to run this installer."
+  echo -e "The installer must exit."
 }
 
 # TODO Add additional parameters for server
 parse_arguments()
 {
-	local parse_arguments_retval=0
+  local parse_arguments_retval=0
 
-	while [ $# -gt 0 ]
-	do
-		case "${1,,}" in
-			-h|-help|--help)
-				show_help
-				parse_arguments_retval=1
-				break
-				;;
-			-nobk)
-				BACKUPSERVER=false
-				;;
-			-hnf)
-				BADHOSTNAMEOVERRIDE=true;
-				;;
-			-hnmf)
-				MISMATCHHOSTNAMEOVERRIDE=true
-				;;
-			-dir)
-				shift
-				if [ -d "$1" ]; then
-					TMPINSTALLDIR="$1"
-				else
-					show_no_tmp_dir_message "$1"
-					parse_arguments_retval=-1
-					break
-				fi
-				;;
+  while [ $# -gt 0 ]
+  do
+    case "${1,,}" in
+      -h|-help|--help)
+        show_help
+        parse_arguments_retval=1
+        break
+        ;;
+      -nobk)
+        BACKUPSERVER=false
+        ;;
+      -hnf)
+        BADHOSTNAMEOVERRIDE=true;
+        ;;
+      -hnmf)
+        MISMATCHHOSTNAMEOVERRIDE=true
+        ;;
+      -dir)
+        shift
+        if [ -d "$1" ]; then
+          TMPINSTALLDIR="$1"
+        else
+          show_no_tmp_dir_message "$1"
+          parse_arguments_retval=-1
+          break
+        fi
+        ;;
       -au)
-				shift
-        if [ $IS_NEWINSTALL == false -a "$GEAPACHEUSER_NAME" != "${1// }"]; then
-					echo -e "\nYou cannot modify the Apache user name using the installer because $GEES is already installed on this server."
-					parse_arguments_retval=1
+        shift
+        if [ $IS_NEWINSTALL = false ] && [ "$GEAPACHEUSER_NAME" != "${1// }" ]; then
+          echo -e "\nYou cannot modify the Apache user name using the installer because $GEES is already installed on this server."
+          parse_arguments_retval=1
           break
         else
           if is_valid_alphanumeric ${1// }; then
@@ -305,10 +311,10 @@ parse_arguments()
         fi
         ;;
       -pgu)
-				shift
-        if [ $IS_NEWINSTALL == false -a "$GEPGUSER_NAME" != "${1// }" ]; then
-					echo -e "\nYou cannot modify the postgres user name using the installer because $GEES is already installed on this server."
-					parse_arguments_retval=1
+        shift
+        if [ $IS_NEWINSTALL == false ] && [ "$GEPGUSER_NAME" != "${1// }" ]; then
+          echo -e "\nYou cannot modify the postgres user name using the installer because $GEES is already installed on this server."
+          parse_arguments_retval=1
           break
         else
           if is_valid_alphanumeric ${1// }; then
@@ -322,19 +328,22 @@ parse_arguments()
         fi
         ;;
       -g)
-				shift
-        if [ $IS_NEWINSTALL == false -a $GRPNAME != ${1// } ]; then
-          echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
+        shift
+        if [ $IS_NEWINSTALL == false ] && [ $GRPNAME != ${1// } ]; then
+          echo -e "\nYou cannot modify the $GEES user group using the installer because $GEES is already installed on this server."
           parse_arguments_retval=1
           # Don't show the User Group dialog since it is invalid to change the fusion
           # username once fusion is installed on the server
           show_user_group_recommendation=false
           break
+        elif [ $FUSION_INSTALLED == true ] && [ $GRPNAME != ${1// } ]; then
+          echo -e "\nYou specified a different group ($1) than for fusion installation ($GRPNAME)"
+          echo -e "You must use the same group for both Fusion and Server"
+          parse_arguments_retval=1
+          break
         else
-
           if is_valid_alphanumeric ${1// }; then
             GRPNAME=${1// }
-						GROUPNAME=$GRPNAME
           else
             echo -e "\nThe group name you specified is not valid. Valid characters are upper/lowercase letters, "
             echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
@@ -349,62 +358,62 @@ parse_arguments()
       parse_arguments_retval=1
       break
       ;;
-		esac
+    esac
 
-		if [ $# -gt 0 ]
-		then
-			shift
-		fi
-	done
+    if [ $# -gt 0 ]
+    then
+      shift
+    fi
+  done
 
-	return $parse_arguments_retval;
+  return $parse_arguments_retval;
 }
 
 show_server_running_message()
 {
-	echo -e "\n$GEES has active running processes."
-	echo -e "To use this installer to upgrade, you must stop all geserver services.\n"
+  echo -e "\n$GEES has active running processes."
+  echo -e "To use this installer to upgrade, you must stop all geserver services.\n"
 }
 
 configure_publish_root()
 {
-	# Update PUBLISHER_ROOT if geserver already installed
-	local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
-	if [ -e "$STREAM_SPACE" ]; then
-		PUBLISHER_ROOT=`cat $STREAM_SPACE | cut -d" " -f3 | sed 's/.\{13\}$//'`
-	fi
+  # Update PUBLISHER_ROOT if geserver already installed
+  local STREAM_SPACE="$GEHTTPD_CONF/stream_space"
+  if [ -e "$STREAM_SPACE" ]; then
+    PUBLISHER_ROOT=`cat $STREAM_SPACE | cut -d" " -f3 | sed 's/.\{13\}$//'`
+  fi
 }
 
 check_publisher_root_volume()
 {
-	local check_publisher_root_volume_retval=0
+  local check_publisher_root_volume_retval=0
   # Get size and available for publisher root volume
   PUBLISHER_ROOT_VOLUME_INFO=($(get_volume_info "$PUBLISHER_ROOT"))
-	if [[ ${PUBLISHER_ROOT_VOLUME_INFO[2]} -lt $MIN_PUBLISER_ROOT_VALUE_IN_KB ]]; then
+  if [[ ${PUBLISHER_ROOT_VOLUME_INFO[2]} -lt $MIN_PUBLISER_ROOT_VALUE_IN_KB ]]; then
     MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB=$(expr $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB / 1024 / 1024)
-		echo -e "\nThe publisher root volume [$PUBLISHER_ROOT] has only ${PUBLISHER_ROOT_VOLUME_INFO[2]} KB available."
-		echo -e "We recommend that an publisher root directory have a minimum of $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB GB of free disk space."
-		echo ""
+    echo -e "\nThe publisher root volume [$PUBLISHER_ROOT] has only ${PUBLISHER_ROOT_VOLUME_INFO[2]} KB available."
+    echo -e "We recommend that an publisher root directory have a minimum of $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB GB of free disk space."
+    echo ""
 
-		if ! prompt_to_quit "X (Exit) the installer and change the asset root location with larger volume - C (Continue) to use the asset root that you have specified."; then
-				check_publisher_root_volume_retval=1
-		fi
-	fi
+    if ! prompt_to_quit "X (Exit) the installer and change the asset root location with larger volume - C (Continue) to use the asset root that you have specified."; then
+        check_publisher_root_volume_retval=1
+    fi
+  fi
 
-	return $check_publisher_root_volume_retval
+  return $check_publisher_root_volume_retval
 }
 
 backup_pgsql_data()
 {
-	# Make the temporary data backup directory
-	mkdir -p "$BACKUP_DATA_DIR"
-	chown "$GEPGUSER_NAME" "$BACKUP_DATA_DIR"
+  # Make the temporary data backup directory
+  mkdir -p "$BACKUP_DATA_DIR"
+  chown "$GEPGUSER_NAME" "$BACKUP_DATA_DIR"
 
-	# Dump PGSQL data
-	RESET_DB_SCRIPT=$TMPINSTALLDIR/server/opt/google/bin/geresetpgdb
+  # Dump PGSQL data
+  RESET_DB_SCRIPT=$TMPINSTALLDIR/server/opt/google/bin/geresetpgdb
 
-	echo 2 | run_as_user "$GEPGUSER_NAME" \
-		"$(printf '%q' "$RESET_DB_SCRIPT") backup $(printf '%q' "$BACKUP_DATA_DIR")"
+  echo 2 | run_as_user "$GEPGUSER_NAME" \
+    "$(printf '%q' "$RESET_DB_SCRIPT") backup $(printf '%q' "$BACKUP_DATA_DIR")"
 }
 
 #-----------------------------------------------------------------
@@ -412,112 +421,112 @@ backup_pgsql_data()
 #-----------------------------------------------------------------
 copy_files_to_target()
 {
-	printf "\nCopying files from source to target directories..."
+  printf "\nCopying files from source to target directories..."
 
-	mkdir -p "$BASEINSTALLDIR_OPT/share/doc"
-	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
-	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
-	mkdir -p "$BASEINSTALLDIR_OPT/search"
-	mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
-	mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
-	mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
-	mkdir -p "$BASEINSTALLDIR_ETC/openldap"
-	mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
+  mkdir -p "$BASEINSTALLDIR_OPT/share/doc"
+  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
+  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
+  mkdir -p "$BASEINSTALLDIR_OPT/search"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
+  mkdir -p "$BASEINSTALLDIR_ETC/openldap"
+  mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
 
-	local error_on_copy=0
-	cp -rf "$TMPINSTALLDIR/common/opt/google/bin" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/common/opt/google/share" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/common/opt/google/qt" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/common/opt/google/qt/lib" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/common/opt/google/lib" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/common/opt/google/gepython" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/postgis/opt/google/share" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/postgis/opt/google/bin" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/postgis/opt/google/lib" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/share" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/bin" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/searchexample/opt/google/share" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/geplaces/opt/google/share" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/AppacheSupport/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
+  local error_on_copy=0
+  cp -rf "$TMPINSTALLDIR/common/opt/google/bin" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/common/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/common/opt/google/qt" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/common/opt/google/qt/lib" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/common/opt/google/lib" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/common/opt/google/gepython" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/bin" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/postgis/opt/google/lib" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/bin" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/searchexample/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/geplaces/opt/google/share" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/AppacheSupport/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-	cp -rf "$TMPINSTALLDIR/server/etc/init.d/geserver" "$BININSTALLROOTDIR"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.sh" "$BININSTALLPROFILEDIR"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.csh" "$BININSTALLPROFILEDIR"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/etc/init.d/geserver" "$BININSTALLROOTDIR"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.sh" "$BININSTALLPROFILEDIR"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/etc/profile.d/ge-server.csh" "$BININSTALLPROFILEDIR"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-	cp -rf "$TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd" "$BASEINSTALLLOGROTATEDIR"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/" "$BASEINSTALLDIR_VAR/pgsql"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/manual/opt/google/share/doc/manual" "$BASEINSTALLDIR_OPT/share/doc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/user_magic/etc/logrotate.d/gehttpd" "$BASEINSTALLLOGROTATEDIR"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/user_magic/var/opt/google/pgsql/logs/" "$BASEINSTALLDIR_VAR/pgsql"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/manual/opt/google/share/doc/manual" "$BASEINSTALLDIR_OPT/share/doc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+  TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
 
-	cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/CA.sh" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/c_name" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/c_issuer" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/c_info" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENSSLPATH/misc/c_hash" "$BASEINSTALLDIR_VAR/openssl/misc"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/CA.sh" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/c_name" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/c_issuer" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/c_info" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/c_hash" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
+  TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
 
-	cp -f "$TMPOPENLDAPPATH/ldap.conf" "$BASEINSTALLDIR_ETC/openldap"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f "$TMPOPENLDAPPATH/ldap.conf.default" "$BASEINSTALLDIR_ETC/openldap"
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENLDAPPATH/ldap.conf" "$BASEINSTALLDIR_ETC/openldap"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENLDAPPATH/ldap.conf.default" "$BASEINSTALLDIR_ETC/openldap"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
 
-	# TODO: final step: copy uninstall script
-	# cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
+  # TODO: final step: copy uninstall script
+  # cp -f $TMPOPENLDAPPATH/<........> $INSTALL_LOG_DIR
 
-	if [ "$error_on_copy" -ne 0 ]
-	then
-		show_corrupt_tmp_dir_message "$TMPINSTALLDIR" "$INSTALL_LOG"
-		exit 1
-	fi
+  if [ "$error_on_copy" -ne 0 ]
+  then
+    show_corrupt_tmp_dir_message "$TMPINSTALLDIR" "$INSTALL_LOG"
+    exit 1
+  fi
 
-	printf "DONE\n"
+  printf "DONE\n"
 }
 
 #-----------------------------------------------------------------
@@ -526,275 +535,292 @@ copy_files_to_target()
 
 postgres_db_config()
 {
-	# a) PostGres folders and configuration
-	chmod -R 700 /var/opt/google/pgsql/
-	chown -R "$GEPGUSER_NAME:$GRPNAME" /var/opt/google/pgsql/
-	reset_pgdb
+  # a) PostGres folders and configuration
+  chmod -R 700 /var/opt/google/pgsql/
+  chown -R "$GEPGUSER_NAME:$GRPNAME" /var/opt/google/pgsql/
+  reset_pgdb
 }
 
 reset_pgdb()
 {
-	# TODO check if correct
-	# a) Always do an upgrade of the psql db
-	echo 2 | run_as_user "$GEPGUSER_NAME" "/opt/google/bin/geresetpgdb upgrade $(printf '%q' "$BACKUP_DATA_DIR")"
-	echo -e "upgrade done"
+  # TODO check if correct
+  # a) Always do an upgrade of the psql db
+  echo 2 | run_as_user "$GEPGUSER_NAME" "/opt/google/bin/geresetpgdb upgrade $(printf '%q' "$BACKUP_DATA_DIR")"
+  echo -e "upgrade done"
 
-	# b) Check for Success of PostGresDb
-	#  If file ‘/var/opt/google/pgsql/data’ doesn’t exist:
+  # b) Check for Success of PostGresDb
+  #  If file ‘/var/opt/google/pgsql/data’ doesn’t exist:
 
-	echo "pgsql_data"
-	echo "$PGSQL_DATA"
-	if [ -d "$PGSQL_DATA" ]; then
-		# PostgreSQL install Success.
-		echo -e "The PostgreSQL component is successfully installed."
-	else
-		# postgress reset/install failed.
-		echo -e "Failed to create PostGresDb."
-		echo -e "The PostgreSQL component of the installation failed
-				 to install."
-	fi
+  echo "pgsql_data"
+  echo "$PGSQL_DATA"
+  if [ -d "$PGSQL_DATA" ]; then
+    # PostgreSQL install Success.
+    echo -e "The PostgreSQL component is successfully installed."
+  else
+    # postgress reset/install failed.
+    echo -e "Failed to create PostGresDb."
+    echo -e "The PostgreSQL component of the installation failed
+         to install."
+  fi
 }
 
 # 4) Creating Daemon thread for geserver
 setup_geserver_daemon()
 {
-	# setup geserver daemon
-	# For Ubuntu
-	printf "Setting up the geserver daemon...\n"
-	test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
-	test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" -f geserver remove
-	test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" geserver start 90 2 3 4 5 . stop 10 0 1 6 .
-	printf "GEE Server daemon setup ... DONE\n"
+  # setup geserver daemon
+  # For Ubuntu
+  printf "Setting up the geserver daemon...\n"
+  test -f "$CHKCONFIG" && "$CHKCONFIG" --add geserver
+  test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" -f geserver remove
+  test -f "$INITSCRIPTUPDATE" && "$INITSCRIPTUPDATE" geserver start 90 2 3 4 5 . stop 10 0 1 6 .
+  printf "GEE Server daemon setup ... DONE\n"
 }
 
 # 6) Install the GEPlaces and SearchExample Databases
 install_search_databases()
 {
-	# a) Start the PSQL Server
-	echo "# a) Start the PSQL Server "
-	run_as_user "$GEPGUSER_NAME" "$(printf '%q' "$PGSQL_PROGRAM") -D $(printf '%q' "$PGSQL_DATA") -l $(printf '%q' "$PGSQL_LOGS/pg.log") start -w"
+  # a) Start the PSQL Server
+  echo "# a) Start the PSQL Server "
+  run_as_user "$GEPGUSER_NAME" "$(printf '%q' "$PGSQL_PROGRAM") -D $(printf '%q' "$PGSQL_DATA") -l $(printf '%q' "$PGSQL_LOGS/pg.log") start -w"
 
-	echo "# b) Install GEPlaces Database"
-	# b) Install GEPlaces Database
-	run_as_user "$GEPGUSER_NAME" "/opt/google/share/geplaces/geplaces create"
+  echo "# b) Install GEPlaces Database"
+  # b) Install GEPlaces Database
+  run_as_user "$GEPGUSER_NAME" "/opt/google/share/geplaces/geplaces create"
 
-	echo "# c) Install SearchExample Database "
-	# c) Install SearchExample Database
-	run_as_user "$GEPGUSER_NAME" "/opt/google/share/searchexample/searchexample create"
+  echo "# c) Install SearchExample Database "
+  # c) Install SearchExample Database
+  run_as_user "$GEPGUSER_NAME" "/opt/google/share/searchexample/searchexample create"
 
-	# d) Stop the PSQL Server
-	echo "# d) Stop the PSQL Server"
-	run_as_user "$GEPGUSER_NAME" "$PGSQL_PROGRAM -D $PGSQL_DATA stop"
+  # d) Stop the PSQL Server
+  echo "# d) Stop the PSQL Server"
+  run_as_user "$GEPGUSER_NAME" "$PGSQL_PROGRAM -D $PGSQL_DATA stop"
 }
 
 modify_files()
 {
-	# Replace IA users in a file if they are found.
-	# this step not requied for the OSS installs, however
-	# if there are non-OSS installs in the system, it might help cleanup those.
+  # Replace IA users in a file if they are found.
+  # this step not requied for the OSS installs, however
+  # if there are non-OSS installs in the system, it might help cleanup those.
 
-	# a) Search and replace the below variables in /etc/init.d/geserver.
-	sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" "$BININSTALLROOTDIR/geserver"
-	sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" "$BININSTALLROOTDIR/geserver"
+  # a) Search and replace the below variables in /etc/init.d/geserver.
+  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" "$BININSTALLROOTDIR/geserver"
+  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" "$BININSTALLROOTDIR/geserver"
 
-	# b) Search and replace the file ‘/opt/google/gehttpd/conf/gehttpd.conf’
-	sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
-	sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
-	sed -i "s/IA_GEGROUP/$GRPNAME/" /opt/google/gehttpd/conf/gehttpd.conf
+  # b) Search and replace the file ‘/opt/google/gehttpd/conf/gehttpd.conf’
+  sed -i "s/IA_GEAPACHE_USER/$GEAPACHEUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+  sed -i "s/IA_GEPGUSER/$GEPGUSER_NAME/" /opt/google/gehttpd/conf/gehttpd.conf
+  sed -i "s/IA_GEGROUP/$GRPNAME/" /opt/google/gehttpd/conf/gehttpd.conf
 
-	# c) Create a new file ‘/etc/opt/google/fusion_server_version’ and
-	# add the below text to it.
-	echo "$LONG_VERSION" > /etc/opt/google/fusion_server_version
+  # c) Create a new file ‘/etc/opt/google/fusion_server_version’ and
+  # add the below text to it.
+  echo "$LONG_VERSION" > /etc/opt/google/fusion_server_version
 
-	# d) Create a new file ‘/etc/init.d/gevars.sh’ and prepend the below lines.
-	echo -e "GEAPACHEUSER=$GEAPACHEUSER_NAME\nGEPGUSER=$GEPGUSER_NAME\nGEFUSIONUSER=$GEFUSIONUSER_NAME\nGEGROUP=$GRPNAME" > $BININSTALLROOTDIR/gevars.sh
+  # d) Create a new file ‘/etc/init.d/gevars.sh’ and prepend the below lines.
+  echo -e "GEAPACHEUSER=$GEAPACHEUSER_NAME\nGEPGUSER=$GEPGUSER_NAME\nGEFUSIONUSER=$GEFUSIONUSER_NAME\nGEGROUP=$GRPNAME" > $BININSTALLROOTDIR/gevars.sh
 }
 
 fix_postinstall_filepermissions()
 {
-	# PostGres
-	chown -R "$GEPGUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_VAR/pgsql/"
+  # PostGres
+  chown -R "$GEPGUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_VAR/pgsql/"
 
-	# Apache
-	mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime"
-	chmod -R 755 "$BASEINSTALLDIR_OPT/gehttpd"
-	chmod -R 775 "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/"
-	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/"
-	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/"
-	chmod -R 700 "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/"
-	chown "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess"
-	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/logs"
+  # Apache
+  mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime"
+  chmod -R 755 "$BASEINSTALLDIR_OPT/gehttpd"
+  chmod -R 775 "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/runtime/"
+  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/virtual_servers/"
+  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/"
+  chmod -R 700 "$BASEINSTALLDIR_OPT/gehttpd/htdocs/cutter/globes/"
+  chown "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/.htaccess"
+  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$BASEINSTALLDIR_OPT/gehttpd/logs"
 
-	# Publish Root
-	chmod 775 "$PUBLISHER_ROOT/stream_space"
-	# TODO - Not Found
-	# chmod 644 $PUBLISHER_ROOT/stream_space/.config
-	chmod 644 "$PUBLISHER_ROOT/.config"
-	chmod 755 "$PUBLISHER_ROOT"
-	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/stream_space"
-	chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/search_space"
+  # Publish Root
+  chmod 775 "$PUBLISHER_ROOT/stream_space"
+  # TODO - Not Found
+  # chmod 644 $PUBLISHER_ROOT/stream_space/.config
+  chmod 644 "$PUBLISHER_ROOT/.config"
+  chmod 755 "$PUBLISHER_ROOT"
+  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/stream_space"
+  chown -R "$GEAPACHEUSER_NAME:$GRPNAME" "$PUBLISHER_ROOT/search_space"
 
-	# Etc
-	chmod 755 /etc/opt/google/
-	chmod 755 "$BASEINSTALLDIR_OPT/etc/"
-	chmod 755 "$BININSTALLROOTDIR/gevars.sh"
-	chmod 755 "$BININSTALLROOTDIR/geserver"
+  # Etc
+  chmod 755 /etc/opt/google/
+  chmod 755 "$BASEINSTALLDIR_OPT/etc/"
+  chmod 755 "$BININSTALLROOTDIR/gevars.sh"
+  chmod 755 "$BININSTALLROOTDIR/geserver"
 
-	# Run
-	chmod 775 "$BASEINSTALLDIR_OPT/run/"
-	chmod 775 "$BASEINSTALLDIR_VAR/run/"
-	chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/run/"
-	chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/run/"
+  # Run
+  chmod 775 "$BASEINSTALLDIR_OPT/run/"
+  chmod 775 "$BASEINSTALLDIR_VAR/run/"
+  chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/run/"
+  chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/run/"
 
-	# Logs
-	chmod 775 "$BASEINSTALLDIR_VAR/log/"
-	chmod 775 "$BASEINSTALLDIR_OPT/log/"
-	chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/log"
-	chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/log"
+  # Logs
+  chmod 775 "$BASEINSTALLDIR_VAR/log/"
+  chmod 775 "$BASEINSTALLDIR_OPT/log/"
+  chown "root:$GRPNAME" "$BASEINSTALLDIR_VAR/log"
+  chown "root:$GRPNAME" "$BASEINSTALLDIR_OPT/log"
 
-	# Other folders
-	chmod 755 "$BASEINSTALLDIR_OPT"
-	chmod 755 "$BASEINSTALLDIR_VAR"
-	chmod -R 755 /opt/google/lib/
-	chmod -R 555 /opt/google/bin/
-	chmod 755 /opt/google/bin
-	chmod +s /opt/google/bin/gerestartapache /opt/google/bin/geresetpgdb /opt/google/bin/geserveradmin
-	chmod -R 755 /opt/google/qt/
-	# TODO: there is not such directory
-	# chmod 755 /etc/opt/google/installed_products/
-	chmod 755 /etc/opt/google/openldap/
+  # Other folders
+  chmod 755 "$BASEINSTALLDIR_OPT"
+  chmod 755 "$BASEINSTALLDIR_VAR"
+  chmod -R 755 /opt/google/lib/
+  chmod -R 555 /opt/google/bin/
+  chmod 755 /opt/google/bin
+  chmod +s /opt/google/bin/gerestartapache /opt/google/bin/geresetpgdb /opt/google/bin/geserveradmin
+  chmod -R 755 /opt/google/qt/
+  # TODO: there is not such directory
+  # chmod 755 /etc/opt/google/installed_products/
+  chmod 755 /etc/opt/google/openldap/
 
-	# Tutorial and Share
-	find /opt/google/share -type d -exec chmod 755 {} \;
-	find /opt/google/share -type f -exec chmod 644 {} \;
-	chmod ugo+x /opt/google/share/searchexample/searchexample
-	chmod ugo+x /opt/google/share/geplaces/geplaces
-	chmod ugo+x /opt/google/share/support/geecheck/geecheck.pl
-	chmod ugo+x /opt/google/share/support/geecheck/convert_to_kml.pl
-	chmod ugo+x /opt/google/share/support/geecheck/find_terrain_pixel.pl
-	chmod ugo+x /opt/google/share/support/geecheck/pg_check.pl
-	# Note: this is installed in install_fusion.sh, but needs setting here too.
-	chmod ugo+x "$BASEINSTALLDIR_OPT/share/tutorials/fusion/download_tutorial.sh"
-	chown -R root:root /opt/google/share
+  # Tutorial and Share
+  find /opt/google/share -type d -exec chmod 755 {} \;
+  find /opt/google/share -type f -exec chmod 644 {} \;
+  chmod ugo+x /opt/google/share/searchexample/searchexample
+  chmod ugo+x /opt/google/share/geplaces/geplaces
+  chmod ugo+x /opt/google/share/support/geecheck/geecheck.pl
+  chmod ugo+x /opt/google/share/support/geecheck/convert_to_kml.pl
+  chmod ugo+x /opt/google/share/support/geecheck/find_terrain_pixel.pl
+  chmod ugo+x /opt/google/share/support/geecheck/pg_check.pl
+  # Note: this is installed in install_fusion.sh, but needs setting here too.
+  chmod ugo+x "$BASEINSTALLDIR_OPT/share/tutorials/fusion/download_tutorial.sh"
+  chown -R root:root /opt/google/share
 
-	#TODO
-	# Set context (needed for SELINUX support) for shared libs
-	# chcon -t texrel_shlib_t /opt/google/lib/*so*
-	# Restrict permissions to uninstaller and installer logs
-	chmod -R go-rwx /opt/google/install
+  #TODO
+  # Set context (needed for SELINUX support) for shared libs
+  # chcon -t texrel_shlib_t /opt/google/lib/*so*
+  # Restrict permissions to uninstaller and installer logs
+  chmod -R go-rwx /opt/google/install
 
-	# Disable cutter (default) during installation.
-	/opt/google/bin/geserveradmin --disable_cutter
+  # Disable cutter (default) during installation.
+  /opt/google/bin/geserveradmin --disable_cutter
 
-	# Restrict permissions to uninstaller and installer logs
-	chmod -R go-rwx "$INSTALL_LOG_DIR"
+  # Restrict permissions to uninstaller and installer logs
+  chmod -R go-rwx "$INSTALL_LOG_DIR"
 }
 
 show_final_success_message(){
  # Install complete
-	INSTALLED_OR_UPGRADED="installed"
-	# TODO check for "UPGRADE" or case insensitive "upgrade"
-	if  [[ "$SERVER_INSTALL_OR_UPGRADE" = *upgrade* ]]; then
-		INSTALLED_OR_UPGRADED="upgraded"
-	fi
+  INSTALLED_OR_UPGRADED="installed"
+  # TODO check for "UPGRADE" or case insensitive "upgrade"
+  if  [[ "$SERVER_INSTALL_OR_UPGRADE" = *upgrade* ]]; then
+    INSTALLED_OR_UPGRADED="upgraded"
+  fi
 
-	# Ask the user to start the GEES service
-	if [ "$START_SERVER_DAEMON" == 1 ]; then
-		while true; do
-			echo -e "Do you want to start the $GEES Service(y/n)?"
-			read PROMPT_FOR_START
-			case "$PROMPT_FOR_START" in
-				[Yy]* )
-					"$BININSTALLROOTDIR/geserver" start
-					check_server_running; break;;
-				[Nn]* )
-					echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
-									 /opt/google \n
-									 Start Google Earth Enterprise Server with the following command:
-									 $BININSTALLROOTDIR/geserver start"
-					exit;;
-				* ) echo "Please answer yes or no.";;
-		esac
-		done
-	else
-		echo -e  " $GEES could not start properly."
-	fi
+  # Ask the user to start the GEES service
+  if [ "$START_SERVER_DAEMON" == 1 ]; then
+    while true; do
+      echo -e "Do you want to start the $GEES Service(y/n)?"
+      read PROMPT_FOR_START
+      case "$PROMPT_FOR_START" in
+        [Yy]* )
+          "$BININSTALLROOTDIR/geserver" start
+          check_server_running; break;;
+        [Nn]* )
+          echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
+                   /opt/google \n
+                   Start Google Earth Enterprise Server with the following command:
+                   $BININSTALLROOTDIR/geserver start"
+          exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+    done
+  else
+    echo -e  " $GEES could not start properly."
+  fi
 
-	echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
-					/opt/google \n
-					Start Google Earth Enterprise Server with the following command:
-					$BININSTALLROOTDIR/geserver start"
+  echo -e "Congratulations! $PRODUCT_NAME has been successfully $INSTALLED_OR_UPGRADED in the following directory:
+          /opt/google \n
+          Start Google Earth Enterprise Server with the following command:
+          $BININSTALLROOTDIR/geserver start"
 
 }
 
 check_server_running()
 {
-	# Check that server is setup properly
+  # Check that server is setup properly
 
-	if ! check_server_processes_running; then
-		echo -e "$GEES service is not running properly. Check the logs in
-						 /opt/google/gehttpd/logs \n
-						 /var/opt/google/pgsql/logs \n
-						 for more details. "
-	fi
+  if ! check_server_processes_running; then
+    echo -e "$GEES service is not running properly. Check the logs in
+             /opt/google/gehttpd/logs \n
+             /var/opt/google/pgsql/logs \n
+             for more details. "
+  fi
 }
 
 # Candidate to move to common
 is_valid_alphanumeric()
 {
-	# Standard function that tests a string to see if it passes the "valid" alphanumeric for user name and group name.
-	# For simplicity -- we limit to letters, numbers and underscores.
-	regex="^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$"
+  # Standard function that tests a string to see if it passes the "valid" alphanumeric for user name and group name.
+  # For simplicity -- we limit to letters, numbers and underscores.
+  regex="^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$"
 
-	if [ ! -z "$1" ] && [[ $1 =~ $regex ]]; then
-		return 0
-	else
-		return 1
-	fi
+  if [ ! -z "$1" ] && [[ $1 =~ $regex ]]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 # Show config values and prompt user for confirmation to continue install
 prompt_install_confirmation()
 {
-	local backupStringValue=""
+  local backupStringValue=""
 
-	if [ $BACKUPSERVER == true ]; then
-		backupStringValue="YES"
-	else
-		backupStringValue="NO"
-	fi
+  if [ $BACKUPSERVER == true ]; then
+    backupStringValue="YES"
+  else
+    backupStringValue="NO"
+  fi
 
-	echo -e "\nYou have chosen to install $GEES with the following settings:\n"
-	echo -e "# CPU's: \t\t$NUM_CPUS"
-	echo -e "Operating System: \t$MACHINE_OS_FRIENDLY"
-	echo -e "64 bit OS: \t\tYES"	# Will always be true because we exit if 32 bit OS
-	if [ $IS_NEWINSTALL == false ]; then
-		echo -e "Backup Server: \t\t$backupStringValue"
-	fi
-  echo -e "Publisher Root: \t${PUBLISHER_ROOT_VOLUME_INFO[0]}s"
-  echo -e "Publisher Root Size: \t${PUBLISHER_ROOT_VOLUME_INFO[1]} Kbyte"
-  echo -e "Publisher Root Avail: \t${PUBLISHER_ROOT_VOLUME_INFO[2]} Kbyte"
+  echo -e "\nYou have chosen to install $GEES with the following settings:\n"
+  echo -e "# CPU's: \t\t\t$NUM_CPUS"
+  echo -e "Operating System: \t\t$MACHINE_OS_FRIENDLY"
+  echo -e "64 bit OS: \t\t\tYES"	# Will always be true because we exit if 32 bit OS
+  if [ $IS_NEWINSTALL == false ]; then
+    echo -e "Backup Server: \t\t\t$backupStringValue"
+  fi
+  echo -e "Publisher Root: \t\t${PUBLISHER_ROOT_VOLUME_INFO[0]}"
   echo -e "Publisher Root Mount Point: \t${PUBLISHER_ROOT_VOLUME_INFO[3]}"
-	echo -e "Install Location: \t$BASEINSTALLDIR_OPT"
-	echo -e "Postgres User: \t\t$GEPGUSER_NAME"
-	echo -e "Apache User: \t\t$GEAPACHEUSER_NAME"
-	echo -e "Group: \t\t\t$GRPNAME"
-	echo -e "Disk Space:\n"
+  echo -e "Install Location: \t\t$BASEINSTALLDIR_OPT"
+  echo -e "Postgres User: \t\t\t$GEPGUSER_NAME"
+  echo -e "Apache User: \t\t\t$GEAPACHEUSER_NAME"
+  echo -e "Group: \t\t\t\t$GRPNAME"
+  echo -e "Disk Space:\n"
 
 #	GRPNAME="gegroup"
 #	GEPGUSER_NAME="gepguser"
 
-	# display disk space
-	df -h | grep -v -E "^none"
+  # display disk space
+  df -h | grep -v -E "^none"
 
-	echo ""
+  echo ""
 
-	if ! prompt_to_quit "X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade."; then
-		return 1
-	else
-				echo -e "\nProceeding with installation..."
-		return 0
-		fi
+  if ! prompt_to_quit "X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade."; then
+    return 1
+  else
+        echo -e "\nProceeding with installation..."
+    return 0
+    fi
+}
+
+load_systemrc_config()
+{
+  if [ -f "$SYSTEMRC" ]; then
+    # read existing config information
+    ASSET_ROOT=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/assetroot/text()")
+    GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+    GRPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
+  fi
+}
+
+# Get user/group info from previous installation.  Uses user/group for particular files/directories
+get_server_installation_info()
+{
+  GEAPACHEUSER_NAME=$(get_default_user "$PUBLISHER_ROOT/search_space" $GEAPACHEUSER_NAME)
+  GRPNAME=$(get_default_group "$PUBLISHER_ROOT/search_space" $GRPNAME)
+  GEPGUSER_NAME=$(get_default_user "$PGSQL_DATA" $GEPGUSER_NAME)
+  GEFUSIONUSER_NAME=$(get_default_user "$ASSET_ROOT" $GEFUSIONUSER_NAME)
 }
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -77,7 +77,7 @@ main_preinstall()
   fi
 
   if is_package_installed "opengee-common" "opengee-common"; then
-    show_opengee_package_installed "install" "$GEES" 
+    show_opengee_package_installed "install" "$GEES"
     exit 1
   fi
 
@@ -98,6 +98,12 @@ main_preinstall()
     exit 1
   fi
 
+  # 64 bit check
+  if [[ "$(uname -i)" != "x86_64" ]]; then
+    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
+    exit 1
+  fi
+
   # 5b) Perform backup
   if [ "$BACKUPSERVER" = true ]; then
     # Backing up current Server Install...
@@ -115,12 +121,6 @@ main_preinstall()
   fi
 
   if ! check_mismatched_hostname; then
-    exit 1
-  fi
-
-  # 64 bit check
-  if [[ "$(uname -i)" != "x86_64" ]]; then
-    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
     exit 1
   fi
 

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -58,7 +58,7 @@ GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
 IS_NEWINSTALL=false
 PUBLISHER_ROOT_VOLUME_INFO=()
 ASSET_ROOT_VOLUME_INFO=()
-MIN_PUBLISER_ROOT_VALUE_IN_KB=1048576
+MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB=1048576
 
 #-----------------------------------------------------------------
 # Main Functions
@@ -381,6 +381,7 @@ check_publisher_root_volume()
   # Get size and available for publisher root volume
   PUBLISHER_ROOT_VOLUME_INFO=($(get_volume_info "$PUBLISHER_ROOT"))
 	if [[ ${PUBLISHER_ROOT_VOLUME_INFO[2]} -lt $MIN_PUBLISER_ROOT_VALUE_IN_KB ]]; then
+    MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB=$(expr $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB / 1024 / 1024)
 		echo -e "\nThe publisher root volume [$PUBLISHER_ROOT] has only ${PUBLISHER_ROOT_VOLUME_INFO[2]} KB available."
 		echo -e "We recommend that an publisher root directory have a minimum of $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB GB of free disk space."
 		echo ""

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -282,12 +282,12 @@ parse_arguments()
 				fi
 				;;
       -au)
-        if [ $IS_NEWINSTALL == false -o "$GEAPACHEUSER_NAME" != "${1// }"]; then
+				shift
+        if [ $IS_NEWINSTALL == false -a "$GEAPACHEUSER_NAME" != "${1// }"]; then
 					echo -e "\nYou cannot modify the Apache user name using the installer because $GEES is already installed on this server."
 					parse_arguments_retval=1
           break
         else
-          shift
           if is_valid_alphanumeric ${1// }; then
             GEAPACHEUSER_NAME=${1// }
           else
@@ -299,12 +299,12 @@ parse_arguments()
         fi
         ;;
       -pgu)
-        if [ $IS_NEWINSTALL == false -o "$GEPGUSER_NAME" != "${1// }" ]; then
+				shift
+        if [ $IS_NEWINSTALL == false -a "$GEPGUSER_NAME" != "${1// }" ]; then
 					echo -e "\nYou cannot modify the postgres user name using the installer because $GEES is already installed on this server."
 					parse_arguments_retval=1
           break
         else
-          shift
           if is_valid_alphanumeric ${1// }; then
             GEPGUSER_NAME=${1// }
           else
@@ -316,7 +316,8 @@ parse_arguments()
         fi
         ;;
       -g)
-        if [ $IS_NEWINSTALL == false -o $GRPNAME != ${1// } ]; then
+				shift
+        if [ $IS_NEWINSTALL == false -a $GRPNAME != ${1// } ]; then
           echo -e "\nYou cannot modify the fusion user group using the installer because Fusion is already installed on this server."
           parse_arguments_retval=1
           # Don't show the User Group dialog since it is invalid to change the fusion
@@ -324,7 +325,6 @@ parse_arguments()
           show_user_group_recommendation=false
           break
         else
-          shift
 
           if is_valid_alphanumeric ${1// }; then
             GRPNAME=${1// }

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -104,6 +104,10 @@ main_preinstall()
     exit 1
   fi
 
+	if ! prompt_install_confirmation; then
+		exit 1
+	fi
+
   # 5b) Perform backup
   if [ "$BACKUPSERVER" = true ]; then
     # Backing up current Server Install...
@@ -627,6 +631,47 @@ check_server_running()
              /var/opt/google/pgsql/logs \n
              for more details. "
   fi
+}
+
+prompt_install_confirmation()
+{
+	local backupStringValue=""
+
+	if [ $BACKUPSERVER == true ]; then
+		backupStringValue="YES"
+	else
+		backupStringValue="NO"
+	fi
+
+	echo -e "\nYou have chosen to install $GEES with the following settings:\n"
+	echo -e "# CPU's: \t\t$NUM_CPUS"
+	echo -e "Operating System: \t$MACHINE_OS_FRIENDLY"
+	echo -e "64 bit OS: \t\tYES"	# Will always be true because we exit if 32 bit OS
+	if [ $IS_NEWINSTALL == false ]; then
+		echo -e "Backup Fusion: \t\t$backupStringValue"
+	fi
+	echo -e "Install Location: \t$BASEINSTALLDIR_OPT"
+	echo -e "Asset Root: \t\t$ASSET_ROOT"
+  echo -e "Source Volume: \t\t$SOURCE_VOLUME"
+	echo -e "Fusion User: \t\t$GEFUSIONUSER_NAME"
+	echo -e "Fusion User Group: \t$GROUPNAME"
+	echo -e "Apache User: \t\t$GEAPACHEUSER_NAME"
+  echo -e "Disk Space:\n"
+
+#	GRPNAME="gegroup"
+#	GEPGUSER_NAME="gepguser"
+
+	# display disk space
+	df -h | grep -v -E "^none"
+
+	echo ""
+
+	if ! prompt_to_quit "X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade."; then
+		return 1
+	else
+        echo -e "\nProceeding with installation..."
+		return 0
+    fi
 }
 
 #-----------------------------------------------------------------


### PR DESCRIPTION
Fixes #171 

1) PUBLISH_ROOT_VOLUME size checking.
 -- Checks if available space is gt 1048576 kb  (is this a reasonable value)
 -- Determine size and mount point for the publish root directory.  Mount point so that user can ensure that proper volume is mounted.
  This information is displayed in modification 4 (see below).

WIP 2) ASSET_ROOT and PUBLISH_ROOT volume checking
 -- ASSET_ROOT volume checking is performed in install_fusion.sh (should it be duplicated in install_server.sh)
Other than size, are there addition checks that should be performed.

3) Some script parameters - parsing and execution (based on those provided by the Fusion installer)
-- Added options similar to Fusion installer:
   * -au -- Apache user option
   * -pgu -- Postgres user
   * -g -- Specifies group
   * -nobk -- Specifies not to execute backup
 
If a previous server installation is detected, user/group information is gathered from owners of specific files/directories associated with the function (i.e, GEAPACHEUSER_NAME is owner $PUBLISHER_ROOT/search_space)
If server not installed but a fusion installation detected, then group and fusion user info collected from systemrc file created by fusion installer.
If option is given, it can't specify a different user/group than used previous installation.
If new install, then defaults from previous version of script are used.
4) Prompts and summary output similar Fusion installer.
 - Created a summary output and prompt similar to Fusion installer