### PR TITLE
I1228 Add y-scroll-bar to webpage

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -154,7 +154,7 @@ gtag('config', 'UA-108632131-2');
           </tr>
           <tr>
             <td>1228</td>
-            <td>Insufficient screen real estate for 'Assemble' button</td>
+            <td>Assemble button is not fully visible, making it difficult to use the GLC assembly tool</td>
             <td>
               Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
             </td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -152,6 +152,14 @@ gtag('config', 'UA-108632131-2');
               Added an experimental option that fixes several memory leaks related to our usage of the Xerces library.
             </td>
           </tr>
+          <tr>
+            <td>1228</td>
+            <td>Insufficient screen real estate for 'Assemble' button</td>
+            <td>
+              Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
+            </td>
+          </tr>
+
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/glc_style.css
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/glc_style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google Inc., 2019 the Open GEE Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ body {
   left: 0px;
   right: 0;
   bottom: 0;
+  overflow-y: scroll;
 }
 
 #right_bar h2 {


### PR DESCRIPTION
Fixes #1228 

Insufficient screen real estate for button on glc-assembly webpage under Firefox:

1. Navigate to Fusion Server admin page (127.0.0.1/admin)
2. Click on tool bar button ("gear" icon on right-hand side of page)
3. Select "Glc Assembly" - a pop-up window appears titled "GLC assembly tool"
4. Fill in 'name', 'title', and dummy text into 'polygon' fields.
5. Click on 'Layers' "3d" radio button
6. Scroll to bottom of page
7. View "Assemble" button at bottom of window.