### PR TITLE
Increase performance logging

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -104,7 +104,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   timespec prevTime;
   timespec curTime;
   clock_gettime(CLOCK_MONOTONIC, &prevTime);
-  notify(NFY_PROGRESS, "Starting UpdateChildren for %s", assetRef.c_str());
+  notify(NFY_PROGRESS, "UpdateChildren starting for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
   // the next lower resolution level
@@ -113,7 +113,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     --level;
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "UpdateChildren starting to find needed insets for level %d.  %ld.%09ld seconds elapsed",
+           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Determine which insets intersect us at this level
@@ -135,7 +136,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     }
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "Finished finding insets for level %d. %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "UpdateChildren finished finding insets for level %d. %ld.%09ld seconds elapsed",
+           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Build most of PacketLevelConfig
@@ -181,7 +183,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       // ***** Normal Blend *****
 
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren starting normal blend for level %d.  %ld.%09ld seconds elapsed",
+             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // we cache the raster if we're in the appropriate range
@@ -213,13 +216,15 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed", level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren normal blend level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed",
+             level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
     } else {
       // ***** Minify *****
 
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Starting to minification for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren starting minification for level %d.  %ld.%09ld seconds elapsed",
+             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
       // if we want to short circuit the merge with opaque product
       // tiles, fill in the info about our top product
@@ -251,7 +256,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed", level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren packet level attributions for level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed",
+             level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // for insets we only care about those that have done work at
@@ -266,7 +272,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %ld.%09ld seconds elapsed", level, mergeIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren finished adding to mergeIndexes for level %d result is %lu items.  %ld.%09ld seconds elapsed",
+             level, mergeIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // populate inputs and inputVers & config.insets
@@ -357,7 +364,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      notify(NFY_PROGRESS, "UpdateChildren finished looping over mergeIndexes for level %d.  %ld.%09ld seconds elapsed",
+             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
       clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       if (config.cacheRaster) {
@@ -389,7 +397,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
 
         clock_gettime(CLOCK_MONOTONIC, &curTime);
-        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+        notify(NFY_PROGRESS, "UpdateChildren finished cacheRaster block for level %d.  %ld.%09ld seconds elapsed",
+               level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
         clock_gettime(CLOCK_MONOTONIC, &prevTime);
       }
 
@@ -409,14 +418,16 @@ void PacketGenAssetVersionImplD::UpdateChildren(
 
     kids.push_back(packLevelVer);
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "Finished all work for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "UpdateChildren finished all work for level %d.  %ld.%09ld seconds elapsed",
+           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
   } // foreach level
 
   AddChildren(kids);
   clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "Finished adding all children.  %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  notify(NFY_PROGRESS, "UpdateChildren finished adding all children.  %ld.%09ld seconds elapsed",
+         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -104,7 +104,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   std::chrono::high_resolution_clock::time_point prevTime = std::chrono::high_resolution_clock::now();
   std::chrono::high_resolution_clock::time_point curTime;
   std::chrono::duration<double> timeDiff; 
-  notify(NFY_PROGRESS, "UpdateChildren starting for %s", assetRef.c_str());
+  notify(NFY_INFO2, "UpdateChildren starting for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
   // the next lower resolution level
@@ -113,8 +113,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     --level;
 
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "UpdateChildren starting to find needed insets for level %d.  %f seconds elapsed",
+    // note: this will give a floating point difference in seconds
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "UpdateChildren starting to find needed insets for level %d.  %f seconds elapsed",
            level, timeDiff.count());
     prevTime = curTime;
 
@@ -137,8 +138,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     }
 
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "UpdateChildren finished finding insets for level %d. %f seconds elapsed",
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "UpdateChildren finished finding insets for level %d. %f seconds elapsed",
            level, timeDiff.count());
     prevTime = curTime;
 
@@ -185,8 +186,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       // ***** Normal Blend *****
 
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren starting normal blend for level %d.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren starting normal blend for level %d.  %f seconds elapsed",
              level, timeDiff.count());
       prevTime = curTime;
 
@@ -219,16 +220,16 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren normal blend level %d finished inner loop over %lu other insets.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren normal blend level %d finished inner loop over %lu other insets.  %f seconds elapsed",
              level, neededIndexes.size(), timeDiff.count());
       prevTime = curTime;
     } else {
       // ***** Minify *****
 
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren starting minification for level %d.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren starting minification for level %d.  %f seconds elapsed",
              level, timeDiff.count());
       prevTime = curTime;
       // if we want to short circuit the merge with opaque product
@@ -261,8 +262,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren packet level attributions for level %d finished inner loop over %lu other insets.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren packet level attributions for level %d finished inner loop over %lu other insets.  %f seconds elapsed",
              level, neededIndexes.size(), timeDiff.count());
       prevTime = curTime;
 
@@ -278,8 +279,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren finished adding to mergeIndexes for level %d result is %lu items.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren finished adding to mergeIndexes for level %d result is %lu items.  %f seconds elapsed",
              level, mergeIndexes.size(), timeDiff.count());
       prevTime = curTime;
 
@@ -371,8 +372,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       }
 
       curTime = std::chrono::high_resolution_clock::now();
-      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-      notify(NFY_PROGRESS, "UpdateChildren finished looping over mergeIndexes for level %d.  %f seconds elapsed",
+      timeDiff = std::chrono::duration<double>(curTime - prevTime);
+      notify(NFY_INFO2, "UpdateChildren finished looping over mergeIndexes for level %d.  %f seconds elapsed",
              level, timeDiff.count());
       prevTime = curTime;
 
@@ -405,8 +406,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
 
         curTime = std::chrono::high_resolution_clock::now();
-        timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-        notify(NFY_PROGRESS, "UpdateChildren finished cacheRaster block for level %d.  %f seconds elapsed",
+        timeDiff = std::chrono::duration<double>(curTime - prevTime);
+        notify(NFY_INFO2, "UpdateChildren finished cacheRaster block for level %d.  %f seconds elapsed",
                level, timeDiff.count());
         prevTime = curTime;
       }
@@ -427,8 +428,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
 
     kids.push_back(packLevelVer);
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "UpdateChildren finished all work for level %d.  %f seconds elapsed",
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "UpdateChildren finished all work for level %d.  %f seconds elapsed",
            level, timeDiff.count());
     prevTime = curTime;
 
@@ -436,8 +437,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
 
   AddChildren(kids);
   curTime = std::chrono::high_resolution_clock::now();
-  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-  notify(NFY_PROGRESS, "UpdateChildren finished adding all children.  %f seconds elapsed",
+  timeDiff = std::chrono::duration<double>(curTime - prevTime);
+  notify(NFY_INFO2, "UpdateChildren finished adding all children.  %f seconds elapsed",
          timeDiff.count());
 }
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -44,7 +44,7 @@ class PacketGenExtraUpdateArg {
 #include <autoingest/sysman/plugins/PacketLevelAssetD.h>
 #include <autoingest/plugins/RasterProductAsset.h>
 #include <autoingest/plugins/MercatorRasterProductAsset.h>
-#include <ctime>
+#include <chrono>
 
 
 template
@@ -101,7 +101,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   std::vector<MutableAssetVersionD> kids;
   kids.reserve(numLevels);
 
-  time_t prevClock = clock();
+  auto prevClock = std::chrono::system_clock::now().time_since_epoch().count();
   notify(NFY_PROGRESS, "Starting UpdateChildren for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
@@ -110,8 +110,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   while (level > config.coverage.beginLevel()) {
     --level;
 
-    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
     // Determine which insets intersect us at this level
     const khLevelCoverage levCov(config.coverage.levelCoverage(level));
@@ -131,8 +131,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                               config.endMinifyLevel);
     }
 
-    notify(NFY_PROGRESS, "Finished finding insets for level %d. %lu ticks elapsed", level, clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "Finished finding insets for level %d. %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
     // Build most of PacketLevelConfig
     PacketLevelConfig packetLevelConfig;
@@ -176,8 +176,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     if (!packetLevelConfig.minify) {
       // ***** Normal Blend *****
 
-      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
       // we cache the raster if we're in the appropriate range
       // and if we've been told to (because we have alpha)
@@ -207,13 +207,13 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.dataRPFile,
               inset.combinedrp_->config.fuid_resource_));
       }
-      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
     } else {
       // ***** Minify *****
 
-      notify(NFY_PROGRESS, "Starting to minification for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Starting to minification for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
       // if we want to short circuit the merge with opaque product
       // tiles, fill in the info about our top product
       if (config.useOpaqueTopInsetInsteadOfMerge) {
@@ -243,8 +243,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
 
-      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
       // for insets we only care about those that have done work at
       // minifySrcLevel
@@ -257,8 +257,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %lu ticks elapsed", level, mergeIndexes.size(), clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %lu ticks elapsed", level, mergeIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
       // populate inputs and inputVers & config.insets
       levInputs.reserve(mergeIndexes.size() * 2 + 1);
@@ -347,8 +347,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-      prevClock = clock();
+      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
       if (config.cacheRaster) {
         // If I've cached my raster blends, I should
@@ -378,8 +378,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               cache_alpha_exist ?
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
 
-        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-        prevClock = clock();
+        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+        prevClock = std::chrono::system_clock::now().time_since_epoch().count();
       }
 
     }
@@ -397,13 +397,13 @@ void PacketGenAssetVersionImplD::UpdateChildren(
        levInputVers);
 
     kids.push_back(packLevelVer);
-    notify(NFY_PROGRESS, "Finished all work for level %d.  %lu ticks elapsed", level, clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "Finished all work for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
   } // foreach level
 
   AddChildren(kids);
-  notify(NFY_PROGRESS, "Finished adding all children.  %lu ticks elapsed", clock()-prevClock);
+  notify(NFY_PROGRESS, "Finished adding all children.  %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -44,7 +44,7 @@ class PacketGenExtraUpdateArg {
 #include <autoingest/sysman/plugins/PacketLevelAssetD.h>
 #include <autoingest/plugins/RasterProductAsset.h>
 #include <autoingest/plugins/MercatorRasterProductAsset.h>
-
+#include <ctime>
 
 
 template
@@ -101,12 +101,17 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   std::vector<MutableAssetVersionD> kids;
   kids.reserve(numLevels);
 
+  time_t prevClock = clock();
+  notify(NFY_PROGRESS, "Starting UpdateChildren for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
   // the next lower resolution level
   uint level = config.coverage.endLevel();
   while (level > config.coverage.beginLevel()) {
     --level;
+
+    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+    prevClock = clock();
 
     // Determine which insets intersect us at this level
     const khLevelCoverage levCov(config.coverage.levelCoverage(level));
@@ -125,6 +130,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                               config.beginMinifyLevel,
                               config.endMinifyLevel);
     }
+
+    notify(NFY_PROGRESS, "Finished finding insets for level %d. %lu ticks elapsed", level, clock()-prevClock);
+    prevClock = clock();
 
     // Build most of PacketLevelConfig
     PacketLevelConfig packetLevelConfig;
@@ -168,6 +176,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     if (!packetLevelConfig.minify) {
       // ***** Normal Blend *****
 
+      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+      prevClock = clock();
+
       // we cache the raster if we're in the appropriate range
       // and if we've been told to (because we have alpha)
       packetLevelConfig.cacheRaster =
@@ -180,6 +191,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       levInputVers.reserve(neededIndexes.size());
       packetLevelConfig.insets.reserve(neededIndexes.size());
       packetLevelConfig.attributions.reserve(neededIndexes.size());
+
       for (std::vector<uint>::const_iterator idx = neededIndexes.begin();
            idx != neededIndexes.end(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[*idx]);
@@ -195,9 +207,13 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.dataRPFile,
               inset.combinedrp_->config.fuid_resource_));
       }
+      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), clock()-prevClock);
+      prevClock = clock();
     } else {
       // ***** Minify *****
 
+      notify(NFY_PROGRESS, "Starting to minification for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+      prevClock = clock();
       // if we want to short circuit the merge with opaque product
       // tiles, fill in the info about our top product
       if (config.useOpaqueTopInsetInsteadOfMerge) {
@@ -227,6 +243,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
 
+      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), clock()-prevClock);
+      prevClock = clock();
 
       // for insets we only care about those that have done work at
       // minifySrcLevel
@@ -238,6 +256,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           mergeIndexes.push_back(*idx);
         }
       }
+
+      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %lu ticks elapsed", level, mergeIndexes.size(), clock()-prevClock);
+      prevClock = clock();
 
       // populate inputs and inputVers & config.insets
       levInputs.reserve(mergeIndexes.size() * 2 + 1);
@@ -326,6 +347,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
+      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+      prevClock = clock();
+
       if (config.cacheRaster) {
         // If I've cached my raster blends, I should
         // start by trying to minify from them
@@ -353,6 +377,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               prevLevelVer.Ref(), /* cached blend */
               cache_alpha_exist ?
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
+
+        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+        prevClock = clock();
       }
 
     }
@@ -370,10 +397,13 @@ void PacketGenAssetVersionImplD::UpdateChildren(
        levInputVers);
 
     kids.push_back(packLevelVer);
+    notify(NFY_PROGRESS, "Finished all work for level %d.  %lu ticks elapsed", level, clock()-prevClock);
+    prevClock = clock();
 
   } // foreach level
 
   AddChildren(kids);
+  notify(NFY_PROGRESS, "Finished adding all children.  %lu ticks elapsed", clock()-prevClock);
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -44,7 +44,7 @@ class PacketGenExtraUpdateArg {
 #include <autoingest/sysman/plugins/PacketLevelAssetD.h>
 #include <autoingest/plugins/RasterProductAsset.h>
 #include <autoingest/plugins/MercatorRasterProductAsset.h>
-#include <chrono>
+#include <time.h>
 
 
 template
@@ -101,7 +101,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   std::vector<MutableAssetVersionD> kids;
   kids.reserve(numLevels);
 
-  auto prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+  timespec prevTime;
+  timespec curTime;
+  clock_gettime(CLOCK_MONOTONIC, &prevTime);
   notify(NFY_PROGRESS, "Starting UpdateChildren for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
@@ -110,8 +112,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   while (level > config.coverage.beginLevel()) {
     --level;
 
-    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "Starting to find needed insets for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Determine which insets intersect us at this level
     const khLevelCoverage levCov(config.coverage.levelCoverage(level));
@@ -131,8 +134,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                               config.endMinifyLevel);
     }
 
-    notify(NFY_PROGRESS, "Finished finding insets for level %d. %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "Finished finding insets for level %d. %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Build most of PacketLevelConfig
     PacketLevelConfig packetLevelConfig;
@@ -176,8 +180,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     if (!packetLevelConfig.minify) {
       // ***** Normal Blend *****
 
-      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Starting normal blend for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // we cache the raster if we're in the appropriate range
       // and if we've been told to (because we have alpha)
@@ -207,13 +212,15 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.dataRPFile,
               inset.combinedrp_->config.fuid_resource_));
       }
-      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Normal blend level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed", level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
     } else {
       // ***** Minify *****
 
-      notify(NFY_PROGRESS, "Starting to minification for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Starting to minification for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
       // if we want to short circuit the merge with opaque product
       // tiles, fill in the info about our top product
       if (config.useOpaqueTopInsetInsteadOfMerge) {
@@ -243,8 +250,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
 
-      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %lu ticks elapsed", level, neededIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Packet level attributions for level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed", level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // for insets we only care about those that have done work at
       // minifySrcLevel
@@ -257,8 +265,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %lu ticks elapsed", level, mergeIndexes.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Finished adding to mergeIndexes for level %d result is %lu items.  %ld.%09ld seconds elapsed", level, mergeIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       // populate inputs and inputVers & config.insets
       levInputs.reserve(mergeIndexes.size() * 2 + 1);
@@ -347,8 +356,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-      prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+      clock_gettime(CLOCK_MONOTONIC, &curTime);
+      notify(NFY_PROGRESS, "Finished looping over mergeIndexes for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+      clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
       if (config.cacheRaster) {
         // If I've cached my raster blends, I should
@@ -378,8 +388,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               cache_alpha_exist ?
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
 
-        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-        prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+        clock_gettime(CLOCK_MONOTONIC, &curTime);
+        notify(NFY_PROGRESS, "Finished cacheRaster block for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+        clock_gettime(CLOCK_MONOTONIC, &prevTime);
       }
 
     }
@@ -397,13 +408,15 @@ void PacketGenAssetVersionImplD::UpdateChildren(
        levInputVers);
 
     kids.push_back(packLevelVer);
-    notify(NFY_PROGRESS, "Finished all work for level %d.  %lu ticks elapsed", level, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "Finished all work for level %d.  %ld.%09ld seconds elapsed", level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
   } // foreach level
 
   AddChildren(kids);
-  notify(NFY_PROGRESS, "Finished adding all children.  %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+  clock_gettime(CLOCK_MONOTONIC, &curTime);
+  notify(NFY_PROGRESS, "Finished adding all children.  %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -44,7 +44,7 @@ class PacketGenExtraUpdateArg {
 #include <autoingest/sysman/plugins/PacketLevelAssetD.h>
 #include <autoingest/plugins/RasterProductAsset.h>
 #include <autoingest/plugins/MercatorRasterProductAsset.h>
-#include <time.h>
+#include <chrono>
 
 
 template
@@ -101,9 +101,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   std::vector<MutableAssetVersionD> kids;
   kids.reserve(numLevels);
 
-  timespec prevTime;
-  timespec curTime;
-  clock_gettime(CLOCK_MONOTONIC, &prevTime);
+  std::chrono::high_resolution_clock::time_point prevTime = std::chrono::high_resolution_clock::now();
+  std::chrono::high_resolution_clock::time_point curTime;
+  std::chrono::duration<double> timeDiff; 
   notify(NFY_PROGRESS, "UpdateChildren starting for %s", assetRef.c_str());
   // Create my children giving them each a different level
   // Go from end to begin so we can use the results from one level to make
@@ -112,10 +112,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
   while (level > config.coverage.beginLevel()) {
     --level;
 
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "UpdateChildren starting to find needed insets for level %d.  %ld.%09ld seconds elapsed",
-           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "UpdateChildren starting to find needed insets for level %d.  %f seconds elapsed",
+           level, timeDiff.count());
+    prevTime = curTime;
 
     // Determine which insets intersect us at this level
     const khLevelCoverage levCov(config.coverage.levelCoverage(level));
@@ -135,10 +136,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                               config.endMinifyLevel);
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "UpdateChildren finished finding insets for level %d. %ld.%09ld seconds elapsed",
-           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "UpdateChildren finished finding insets for level %d. %f seconds elapsed",
+           level, timeDiff.count());
+    prevTime = curTime;
 
     // Build most of PacketLevelConfig
     PacketLevelConfig packetLevelConfig;
@@ -182,10 +184,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
     if (!packetLevelConfig.minify) {
       // ***** Normal Blend *****
 
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren starting normal blend for level %d.  %ld.%09ld seconds elapsed",
-             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren starting normal blend for level %d.  %f seconds elapsed",
+             level, timeDiff.count());
+      prevTime = curTime;
 
       // we cache the raster if we're in the appropriate range
       // and if we've been told to (because we have alpha)
@@ -215,17 +218,19 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.dataRPFile,
               inset.combinedrp_->config.fuid_resource_));
       }
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren normal blend level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed",
-             level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren normal blend level %d finished inner loop over %lu other insets.  %f seconds elapsed",
+             level, neededIndexes.size(), timeDiff.count());
+      prevTime = curTime;
     } else {
       // ***** Minify *****
 
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren starting minification for level %d.  %ld.%09ld seconds elapsed",
-             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren starting minification for level %d.  %f seconds elapsed",
+             level, timeDiff.count());
+      prevTime = curTime;
       // if we want to short circuit the merge with opaque product
       // tiles, fill in the info about our top product
       if (config.useOpaqueTopInsetInsteadOfMerge) {
@@ -255,10 +260,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               inset.combinedrp_->config.fuid_resource_));
       }
 
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren packet level attributions for level %d finished inner loop over %lu other insets.  %ld.%09ld seconds elapsed",
-             level, neededIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren packet level attributions for level %d finished inner loop over %lu other insets.  %f seconds elapsed",
+             level, neededIndexes.size(), timeDiff.count());
+      prevTime = curTime;
 
       // for insets we only care about those that have done work at
       // minifySrcLevel
@@ -271,10 +277,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren finished adding to mergeIndexes for level %d result is %lu items.  %ld.%09ld seconds elapsed",
-             level, mergeIndexes.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren finished adding to mergeIndexes for level %d result is %lu items.  %f seconds elapsed",
+             level, mergeIndexes.size(), timeDiff.count());
+      prevTime = curTime;
 
       // populate inputs and inputVers & config.insets
       levInputs.reserve(mergeIndexes.size() * 2 + 1);
@@ -363,10 +370,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         }
       }
 
-      clock_gettime(CLOCK_MONOTONIC, &curTime);
-      notify(NFY_PROGRESS, "UpdateChildren finished looping over mergeIndexes for level %d.  %ld.%09ld seconds elapsed",
-             level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-      clock_gettime(CLOCK_MONOTONIC, &prevTime);
+      curTime = std::chrono::high_resolution_clock::now();
+      timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+      notify(NFY_PROGRESS, "UpdateChildren finished looping over mergeIndexes for level %d.  %f seconds elapsed",
+             level, timeDiff.count());
+      prevTime = curTime;
 
       if (config.cacheRaster) {
         // If I've cached my raster blends, I should
@@ -396,10 +404,11 @@ void PacketGenAssetVersionImplD::UpdateChildren(
               cache_alpha_exist ?
                   prevLevelVer.Ref() : std::string() /* cached blend alpha */));
 
-        clock_gettime(CLOCK_MONOTONIC, &curTime);
-        notify(NFY_PROGRESS, "UpdateChildren finished cacheRaster block for level %d.  %ld.%09ld seconds elapsed",
-               level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-        clock_gettime(CLOCK_MONOTONIC, &prevTime);
+        curTime = std::chrono::high_resolution_clock::now();
+        timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+        notify(NFY_PROGRESS, "UpdateChildren finished cacheRaster block for level %d.  %f seconds elapsed",
+               level, timeDiff.count());
+        prevTime = curTime;
       }
 
     }
@@ -417,17 +426,19 @@ void PacketGenAssetVersionImplD::UpdateChildren(
        levInputVers);
 
     kids.push_back(packLevelVer);
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "UpdateChildren finished all work for level %d.  %ld.%09ld seconds elapsed",
-           level, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "UpdateChildren finished all work for level %d.  %f seconds elapsed",
+           level, timeDiff.count());
+    prevTime = curTime;
 
   } // foreach level
 
   AddChildren(kids);
-  clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "UpdateChildren finished adding all children.  %ld.%09ld seconds elapsed",
-         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  curTime = std::chrono::high_resolution_clock::now();
+  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+  notify(NFY_PROGRESS, "UpdateChildren finished adding all children.  %f seconds elapsed",
+         timeDiff.count());
 }
 
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -241,7 +241,7 @@ class RasterProjectAssetVersionImplD {
 #include "common/khTileAddr.h"
 #include "common/khConstants.h"
 #include <third_party/rfc_uuid/uuid.h>
-#include <chrono>
+#include <time.h>
 
 
 // Throw and exception about invalid dates in time machine projects if the
@@ -984,7 +984,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     RasterProductAssetVersion> >::const_reverse_iterator last_iter =
       inset_infos.rbegin();
   notify(NFY_PROGRESS, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
-  auto prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+  timespec prevTime;
+  timespec curTime;
+  clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
   // get the range of levels that we're going to generate
   const uint beginProjectLevel =
@@ -1009,13 +1011,14 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
                     config.overlay_terrain_resources_min_level_);
 #if 1
   // Calculate levels where transparent tiles may be skipped.
-  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-  prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+  clock_gettime(CLOCK_MONOTONIC, &curTime);
+  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  clock_gettime(CLOCK_MONOTONIC, &prevTime);
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
-  
-  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-  prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+  clock_gettime(CLOCK_MONOTONIC, &curTime);
+  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  clock_gettime(CLOCK_MONOTONIC, &prevTime);
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
   // routines want pointers.
   std::vector<const InsetInfo<RasterProductAssetVersion> *> insetInfoPtrs;
@@ -1044,8 +1047,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     std::vector<uint> neededIndexes;
     neededIndexes.reserve(i);
 
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %lu ticks elapsed", i, genInfo.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed", i, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     if (type == AssetDefs::Imagery) {
       FindNeededImageryInsets(genInfo[i].coverage,
@@ -1062,8 +1066,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
     neededIndexes.push_back(i); // each inset always intersects itself
 
-    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %lu ticks elapsed", neededIndexes.size(), i, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %ld.%09ld seconds elapsed", neededIndexes.size(), i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // calculate the level range that will be minified
     uint effectiveBeginMinifyLevel =
@@ -1109,8 +1114,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
           packgenVerRef));
     }
 
-    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %lu ticks elapsed", i, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
-    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
+    clock_gettime(CLOCK_MONOTONIC, &curTime);
+    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %ld.%09ld seconds elapsed", i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Build a PacketGenExtraUpdateArg
     PacketGenExtraUpdateArg<RasterProductAssetVersion> extraArg;
@@ -1143,7 +1149,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     packgenvers.push_back(packgen);
   }
 
-  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+  clock_gettime(CLOCK_MONOTONIC, &curTime);
+  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -983,7 +983,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   std::vector<InsetInfo<
     RasterProductAssetVersion> >::const_reverse_iterator last_iter =
       inset_infos.rbegin();
-  notify(NFY_PROGRESS, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
+  notify(NFY_INFO2, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
   std::chrono::high_resolution_clock::time_point prevTime = std::chrono::high_resolution_clock::now();
   std::chrono::high_resolution_clock::time_point curTime;
   std::chrono::duration<double> timeDiff; 
@@ -1012,15 +1012,15 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
 #if 1
   // Calculate levels where transparent tiles may be skipped.
   curTime = std::chrono::high_resolution_clock::now();
-  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-  notify(NFY_PROGRESS, "BuildIndex finished calculation of packet gen info - %f seconds elapsed",
+  timeDiff = std::chrono::duration<double>(curTime - prevTime);
+  notify(NFY_INFO2, "BuildIndex finished calculation of packet gen info - %f seconds elapsed",
          timeDiff.count());
   prevTime = curTime;
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
   curTime = std::chrono::high_resolution_clock::now();
-  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-  notify(NFY_PROGRESS, "BuildIndex finished calcLevelsToSkipTransparentTiles - %f seconds elapsed",
+  timeDiff = std::chrono::duration<double>(curTime - prevTime);
+  notify(NFY_INFO2, "BuildIndex finished calcLevelsToSkipTransparentTiles - %f seconds elapsed",
          timeDiff.count());
   prevTime = curTime;
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
@@ -1052,8 +1052,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     neededIndexes.reserve(i);
 
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %f seconds elapsed",
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "BuildIndex starting inner loop for inset %d of %lu - %f seconds elapsed",
            i+1, genInfo.size(), timeDiff.count());
     prevTime = curTime;
 
@@ -1073,8 +1073,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     neededIndexes.push_back(i); // each inset always intersects itself
 
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %f seconds elapsed",
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "BuildIndex finished compiling %lu needed indices for inset %d - %f seconds elapsed",
            neededIndexes.size(), i, timeDiff.count());
     prevTime = curTime;
 
@@ -1123,8 +1123,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
 
     curTime = std::chrono::high_resolution_clock::now();
-    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %f seconds elapsed",
+    timeDiff = std::chrono::duration<double>(curTime - prevTime);
+    notify(NFY_INFO2, "BuildIndex finished nested loop for inset %d - %f seconds elapsed",
            i, timeDiff.count());
     prevTime = curTime;
 
@@ -1160,8 +1160,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   }
 
   curTime = std::chrono::high_resolution_clock::now();
-  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
-  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %f seconds elapsed",
+  timeDiff = std::chrono::duration<double>(curTime - prevTime);
+  notify(NFY_INFO2, "BuildIndex finished looping through insets - %f seconds elapsed",
          timeDiff.count());
 
   // Make index subasset (RasterGEIndex).

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1048,7 +1048,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     neededIndexes.reserve(i);
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed", i, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed", i+1, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     if (type == AssetDefs::Imagery) {

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1012,12 +1012,14 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
 #if 1
   // Calculate levels where transparent tiles may be skipped.
   clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  notify(NFY_PROGRESS, "BuildIndex finished calculation of packet gen info - %ld.%09ld seconds elapsed",
+         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
   clock_gettime(CLOCK_MONOTONIC, &prevTime);
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
   clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  notify(NFY_PROGRESS, "BuildIndex finished calcLevelsToSkipTransparentTiles - %ld.%09ld seconds elapsed",
+         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
   clock_gettime(CLOCK_MONOTONIC, &prevTime);
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
   // routines want pointers.
@@ -1048,7 +1050,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     neededIndexes.reserve(i);
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed", i+1, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed",
+           i+1, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     if (type == AssetDefs::Imagery) {
@@ -1067,7 +1070,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     neededIndexes.push_back(i); // each inset always intersects itself
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %ld.%09ld seconds elapsed", neededIndexes.size(), i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %ld.%09ld seconds elapsed",
+           neededIndexes.size(), i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // calculate the level range that will be minified
@@ -1115,7 +1119,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
 
     clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %ld.%09ld seconds elapsed", i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %ld.%09ld seconds elapsed",
+           i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
     clock_gettime(CLOCK_MONOTONIC, &prevTime);
 
     // Build a PacketGenExtraUpdateArg
@@ -1150,7 +1155,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   }
 
   clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %ld.%09ld seconds elapsed", curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %ld.%09ld seconds elapsed",
+         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -241,6 +241,7 @@ class RasterProjectAssetVersionImplD {
 #include "common/khTileAddr.h"
 #include "common/khConstants.h"
 #include <third_party/rfc_uuid/uuid.h>
+#include <ctime>
 
 
 // Throw and exception about invalid dates in time machine projects if the
@@ -982,8 +983,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   std::vector<InsetInfo<
     RasterProductAssetVersion> >::const_reverse_iterator last_iter =
       inset_infos.rbegin();
-  notify(NFY_DEBUG, "Building GERasterIndex: %zu insets, level %d for %s\n",
-         inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
+  notify(NFY_PROGRESS, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
+  clock_t prevClock = clock();
 
   // get the range of levels that we're going to generate
   const uint beginProjectLevel =
@@ -998,7 +999,6 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   // increases low res image quality.
   const uint beginMinifyLevel  = beginProjectLevel;
   const uint endMinifyLevel    = inset_infos[0].effectiveMaxLevel;
-
   // Calc the info about what work to do.
   std::vector<PacketGenInfo> genInfo;
   CalcPacketGenInfo(tilespace, type, inset_infos,
@@ -1009,9 +1009,13 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
                     config.overlay_terrain_resources_min_level_);
 #if 1
   // Calculate levels where transparent tiles may be skipped.
+  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %lu ticks elapsed", clock()-prevClock);
+  prevClock = clock();
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
-
+  
+  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %lu ticks elapsed", clock()-prevClock);
+  prevClock = clock();
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
   // routines want pointers.
   std::vector<const InsetInfo<RasterProductAssetVersion> *> insetInfoPtrs;
@@ -1039,6 +1043,10 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     // Determine which insets (0 .. i) intersect this coverage area.
     std::vector<uint> neededIndexes;
     neededIndexes.reserve(i);
+
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %lu ticks elapsed", i, genInfo.size(), clock()-prevClock);
+    prevClock = clock();
+
     if (type == AssetDefs::Imagery) {
       FindNeededImageryInsets(genInfo[i].coverage,
                               insetInfoPtrs, i,
@@ -1054,6 +1062,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
     neededIndexes.push_back(i); // each inset always intersects itself
 
+    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %lu ticks elapsed", neededIndexes.size(), i, clock()-prevClock);
+    prevClock = clock();
 
     // calculate the level range that will be minified
     uint effectiveBeginMinifyLevel =
@@ -1072,7 +1082,6 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
       genInfo[i].beginSkipTransparentLevel;
 
     packetGenConfig.useOpaqueTopInsetInsteadOfMerge = true;
-
     packetGenConfig.insets.reserve(neededIndexes.size());
     for (std::vector<uint>::const_iterator idx = neededIndexes.begin();
          idx != neededIndexes.end(); ++idx) {
@@ -1099,6 +1108,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
          (inset_infos[*idx].combinedrp_.Ref(),
           packgenVerRef));
     }
+
+    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %lu ticks elapsed", i, clock()-prevClock);
+    prevClock = clock();
 
     // Build a PacketGenExtraUpdateArg
     PacketGenExtraUpdateArg<RasterProductAssetVersion> extraArg;
@@ -1130,6 +1142,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     packgenassets.push_back(packgen->GetAssetRef());
     packgenvers.push_back(packgen);
   }
+
+  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %lu ticks elapsed", clock()-prevClock);
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -241,7 +241,7 @@ class RasterProjectAssetVersionImplD {
 #include "common/khTileAddr.h"
 #include "common/khConstants.h"
 #include <third_party/rfc_uuid/uuid.h>
-#include <ctime>
+#include <chrono>
 
 
 // Throw and exception about invalid dates in time machine projects if the
@@ -984,7 +984,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     RasterProductAssetVersion> >::const_reverse_iterator last_iter =
       inset_infos.rbegin();
   notify(NFY_PROGRESS, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
-  clock_t prevClock = clock();
+  auto prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
   // get the range of levels that we're going to generate
   const uint beginProjectLevel =
@@ -1009,13 +1009,13 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
                     config.overlay_terrain_resources_min_level_);
 #if 1
   // Calculate levels where transparent tiles may be skipped.
-  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %lu ticks elapsed", clock()-prevClock);
-  prevClock = clock();
+  notify(NFY_PROGRESS, "Finished calculation of packet gen info - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+  prevClock = std::chrono::system_clock::now().time_since_epoch().count();
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
   
-  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %lu ticks elapsed", clock()-prevClock);
-  prevClock = clock();
+  notify(NFY_PROGRESS, "Finished calcLevelsToSkipTransparentTiles - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+  prevClock = std::chrono::system_clock::now().time_since_epoch().count();
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
   // routines want pointers.
   std::vector<const InsetInfo<RasterProductAssetVersion> *> insetInfoPtrs;
@@ -1044,8 +1044,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     std::vector<uint> neededIndexes;
     neededIndexes.reserve(i);
 
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %lu ticks elapsed", i, genInfo.size(), clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %lu ticks elapsed", i, genInfo.size(), std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
     if (type == AssetDefs::Imagery) {
       FindNeededImageryInsets(genInfo[i].coverage,
@@ -1062,8 +1062,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
     neededIndexes.push_back(i); // each inset always intersects itself
 
-    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %lu ticks elapsed", neededIndexes.size(), i, clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %lu ticks elapsed", neededIndexes.size(), i, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
     // calculate the level range that will be minified
     uint effectiveBeginMinifyLevel =
@@ -1109,8 +1109,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
           packgenVerRef));
     }
 
-    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %lu ticks elapsed", i, clock()-prevClock);
-    prevClock = clock();
+    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %lu ticks elapsed", i, std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
+    prevClock = std::chrono::system_clock::now().time_since_epoch().count();
 
     // Build a PacketGenExtraUpdateArg
     PacketGenExtraUpdateArg<RasterProductAssetVersion> extraArg;
@@ -1143,7 +1143,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     packgenvers.push_back(packgen);
   }
 
-  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %lu ticks elapsed", clock()-prevClock);
+  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %lu ticks elapsed", std::chrono::system_clock::now().time_since_epoch().count()-prevClock);
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -241,7 +241,7 @@ class RasterProjectAssetVersionImplD {
 #include "common/khTileAddr.h"
 #include "common/khConstants.h"
 #include <third_party/rfc_uuid/uuid.h>
-#include <time.h>
+#include <chrono>
 
 
 // Throw and exception about invalid dates in time machine projects if the
@@ -984,9 +984,9 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     RasterProductAssetVersion> >::const_reverse_iterator last_iter =
       inset_infos.rbegin();
   notify(NFY_PROGRESS, "Building GERasterIndex: %zu insets, level %d for %s\n", inset_infos.size(), last_iter->effectiveMaxLevel, date.c_str());
-  timespec prevTime;
-  timespec curTime;
-  clock_gettime(CLOCK_MONOTONIC, &prevTime);
+  std::chrono::high_resolution_clock::time_point prevTime = std::chrono::high_resolution_clock::now();
+  std::chrono::high_resolution_clock::time_point curTime;
+  std::chrono::duration<double> timeDiff; 
 
   // get the range of levels that we're going to generate
   const uint beginProjectLevel =
@@ -1011,16 +1011,18 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
                     config.overlay_terrain_resources_min_level_);
 #if 1
   // Calculate levels where transparent tiles may be skipped.
-  clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "BuildIndex finished calculation of packet gen info - %ld.%09ld seconds elapsed",
-         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-  clock_gettime(CLOCK_MONOTONIC, &prevTime);
+  curTime = std::chrono::high_resolution_clock::now();
+  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+  notify(NFY_PROGRESS, "BuildIndex finished calculation of packet gen info - %f seconds elapsed",
+         timeDiff.count());
+  prevTime = curTime;
   CalcLevelsToSkipTransparentTiles(&genInfo, beginProjectLevel, endMinifyLevel);
 #endif
-  clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "BuildIndex finished calcLevelsToSkipTransparentTiles - %ld.%09ld seconds elapsed",
-         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-  clock_gettime(CLOCK_MONOTONIC, &prevTime);
+  curTime = std::chrono::high_resolution_clock::now();
+  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+  notify(NFY_PROGRESS, "BuildIndex finished calcLevelsToSkipTransparentTiles - %f seconds elapsed",
+         timeDiff.count());
+  prevTime = curTime;
   // make a copy of the inset_infos w/ pointers. The FindNeeded*
   // routines want pointers.
   std::vector<const InsetInfo<RasterProductAssetVersion> *> insetInfoPtrs;
@@ -1049,10 +1051,11 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     std::vector<uint> neededIndexes;
     neededIndexes.reserve(i);
 
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %ld.%09ld seconds elapsed",
-           i+1, genInfo.size(), curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "BuildIndex starting inner loop for inset %d of %lu - %f seconds elapsed",
+           i+1, genInfo.size(), timeDiff.count());
+    prevTime = curTime;
 
     if (type == AssetDefs::Imagery) {
       FindNeededImageryInsets(genInfo[i].coverage,
@@ -1069,10 +1072,11 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     }
     neededIndexes.push_back(i); // each inset always intersects itself
 
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %ld.%09ld seconds elapsed",
-           neededIndexes.size(), i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "BuildIndex finished compiling %lu needed indices for inset %d - %f seconds elapsed",
+           neededIndexes.size(), i, timeDiff.count());
+    prevTime = curTime;
 
     // calculate the level range that will be minified
     uint effectiveBeginMinifyLevel =
@@ -1118,10 +1122,11 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
           packgenVerRef));
     }
 
-    clock_gettime(CLOCK_MONOTONIC, &curTime);
-    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %ld.%09ld seconds elapsed",
-           i, curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
-    clock_gettime(CLOCK_MONOTONIC, &prevTime);
+    curTime = std::chrono::high_resolution_clock::now();
+    timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+    notify(NFY_PROGRESS, "BuildIndex finished nested loop for inset %d - %f seconds elapsed",
+           i, timeDiff.count());
+    prevTime = curTime;
 
     // Build a PacketGenExtraUpdateArg
     PacketGenExtraUpdateArg<RasterProductAssetVersion> extraArg;
@@ -1154,9 +1159,10 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     packgenvers.push_back(packgen);
   }
 
-  clock_gettime(CLOCK_MONOTONIC, &curTime);
-  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %ld.%09ld seconds elapsed",
-         curTime.tv_sec-prevTime.tv_sec, curTime.tv_nsec-prevTime.tv_nsec);
+  curTime = std::chrono::high_resolution_clock::now();
+  timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(curTime - prevTime);
+  notify(NFY_PROGRESS, "BuildIndex finished looping through insets - %f seconds elapsed",
+         timeDiff.count());
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);


### PR DESCRIPTION
Adding additional logging at the NFY_PROGRESS level to more easily analyze very large and slow builds.  Each message will identify the location in the method of interest and indicate the elapsed time from the previous performance log.

Note: I'm unsure if this is desirable to merge to master or if it should only live in the experimental branch.

Verification steps:

1. Build the branch for this PR and install on target
1. Change logging level to 3 or higher in `/etc/opt/google/systemrc`
1. Restart or reload gefusion service
1. Perform a build of an imagery or terrain project.
1. View the additional log output and ensure it all makes sense and is usable.