### PR TITLE
Fixes #279 - Admin Console password will be preserved on GEE server upgrade

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -159,7 +159,13 @@ gtag('config', 'UA-108632131-2');
               Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
             </td>
           </tr>
-
+          <tr>
+            <td>279</td>
+            <td>Server upgrade resets the Admin Console password</td>
+            <td>
+              When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
+            </td>
+          </tr>
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 The Open GEE Contributors
+# Copyright 2018-2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,7 +65,12 @@ main_postinstall()
     # 9) Restore portable globes symlink if it existed previously
     restore_portable_symlink
  
-    #10) done!
+    #10) Restore Admin Console password if it exists
+    if [ -f "/tmp/.htpasswd" ]; then
+        mv -f "/tmp/.htpasswd" "$BASEINSTALLDIR_OPT/gehttpd/conf.d/"
+    fi
+
+    #11) done!
     service geserver start
 }
 

--- a/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/pre-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 The Open GEE Contributors
+# Copyright 2018-2019 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ main_preinstall()
 
     # If user previously symlinked to another location for portable globes storage don't let the installer mess that up
     save_portable_globe_symlink
+
+    # Preserve Admin Console password if it exists. To be restored on post-install
+    if [ -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" ]; then
+        mv -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" "/tmp/"
+    fi
 }
 
 #-----------------------------------------------------------------

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Google Inc.
+# Copyright 2017 Google Inc., 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -459,7 +459,15 @@ copy_files_to_target()
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/lib" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  
+  if [ -f "$BASEINSTALLDIR_OPT/gehttpd/conf.d/.htpasswd" ]
+  then
+    # Preserve Admin Console password
+    rsync -rl "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT" --exclude conf.d/.htpasswd
+  else
+    cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+  fi
+
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/search" "$BASEINSTALLDIR_OPT"
   if [ $? -ne 0 ]; then error_on_copy=1; fi

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Google Inc., 2019 Open GEE Contributors
+# Copyright 2017 Google Inc., 2018-2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -465,7 +465,7 @@ copy_files_to_target()
     # Preserve Admin Console password
     rsync -rl "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT" --exclude conf.d/.htpasswd
   else
-    cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
+    rsync -rl "$TMPINSTALLDIR/server/opt/google/gehttpd" "$BASEINSTALLDIR_OPT"
   fi
 
   if [ $? -ne 0 ]; then error_on_copy=1; fi


### PR DESCRIPTION
- The install_server.sh script has been updated to keep the password file from being overwritten if it already exists
- The server RPM pre and post install scripts will preserve and restore the password file as well
- Release notes and applicable copyright info also updated

Test reproduction steps for install_server.sh (tested on Ubuntu 16.04):
1. Start with a previous version of GEE server installed, but with the service stopped
2. Change the Admin Console password to a non-default one (using htpasswd)
3. Run the install_server.sh script, and start the server
4. Verify through the web interface that the Admin Console password did not revert to the default

Test reproduction steps for RPM install (tested on CentOS 7):
1. Start with a previous version of GEE server installed
2. Change the Admin Console password to a non-default one (using htpasswd)
3. Build the RPMs, then install them
4. Verify through the web interface that the Admin Console password did not revert to the default