### PR TITLE
#1236 Polygons constructor can accept KML as a string

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
@@ -26,6 +26,7 @@
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>
+#include <sstream>
 #include "fusion/portableglobe/quadtree/qtutils.h"
 
 namespace fusion_portableglobe {
@@ -34,7 +35,7 @@ namespace fusion_portableglobe {
  * Polygon constructor.
  * Reads in the first polygon from the given kml file.
  */
-Polygon::Polygon(std::ifstream* fin) {
+Polygon::Polygon(std::istream* fin) {
   std::string token;
 
   bool found_linear_ring = false;
@@ -82,20 +83,39 @@ Polygon::Polygon(std::ifstream* fin) {
  */
 Polygons::Polygons(const std::string& kml_file) {
   std::ifstream fin(kml_file.c_str());
+  AddPolygonsFromStream(fin);
+  fin.close();
+}
+
+
+/**
+ * Polygons constructor.
+ * Reads in the polygons from the given kml string.
+ */
+Polygons::Polygons(const kml_as_string, const std::string& kml_string) {
+  std::istringstream iss(kml_string);
+  AddPolygonsFromStream(iss);
+}
+
+
+/**
+ * Polygons constructor helper.
+ * Reads in the polygons from an input stream object.
+ */
+void Polygons::AddPolygonsFromStream(std::istream& in_stream) {
   std::string token;
 
   // TODO: Use more robust xml parsing.
-  while (!fin.eof()) {
+  while (!in_stream.eof()) {
     token = "";
-    fin >> token;
+    in_stream >> token;
     if (!token.empty()) {
       if ("<Polygon>" == token) {
-        polygons.push_back(Polygon(&fin));
+        polygons.push_back(Polygon(&in_stream));
       }
     }
   }
 
-  fin.close();
   notify(NFY_NOTICE, "Found %Zu polygons.", polygons.size());
 }
 

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
@@ -92,7 +92,7 @@ Polygons::Polygons(const std::string& kml_file) {
  * Polygons constructor.
  * Reads in the polygons from the given kml string.
  */
-Polygons::Polygons(const kml_as_string, const std::string& kml_string) {
+Polygons::Polygons(const kml_as_string&, const std::string& kml_string) {
   std::istringstream iss(kml_string);
   AddPolygonsFromStream(iss);
 }

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
@@ -90,7 +90,7 @@ class Polygons {
 
   explicit Polygons(const std::string& kml_file);
 
-  explicit Polygons(const kml_as_string&, const std::string& kml_string);
+  Polygons(const kml_as_string&, const std::string& kml_string);
 
   Polygon* GetPolygon(size_t index) { return &polygons[index]; }
 

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
@@ -90,7 +90,7 @@ class Polygons {
 
   explicit Polygons(const std::string& kml_file);
 
-  explicit Polygons(const kml_as_string, const std::string& kml_string);
+  explicit Polygons(const kml_as_string&, const std::string& kml_string);
 
   Polygon* GetPolygon(size_t index) { return &polygons[index]; }
 

--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.h
@@ -58,7 +58,7 @@ class Polygon {
    */
   Polygon() {}
 
-  explicit Polygon(std::ifstream* fin);
+  explicit Polygon(std::istream* fin);
 
   std::vector<Vertex> *Vertices() { return &vertices; }
 
@@ -67,6 +67,16 @@ class Polygon {
  private:
   std::vector<Vertex> vertices;
 };
+
+
+/**
+ * This is a dummy struct for passing to the Polygons constructor
+ * to indicate that the accompanying string is actual KML and not
+ * the name of a KML file.
+ */
+struct kml_as_string {
+};
+
 
 /**
  * Set of Polygons read in from a kml file.
@@ -80,6 +90,8 @@ class Polygons {
 
   explicit Polygons(const std::string& kml_file);
 
+  explicit Polygons(const kml_as_string, const std::string& kml_string);
+
   Polygon* GetPolygon(size_t index) { return &polygons[index]; }
 
   size_t NumberOfPolygons() { return polygons.size(); }
@@ -91,6 +103,8 @@ class Polygons {
 
  private:
   std::vector<Polygon> polygons;
+
+  void AddPolygonsFromStream(std::istream& in_stream);
 };
 
 /**


### PR DESCRIPTION
Added the ability for Polygons constructor to accept a KML string.  The existing Polygons constructor would only accept a string that was a KML file.  I also added unit tests for the new constructor.

Testing should include:
1. The polygontoqtnodes_unittest should pass.
2. Using one or more KML files, run the gepolygontoqtnodes utility and ensure the result is the same as before these changes.