### PR TITLE
#1201 - Fix issue with setting source date when using .kip directories

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -190,9 +190,12 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                                     inset.alphaRPFile,
                                     std::string(), /* cached blend */
                                     std::string()  /* cached blend alpha */));
+        std::string acquisitionDate = inset.resource_->GetAcquisitionDate();
+
         packetLevelConfig.attributions.push_back
           (PacketLevelConfig::Attribution(
               inset.dataRPFile,
+              acquisitionDate,
               inset.combinedrp_->config.fuid_resource_));
       }
     } else {
@@ -221,9 +224,12 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       for (std::vector<uint>::const_iterator idx = neededIndexes.begin();
            idx != neededIndexes.end(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[*idx]);
+        std::string acquisitionDate = inset.resource_->GetAcquisitionDate();
+
         packetLevelConfig.attributions.push_back
           (PacketLevelConfig::Attribution(
               inset.dataRPFile,
+              acquisitionDate,
               inset.combinedrp_->config.fuid_resource_));
       }
 

--- a/earth_enterprise/src/fusion/autoingest/storage/PacketLevelConfig.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/PacketLevelConfig.idl
@@ -48,6 +48,7 @@ class PacketLevelConfig {
 
   class Attribution {
     std::string dataRP;
+    std::string acquisitionDate;
     uint32      fuid_resource_;
   };
 

--- a/earth_enterprise/src/fusion/khraster/AttributionByExtents.cpp
+++ b/earth_enterprise/src/fusion/khraster/AttributionByExtents.cpp
@@ -29,7 +29,7 @@ AttributionByExtents::Inset::Inset(const std::string &rppath, uint32 id, const s
   }
   max_level_   = rp->maxLevel();
   deg_extents_ = rp->degOrMeterExtents();
-  if (acquisitionDate != kUnknownDateTimeUTC) {
+  if (acquisitionDate != kUnknownDateTimeUTC && acquisitionDate != kUnknownDate) {
     acquisition_date_ = acquisitionDate;
   } else {
     acquisition_date_ = rp->GetAcquisitionDate();

--- a/earth_enterprise/src/fusion/khraster/AttributionByExtents.cpp
+++ b/earth_enterprise/src/fusion/khraster/AttributionByExtents.cpp
@@ -20,7 +20,7 @@
 #include <khTileAddr.h>
 #include <common/khConstants.h>
 
-AttributionByExtents::Inset::Inset(const std::string &rppath, uint32 id) :
+AttributionByExtents::Inset::Inset(const std::string &rppath, uint32 id, const std::string &acquisitionDate) :
     inset_id_(id)
 {
   khDeleteGuard<khRasterProduct> rp(khRasterProduct::Open(rppath));
@@ -29,7 +29,11 @@ AttributionByExtents::Inset::Inset(const std::string &rppath, uint32 id) :
   }
   max_level_   = rp->maxLevel();
   deg_extents_ = rp->degOrMeterExtents();
-  acquisition_date_ = rp->GetAcquisitionDate();
+  if (acquisitionDate != kUnknownDateTimeUTC) {
+    acquisition_date_ = acquisitionDate;
+  } else {
+    acquisition_date_ = rp->GetAcquisitionDate();
+  }
 }
 
 uint32 AttributionByExtents::GetInternalInsetIndex(const khTileAddr &addr)

--- a/earth_enterprise/src/fusion/khraster/AttributionByExtents.h
+++ b/earth_enterprise/src/fusion/khraster/AttributionByExtents.h
@@ -33,7 +33,7 @@ class AttributionByExtents {
     uint32            inset_id_;
     std::string       acquisition_date_;
 
-    Inset(const std::string &rppath, uint32 id);
+    Inset(const std::string &rppath, uint32 id, const std::string &acquisitionDate);
   };
 
   // will we ordered low-res to high-res
@@ -42,8 +42,8 @@ class AttributionByExtents {
 public:
   AttributionByExtents(void) { }
 
-  void AddInset(const std::string &rppath, uint32 id) {
-    insets.push_back(Inset(rppath, id));
+  void AddInset(const std::string &rppath, uint32 id, const std::string &acquisitionDate) {
+    insets.push_back(Inset(rppath, id, acquisitionDate));
   }
 
   // Return the inset id for the most significant inset for the

--- a/earth_enterprise/src/fusion/rasterfuse/PackgenTraverserImpl.h
+++ b/earth_enterprise/src/fusion/rasterfuse/PackgenTraverserImpl.h
@@ -56,7 +56,11 @@ PackgenTraverser<Config>::PackgenTraverser(
        attribution != config.attributions.end(); ++attribution) {
     if (!attribution->dataRP.empty() &&
         (attribution->fuid_resource_ != 0)) {
-      attributions.AddInset(attribution->dataRP, attribution->fuid_resource_);
+      std::string acquisitionDate = kUnknownDateTimeUTC;
+      if (!attribution->acquisitionDate.empty()) {
+        acquisitionDate = attribution->acquisitionDate;
+      }
+      attributions.AddInset(attribution->dataRP, attribution->fuid_resource_, acquisitionDate);
     }
   }
 }

--- a/earth_enterprise/src/fusion/tools/gerasterpackupgrade.cpp
+++ b/earth_enterprise/src/fusion/tools/gerasterpackupgrade.cpp
@@ -137,7 +137,8 @@ int main(int argc, char *argv[]) {
              attribution = config.attributions.begin();
            attribution != config.attributions.end(); ++attribution) {
         attributions.AddInset(attribution->dataRP,
-                              attribution->fuid_resource_);
+                              attribution->fuid_resource_,
+                              kUnknownDate);
       }
     }
 

--- a/earth_enterprise/src/fusion/tools/gerasterpackupgrade.cpp
+++ b/earth_enterprise/src/fusion/tools/gerasterpackupgrade.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
            attribution != config.attributions.end(); ++attribution) {
         attributions.AddInset(attribution->dataRP,
                               attribution->fuid_resource_,
-                              kUnknownDate);
+                              kUnknownDateTimeUTC);
       }
     }
 


### PR DESCRIPTION
Verification steps:
1. Build 2 imagery resources with date set (suggestion: Blue Marble and usgsLanSat from tutorial)
1. Copy the 2 prebuilt resources into source directory, for Blue Marble just get the product raster.kip directory (you can rename it), for the USGS image get the whole asset (name.kiasset directory)
1. Create imagery resources using command line utility e.g. `genewimageryresource -o Resources/Imagery/usgsLanSat_kip1 /gevol/src/Imagery/usgsLanSat.kiasset/product.kia/ver001/raster.kip`
1. Before building the images, set a unique date for the new Blue Marble resource
1. Create a new Imagery project and database for the 2 new resources
1. Build and publish database
1. Load published database in Google Earth EC
1. The date for Blue Marble should be the new date set for the resource while the USGS image should be the original date that was set

Notes:
* If you end up changing a date, you will need to clean the resource version and rebuild the project and database before the new date will be used