### PR TITLE
I1225 Re-add GROUPNAME to install_server.sh

### DIFF
--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -46,6 +46,8 @@ PROMPT_FOR_START="n"
 
 # user names
 DEFAULTGROUPNAME="gegroup"
+# $GROUPNAME is used in common.sh by the check_group and check_username functions
+GROUPNAME=$DEFAULTGROUPNAME
 GRPNAME=$DEFAULTGROUPNAME
 GEAPACHEUSER_NAME="geapacheuser"
 GEPGUSER_NAME="gepguser"


### PR DESCRIPTION
Re-add "GROUPNAME" variable to 'install_server.sh'.



```
[centos@tstserver installer]$ sudo ./install_server.sh 

Welcome to the Google Earth Enterprise Server 5.2.5.1 installer.

Checking geserver services:
postgres service: false
gehttpd service: false
wsgi service: false

You have chosen to install Google Earth Enterprise Server with the following settings:

# CPU's: 			2
Operating System: 		CentOS Linux 7
64 bit OS: 			YES
Publisher Root: 		/gevol/published_dbs
Publisher Root Mount Point: 	/
Install Location: 		/opt/google
Postgres User: 			gepguser
Apache User: 			geapacheuser
Group: 				gegroup
Disk Space:

Filesystem      Size  Used Avail Use% Mounted on
/dev/xvda1       60G  9.4G   51G  16% /
devtmpfs        1.9G     0  1.9G   0% /dev
tmpfs           1.9G  4.0K  1.9G   1% /dev/shm
tmpfs           1.9G   18M  1.9G   1% /run
tmpfs           1.9G     0  1.9G   0% /sys/fs/cgroup
tmpfs           379M   28K  379M   1% /run/user/1000
tmpfs           379M     0  379M   0% /run/user/0

X (Exit) the installer and cancel the installation - C (Continue) to install/upgrade. c

Proceeding with installation...

Copying files from source to target directories...DONE
Setting up system links...DONE
Starting server
waiting for server to start.... done
server started
Creating geserve-databases...
 create_or_update_tables 
-------------------------
 
(1 row)

 create_tables 
---------------
 
(1 row)

 run_searchdef_upsert 
----------------------
 
(1 row)

CREATE EXTENSION
Done.
waiting for server to shut down.... done
server stopped
upgrade done
pgsql_data
/var/opt/google/pgsql/data
The PostgreSQL component is successfully installed.
Setting up the geserver daemon...
GEE Server daemon setup ... DONE
Publishroot creation succeeded.
Please restart your server to apply the change.
# a) Start the PSQL Server 
waiting for server to start.... done
server started
# b) Install GEPlaces Database
Creating GEPLACES database...
CREATE EXTENSION
# c) Install SearchExample Database 
Creating SEARCH EXAMPLE database...
CREATE EXTENSION
# d) Stop the PSQL Server
waiting for server to shut down.... done
server stopped
Do you want to start the Google Earth Enterprise Server Service(y/n)?
y
--------------------------------------------------------------------
waiting for server to start.... done
server started

--------------------------------------------------------------------
Google Earth Enterprise Server for RedHat
Starting gehttpd: SetGlobeDirectory: /opt/google/gehttpd/htdocs/cutter/globes/
[  OK  ]

--------------------------------------------------------------------
Done Starting Google Earth Enterprise Server


Checking geserver services:
postgres service: true
gehttpd service: true
wsgi service: false
Congratulations! Google Earth Enterprise has been successfully installed in the following directory:
          /opt/google 

          Start Google Earth Enterprise Server with the following command:
          /etc/init.d/geserver start
[centos@tstserver installer]$
```