### PR TITLE
Fixes #279 - Admin Console password will be preserved on GEE server upgrade

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -159,7 +159,13 @@ gtag('config', 'UA-108632131-2');
               Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
             </td>
           </tr>
-
+          <tr>
+            <td>279</td>
+            <td>Server upgrade resets the Admin Console password</td>
+            <td>
+              When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
+            </td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -145,6 +145,13 @@ gtag('config', 'UA-108632131-2');
               Added a validity check that ensures a valid date is entered. A date of 0000-00-00 can also be entered as a default value. The user will not be allowed to save with an invalid date entered.
             </td>
           </tr>
+          <tr>
+            <td>279</td>
+            <td>Server upgrade resets the Admin Console password</td>
+            <td>
+              When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
+            </td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -152,6 +152,14 @@ gtag('config', 'UA-108632131-2');
               Added an experimental option that fixes several memory leaks related to our usage of the Xerces library.
             </td>
           </tr>
+          <tr>
+            <td>1228</td>
+            <td>Assemble button is not fully visible, making it difficult to use the GLC assembly tool</td>
+            <td>
+              Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
+            </td>
+          </tr>
+
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 The Open GEE Contributors
+# Copyright 2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,12 @@ main_postinstall()
     # 9) Restore portable globes symlink if it existed previously
     restore_portable_symlink
  
-    #10) done!
+    #10) Restore Admin Console password if it exists
+    if [ -f "/tmp/.htpasswd" ]; then
+        mv -f "/tmp/.htpasswd" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/"
+    fi
+
+    #11) done!
     service geserver start
 }
 

--- a/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 The Open GEE Contributors
+# Copyright 2018-2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 The Open GEE Contributors
+# Copyright 2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ main_preinstall()
 
     # If user previously symlinked to another location for portable globes storage don't let the installer mess that up
     save_portable_globe_symlink
+
+    # Preserve Admin Console password if it exists. To be restored on post-install
+    if [ -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" ]; then
+        mv -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" "/tmp/"
+    fi
 }
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 The Open GEE Contributors
+# Copyright 2018-2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/glc_style.css
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/glc_style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google Inc., 2019 the Open GEE Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ body {
   left: 0px;
   right: 0;
   bottom: 0;
+  overflow-y: scroll;
 }
 
 #right_bar h2 {

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
@@ -26,6 +26,7 @@
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>
+#include <sstream>
 #include "fusion/portableglobe/quadtree/qtutils.h"
 
 namespace fusion_portableglobe {
@@ -34,7 +35,7 @@ namespace fusion_portableglobe {
  * Polygon constructor.
  * Reads in the first polygon from the given kml file.
  */
-Polygon::Polygon(std::ifstream* fin) {
+Polygon::Polygon(std::istream* fin) {
   std::string token;
 
   bool found_linear_ring = false;
@@ -82,20 +83,39 @@ Polygon::Polygon(std::ifstream* fin) {
  */
 Polygons::Polygons(const std::string& kml_file) {
   std::ifstream fin(kml_file.c_str());
+  AddPolygonsFromStream(fin);
+  fin.close();
+}
+
+
+/**
+ * Polygons constructor.
+ * Reads in the polygons from the given kml string.
+ */
+Polygons::Polygons(const kml_as_string&, const std::string& kml_string) {
+  std::istringstream iss(kml_string);
+  AddPolygonsFromStream(iss);
+}
+
+
+/**
+ * Polygons constructor helper.
+ * Reads in the polygons from an input stream object.
+ */
+void Polygons::AddPolygonsFromStream(std::istream& in_stream) {
   std::string token;
 
   // TODO: Use more robust xml parsing.
-  while (!fin.eof()) {
+  while (!in_stream.eof()) {
     token = "";
-    fin >> token;
+    in_stream >> token;
     if (!token.empty()) {
       if ("<Polygon>" == token) {
-        polygons.push_back(Polygon(&fin));
+        polygons.push_back(Polygon(&in_stream));
       }
     }
   }
 
-  fin.close();
   notify(NFY_NOTICE, "Found %Zu polygons.", polygons.size());
 }
 

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
@@ -58,7 +58,7 @@ class Polygon {
    */
   Polygon() {}
 
-  explicit Polygon(std::ifstream* fin);
+  explicit Polygon(std::istream* fin);
 
   std::vector<Vertex> *Vertices() { return &vertices; }
 
@@ -67,6 +67,16 @@ class Polygon {
  private:
   std::vector<Vertex> vertices;
 };
+
+
+/**
+ * This is a dummy struct for passing to the Polygons constructor
+ * to indicate that the accompanying string is actual KML and not
+ * the name of a KML file.
+ */
+struct kml_as_string {
+};
+
 
 /**
  * Set of Polygons read in from a kml file.
@@ -80,6 +90,8 @@ class Polygons {
 
   explicit Polygons(const std::string& kml_file);
 
+  Polygons(const kml_as_string&, const std::string& kml_string);
+
   Polygon* GetPolygon(size_t index) { return &polygons[index]; }
 
   size_t NumberOfPolygons() { return polygons.size(); }
@@ -91,6 +103,8 @@ class Polygons {
 
  private:
   std::vector<Polygon> polygons;
+
+  void AddPolygonsFromStream(std::istream& in_stream);
 };
 
 /**

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc., 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -459,7 +459,15 @@ copy_files_to_target()
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+
+  if [ -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" ]
+  then
+    # Preserve Admin Console password
+    rsync -rl "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT" --exclude conf.d/.htpasswd
+  else
+    cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  fi
+
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc., 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -457,7 +457,15 @@ copy_files_to_target()
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+
+  if [ -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" ]
+  then
+    # Preserve Admin Console password
+    rsync -rl "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT" --exclude conf.d/.htpasswd
+  else
+    cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  fi
+
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -46,6 +46,8 @@ PROMPT_FOR_START="n"
 
 # user names
 DEFAULTGROUPNAME="gegroup"
+# $GROUPNAME is used in common.sh by the check_group and check_username functions
+GROUPNAME=$DEFAULTGROUPNAME
 GRPNAME=$DEFAULTGROUPNAME
 GEAPACHEUSER_NAME="geapacheuser"
 GEPGUSER_NAME="gepguser"


### PR DESCRIPTION
- The install_server.sh script has been updated to keep the password file from being overwritten if it already exists
- The server RPM pre and post install scripts will preserve and restore the password file as well
- Release notes and applicable copyright info also updated

Test reproduction steps for install_server.sh (tested on Ubuntu 16.04):
1. Start with a previous version of GEE server installed, but with the service stopped
2. Change the Admin Console password to a non-default one (using htpasswd)
3. Run the install_server.sh script, and start the server
4. Verify through the web interface that the Admin Console password did not revert to the default

Test reproduction steps for RPM install (tested on CentOS 7):
1. Start with a previous version of GEE server installed
2. Change the Admin Console password to a non-default one (using htpasswd)
3. Build the RPMs, then install them
4. Verify through the web interface that the Admin Console password did not revert to the default
