### PR TITLE
Add advanced parameters to geserver installer

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -76,6 +76,22 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
+          <tr>
+            <td><br><br>171</td>
+            <td>
+                PUBLISH_ROOT_VOLUME size checking<br>
+                ASSET_ROOT and PUBLISH_ROOT volume checking<br>
+                Some script parameters - parsing and execution (based on those provided by the Fusion installer)<br>
+                Prompts and summary output similar Fusion installer
+            </td>
+            <td>
+              Added PUBLISHER_ROOT size checking.<br>
+              ASSET_ROOT checking is performed in fusion installer - not duplicated in server installer<br>
+              Added <code>-pgu pguser</code>, <code>-au apacheuser</code>, and <code>-g group</code> options.<br>
+              Added prompt and summary output similar to fusion installer.
+            </td>
+          </tr>
+          <tr>
             <td>200</td>
             <td><code>stage_install</code> fails on the tutorial files when <code>/home</code>
               and <code>/tmp</code> are on different file systems</td>

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -110,7 +110,7 @@ software_check()
         if [ "$MACHINE_OS" == "$UBUNTUKEY" ] && [ ! -z "$2" ]; then
             echo -e "\nInstall $2 and restart the $1."
             software_check_retval=1
-        elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then 
+        elif { [ "$MACHINE_OS" == "$REDHATKEY" ] || [ "$MACHINE_OS" == "$CENTOSKEY" ]; } && [ ! -z "$3" ]; then
             echo -e "\nInstall $3 and restart the $1."
             software_check_retval=1
         else
@@ -420,4 +420,48 @@ prompt_to_quit()
     fi
 
     return $prompt_to_quit_retval
+}
+
+# Returns the default user
+get_default_user()
+{
+	# $1 -- is file/directory from which to obtain user
+	# $2 -- user to return if file/directory does not exist (or unable to stat file)
+	local USER=$(stat --printf="%U" $1 2> /dev/null)
+	[ -z "$USER" ] && USER=$2
+	echo "$USER"
+}
+
+# Returns the default group
+get_default_group()
+{
+	# $1 -- is file/directory from which to obtain group
+	# $2 -- group to return if file/directory does not exist (or unable to stat file)
+	local GRP=$(stat --printf="%G" $1 2> /dev/null)
+	[ -z "$GRP" ] && GRP=$2
+	echo "$GRP"
+}
+
+# For given directory, array containing directory, size, available, and mount point
+get_volume_info()
+{
+	local info=()
+	local DIR=$1
+
+	# Check if dir exists.  If so, do a df at this point
+	while true; do
+		if [ -d "$DIR" ] ; then
+			info=($1 $(df -k $DIR --output=size,avail,target | tail -1))
+			break
+		fi
+
+		# Drop last part of path and retry
+		DIR=${DIR%/*}
+		# Check if reached the root
+		if [ -z $DIR ]; then
+			info=($1 $(df -k / --output=size,avail,target | tail -1))
+			break
+		fi
+	done
+	echo "${info[@]}"
 }

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -25,6 +25,7 @@ SCRIPTDIR=`dirname $0`
 . $SCRIPTDIR/common.sh
 
 # config values
+ASSET_ROOT="/gevol/assets"
 PUBLISHER_ROOT="/gevol/published_dbs"
 INSTALL_LOG="$INSTALL_LOG_DIR/geserver_install_$(date +%Y_%m_%d.%H%M%S).log"
 BACKUP_DIR="$BASEINSTALLDIR_VAR/server-backups/$(date +%Y_%m_%d.%H%M%S)"
@@ -34,15 +35,6 @@ BACKUP_DATA_DIR=$BACKUP_DIR/data.backup
 BACKUPSERVER=true
 BADHOSTNAMEOVERRIDE=false
 MISMATCHHOSTNAMEOVERRIDE=false
-DEFAULTGROUPNAME="gegroup"
-GROUPNAME=$DEFAULTGROUPNAME
-
-# user names
-GRPNAME="gegroup"
-GEPGUSER_NAME="gepguser"
-GEAPACHEUSER_NAME="geapacheuser"
-DEFAULTGEFUSIONUSER_NAME="gefusionuser"
-GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
 
 SERVER_INSTALL_OR_UPGRADE="install"
 GEE_CHECK_CONFIG_SCRIPT="/opt/google/gehttpd/cgi-bin/set_geecheck_config.py"
@@ -52,6 +44,20 @@ PGSQL_PROGRAM="/opt/google/bin/pg_ctl"
 PRODUCT_NAME="$GEE"
 START_SERVER_DAEMON=1
 PROMPT_FOR_START="n"
+
+# user names
+DEFAULTGROUPNAME="gegroup"
+GRPNAME=$DEFAULTGROUPNAME
+GEAPACHEUSER_NAME="geapacheuser"
+GEPGUSER_NAME="gepguser"
+DEFAULTGEFUSIONUSER_NAME="gefusionuser"
+GEFUSIONUSER_NAME=$DEFAULTGEFUSIONUSER_NAME
+
+# addition variables
+IS_NEWINSTALL=false
+FUSION_INSTALLED=false
+PUBLISHER_ROOT_VOLUME_INFO=()
+MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB=1048576
 
 #-----------------------------------------------------------------
 # Main Functions
@@ -67,6 +73,22 @@ main_preinstall()
     exit 1
   fi
 
+  # Check if a new install
+  if [ -f "$GESERVERBININSTALL" ]; then
+    # Get usernames that were used in previous installation
+    IS_NEWINSTALL=false
+    get_server_installation_info
+  else
+    IS_NEWINSTALL=true
+    BACKUPSERVER=false
+    # If fusion has been installed, get fusion user and group name used in fusion install
+    if [ -f "$FUSIONBININSTALL" ] && [ -f "$SYSTEMRC" ]; then
+      GRPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
+      GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+      FUSION_INSTALLED=true
+    fi
+  fi
+
   # Argument check
   if ! parse_arguments "$@"; then
     exit 1
@@ -77,7 +99,7 @@ main_preinstall()
   fi
 
   if is_package_installed "opengee-common" "opengee-common"; then
-    show_opengee_package_installed "install" "$GEES" 
+    show_opengee_package_installed "install" "$GEES"
     exit 1
   fi
 
@@ -98,15 +120,33 @@ main_preinstall()
     exit 1
   fi
 
+  # 64 bit check
+  if [[ "$(uname -i)" != "x86_64" ]]; then
+    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
+    exit 1
+  fi
+
+  # 10) Configure Publish Root
+  configure_publish_root
+
+  # Check publisher root volume size
+  if ! check_publisher_root_volume; then
+    exit 1
+  fi
+
+  if ! prompt_install_confirmation; then
+    exit 1
+  fi
+
   # 5b) Perform backup
   if [ "$BACKUPSERVER" = true ]; then
     # Backing up current Server Install...
     backup_server
-  fi
 
-  # Backup PGSQL data
-  if [ -d "$PGSQL_DATA" ]; then
-    backup_pgsql_data
+    # Backup PGSQL data
+    if [ -d "$PGSQL_DATA" ]; then
+      backup_pgsql_data
+    fi
   fi
 
   # 6) Check valid host properties
@@ -118,20 +158,12 @@ main_preinstall()
     exit 1
   fi
 
-  # 64 bit check
-  if [[ "$(uname -i)" != "x86_64" ]]; then
-    echo -e "\n$GEES $LONG_VERSION can only be installed on a 64 bit operating system."
-    exit 1
-  fi
-
   # 8) Check if group and users exist
   check_group
 
   check_username "$GEAPACHEUSER_NAME"
   check_username "$GEPGUSER_NAME"
 
-  # 10) Configure Publish Root
-  configure_publish_root
 }
 
 check_prereq_software()
@@ -207,12 +239,18 @@ show_intro()
 # TODO: Add additional parameters for GEE Server
 show_help()
 {
-  echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf]\n"
-
+  echo -e "\nUsage: \tsudo ./install_server.sh [-h] [-dir /tmp/fusion_os_install -hnf -hnmf] [-pgu gepguser]"
+  echo -e "\t\t[-au geapacheuser] [-g gegroup] [-nobk]"
+  echo -e "\n"
   echo -e "-h --help \tHelp - display this help screen"
   echo -e "-dir \t\tTemp Install Directory - specify the temporary install directory. Default is [$TMPINSTALLDIR]."
   echo -e "-hnf \t\tHostname Force - force the installer to continue installing with a bad \n\t\thostname. Bad hostname values are [${BADHOSTNAMELIST[*]}]."
-  echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname.\n"
+  echo -e "-hnmf \t\tHostname Mismatch Force - force the installer to continue installing with a \n\t\tmismatched hostname."
+  echo -e "-au \t\tApache user name. Default is [$GEAPACHEUSER_NAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-pgu \t\tPostgres user name. Default is [$GEPGUSER_NAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-g \t\tUser Group Name - the group name to use for the Server, Postgress, and Apache user. Default is [$GRPNAME]. \n\t\tNote: this is only used for new installations."
+  echo -e "-nobk \t\tNo Backup - do not backup the current server setup. Default is to backup \n\t\tserver before installing."
+  echo -e "\n"
 }
 
 # TODO convert to common function
@@ -236,6 +274,9 @@ parse_arguments()
         parse_arguments_retval=1
         break
         ;;
+      -nobk)
+        BACKUPSERVER=false
+        ;;
       -hnf)
         BADHOSTNAMEOVERRIDE=true;
         ;;
@@ -252,12 +293,71 @@ parse_arguments()
           break
         fi
         ;;
-      *)
-        echo -e "\nArgument Error: $1 is not a valid argument."
-        show_help
-        parse_arguments_retval=1
-        break
+      -au)
+        shift
+        if [ $IS_NEWINSTALL = false ] && [ "$GEAPACHEUSER_NAME" != "${1// }" ]; then
+          echo -e "\nYou cannot modify the Apache user name using the installer because $GEES is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          if is_valid_alphanumeric ${1// }; then
+            GEAPACHEUSER_NAME=${1// }
+          else
+            echo -e "\nThe Apache user name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
         ;;
+      -pgu)
+        shift
+        if [ $IS_NEWINSTALL == false ] && [ "$GEPGUSER_NAME" != "${1// }" ]; then
+          echo -e "\nYou cannot modify the postgres user name using the installer because $GEES is already installed on this server."
+          parse_arguments_retval=1
+          break
+        else
+          if is_valid_alphanumeric ${1// }; then
+            GEPGUSER_NAME=${1// }
+          else
+            echo -e "\nThe Postgres user name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The user name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+        ;;
+      -g)
+        shift
+        if [ $IS_NEWINSTALL == false ] && [ $GRPNAME != ${1// } ]; then
+          echo -e "\nYou cannot modify the $GEES user group using the installer because $GEES is already installed on this server."
+          parse_arguments_retval=1
+          # Don't show the User Group dialog since it is invalid to change the fusion
+          # username once fusion is installed on the server
+          show_user_group_recommendation=false
+          break
+        elif [ $FUSION_INSTALLED == true ] && [ $GRPNAME != ${1// } ]; then
+          echo -e "\nYou specified a different group ($1) than for fusion installation ($GRPNAME)"
+          echo -e "You must use the same group for both Fusion and Server"
+          parse_arguments_retval=1
+          break
+        else
+          if is_valid_alphanumeric ${1// }; then
+            GRPNAME=${1// }
+          else
+            echo -e "\nThe group name you specified is not valid. Valid characters are upper/lowercase letters, "
+            echo -e "numbers, dashes and the underscore characters. The group name cannot start with a number or dash."
+            parse_arguments_retval=1
+            break
+          fi
+        fi
+      ;;
+    *)
+      echo -e "\nArgument Error: $1 is not a valid argument."
+      show_help
+      parse_arguments_retval=1
+      break
+      ;;
     esac
 
     if [ $# -gt 0 ]
@@ -282,6 +382,25 @@ configure_publish_root()
   if [ -e "$STREAM_SPACE" ]; then
     PUBLISHER_ROOT=`cat $STREAM_SPACE | cut -d" " -f3 | sed 's/.\{13\}$//'`
   fi
+}
+
+check_publisher_root_volume()
+{
+  local check_publisher_root_volume_retval=0
+  # Get size and available for publisher root volume
+  PUBLISHER_ROOT_VOLUME_INFO=($(get_volume_info "$PUBLISHER_ROOT"))
+  if [[ ${PUBLISHER_ROOT_VOLUME_INFO[2]} -lt $MIN_PUBLISER_ROOT_VALUE_IN_KB ]]; then
+    MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB=$(expr $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_KB / 1024 / 1024)
+    echo -e "\nThe publisher root volume [$PUBLISHER_ROOT] has only ${PUBLISHER_ROOT_VOLUME_INFO[2]} KB available."
+    echo -e "We recommend that an publisher root directory have a minimum of $MIN_PUBLISHER_ROOT_VOLUME_SIZE_IN_GB GB of free disk space."
+    echo ""
+
+    if ! prompt_to_quit "X (Exit) the installer and change the asset root location with larger volume - C (Continue) to use the asset root that you have specified."; then
+        check_publisher_root_volume_retval=1
+    fi
+  fi
+
+  return $check_publisher_root_volume_retval
 }
 
 backup_pgsql_data()
@@ -627,6 +746,81 @@ check_server_running()
              /var/opt/google/pgsql/logs \n
              for more details. "
   fi
+}
+
+# Candidate to move to common
+is_valid_alphanumeric()
+{
+  # Standard function that tests a string to see if it passes the "valid" alphanumeric for user name and group name.
+  # For simplicity -- we limit to letters, numbers and underscores.
+  regex="^[a-zA-Z_]{1}[a-zA-Z0-9_-]*$"
+
+  if [ ! -z "$1" ] && [[ $1 =~ $regex ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Show config values and prompt user for confirmation to continue install
+prompt_install_confirmation()
+{
+  local backupStringValue=""
+
+  if [ $BACKUPSERVER == true ]; then
+    backupStringValue="YES"
+  else
+    backupStringValue="NO"
+  fi
+
+  echo -e "\nYou have chosen to install $GEES with the following settings:\n"
+  echo -e "# CPU's: \t\t\t$NUM_CPUS"
+  echo -e "Operating System: \t\t$MACHINE_OS_FRIENDLY"
+  echo -e "64 bit OS: \t\t\tYES"	# Will always be true because we exit if 32 bit OS
+  if [ $IS_NEWINSTALL == false ]; then
+    echo -e "Backup Server: \t\t\t$backupStringValue"
+  fi
+  echo -e "Publisher Root: \t\t${PUBLISHER_ROOT_VOLUME_INFO[0]}"
+  echo -e "Publisher Root Mount Point: \t${PUBLISHER_ROOT_VOLUME_INFO[3]}"
+  echo -e "Install Location: \t\t$BASEINSTALLDIR_OPT"
+  echo -e "Postgres User: \t\t\t$GEPGUSER_NAME"
+  echo -e "Apache User: \t\t\t$GEAPACHEUSER_NAME"
+  echo -e "Group: \t\t\t\t$GRPNAME"
+  echo -e "Disk Space:\n"
+
+#	GRPNAME="gegroup"
+#	GEPGUSER_NAME="gepguser"
+
+  # display disk space
+  df -h | grep -v -E "^none"
+
+  echo ""
+
+  if ! prompt_to_quit "X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade."; then
+    return 1
+  else
+        echo -e "\nProceeding with installation..."
+    return 0
+    fi
+}
+
+load_systemrc_config()
+{
+  if [ -f "$SYSTEMRC" ]; then
+    # read existing config information
+    ASSET_ROOT=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/assetroot/text()")
+    GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
+    GRPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
+  fi
+}
+
+# Get user/group info from previous installation.  Uses user/group for particular files/directories
+get_server_installation_info()
+{
+  GEAPACHEUSER_NAME=$(get_default_user "$PUBLISHER_ROOT/search_space" $GEAPACHEUSER_NAME)
+  GRPNAME=$(get_default_group "$PUBLISHER_ROOT/search_space" $GRPNAME)
+  GEPGUSER_NAME=$(get_default_user "$PGSQL_DATA" $GEPGUSER_NAME)
+  GEFUSIONUSER_NAME=$(get_default_user "$ASSET_ROOT" $GEFUSIONUSER_NAME)
 }
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -25,7 +25,6 @@ SCRIPTDIR=`dirname $0`
 . $SCRIPTDIR/common.sh
 
 # config values
-ASSET_ROOT="/gevol/assets"
 PUBLISHER_ROOT="/gevol/published_dbs"
 INSTALL_LOG="$INSTALL_LOG_DIR/geserver_install_$(date +%Y_%m_%d.%H%M%S).log"
 BACKUP_DIR="$BASEINSTALLDIR_VAR/server-backups/$(date +%Y_%m_%d.%H%M%S)"
@@ -804,23 +803,12 @@ prompt_install_confirmation()
     fi
 }
 
-load_systemrc_config()
-{
-  if [ -f "$SYSTEMRC" ]; then
-    # read existing config information
-    ASSET_ROOT=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/assetroot/text()")
-    GEFUSIONUSER_NAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/fusionUsername/text()")
-    GRPNAME=$(xml_file_get_xpath "$SYSTEMRC" "//Systemrc/userGroupname/text()")
-  fi
-}
-
 # Get user/group info from previous installation.  Uses user/group for particular files/directories
 get_server_installation_info()
 {
   GEAPACHEUSER_NAME=$(get_default_user "$PUBLISHER_ROOT/search_space" $GEAPACHEUSER_NAME)
   GRPNAME=$(get_default_group "$PUBLISHER_ROOT/search_space" $GRPNAME)
   GEPGUSER_NAME=$(get_default_user "$PGSQL_DATA" $GEPGUSER_NAME)
-  GEFUSIONUSER_NAME=$(get_default_user "$ASSET_ROOT" $GEFUSIONUSER_NAME)
 }
 
 #-----------------------------------------------------------------


### PR DESCRIPTION
Fixes #171

PUBLISH_ROOT_VOLUME size checking.
-- Checks if available space is gt 1048576 kb (is this a reasonable value)
-- Determine size and mount point for the publish root directory. Mount point so that user can ensure that proper volume is mounted.
This information is displayed in modification 4 (see below).
WIP 2) ASSET_ROOT and PUBLISH_ROOT volume checking
-- ASSET_ROOT volume checking is performed in install_fusion.sh (should it be duplicated in install_server.sh)
Other than size, are there addition checks that should be performed.

Some script parameters - parsing and execution (based on those provided by the Fusion installer)
-- Added options similar to Fusion installer:
-au -- Apache user option
-pgu -- Postgres user
-g -- Specifies group
-nobk -- Specifies not to execute backup
If a previous server installation is detected, user/group information is gathered from owners of specific files/directories associated with the function (i.e, GEAPACHEUSER_NAME is owner $PUBLISHER_ROOT/search_space)
If server not installed but a fusion installation detected, then group and fusion user info collected from systemrc file created by fusion installer.
If option is given, it can't specify a different user/group than used previous installation.
If new install, then defaults from previous version of script are used.
4) Prompts and summary output similar Fusion installer.

Created a summary output and prompt similar to Fusion installer
