### PR TITLE
[WIP] Resolve issue #798 - investigate Qt build performance

### DIFF
--- a/earth_enterprise/src/third_party/qt/SConscript
+++ b/earth_enterprise/src/third_party/qt/SConscript
@@ -88,6 +88,7 @@ qt_configure = qt_env.Command(
         '-I/usr/include/libpng12 '
         '-qt-imgfmt-jpeg -qt-imgfmt-mng '
         '-thread '
+        '-fast -nomake examples -nomake demos -nomake tests -nomake docs '
         '-shared -no-cups -freetype -stl -xcursor -xinerama -xrandr -xrender '
         '-xft -no-pch -ipv6 -nis -largefile -no-gif -xshape -no-tablet -xkb '
         '-L%s/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib64 -I%s/include '


### PR DESCRIPTION
Summary:
Qt build investigated, negligible performance impact gained from excluding non-critical code

Process:
Qt is built via a SConscript kicking off the build to patch and then "configure" the Qt build with a bunch of specific parameters, followed by qmake being run on pro files to generate makefiles. Some of these Makefiles are then executed, depending on the configuration options as well as the SUBDIRs listed in the pro files.

Code:
A quick search of the code for Qt components yields a wide range of them being used in the GEE build, but also large sections that upon deeper inspection that may not be utilized at all - such as SQL, Network, or Embedded. However, removing one or more of these components from the Qt build results in a failure to build Qt Designer in the tools section. Qt Designer is needed for its UIC or user-interface compiler. Thusly, we really can't cut out any large Qt components and still complete the GEE build.

This means that all we can really remove from the build are the examples/tutorials/demos/docs components, as mentioned in the issue.

Build:
The current Qt build process finds 241 pro files in the Qt directory, displays a message stating that it's creating Makefiles, and then proceeds to generate a makefile for each of the pro files.
This can be a little confusing though, because despite a Makefile being created for things like the example projects, whether or not the project is actually built is determined by other parts of the Qt build hierarchy. These parts are currently disabled in the GEE build process, meaning that we do not actually build the examples.
It is possible to skip the generation of some of these Makefiles with a paramater in the configuration process with "-fast"
By adding "-fast" qt will only generate makefiles for library and subdirectory targets (defined by the SUBDIRS, as mentioned above).
This means that we can now cut down the makefile generation, and eliminate some confusing output in the build process. This is not a silver bullet though, as it still generates makefiles as "wrappers, which will in turn run qmake" and the files still appear in the build just with "(fast)" after them.
This brings the pro files found (and subsequent makefiles generated) from 241 to 84

Further options can be injected into the configuration to improve the build:
 "-nomake examples -nomake demos -nomake tests -nomake docs"
Will prevent a few extra makefiles from being made, bringing the count down from 84 to 80 project files. This injection can happen in the custom SConscript located at /src/third_party/qt/SConscript, preventing the need to mess with the qt source tarball.

Another option is the outright removal of the directories in the Qt tarball - examples, tutorials, doc
This requires a change in the Makefile, removing these directories and subsequent make calls as targets which requires some cascading changes (or phony targets in the existing Makefiles), and the overall time-save for this added complexity (and changing of source tarball) is not even 1s compared to the above nomake options.

Conclusion:
In total, adding these nomake config parameters resulted in roughly a 0.2% increase in build performance (5 seconds saved on a 54 minute, single core build). Though this is an increase, some users have noted that the "-nomake ..." parameters only work on X11 environments. A 0.2% speedup may not be worth the potential issue later on, and since the actual examples/tutorials themselves are still skipped, even if their pro files aren't. I have added the change to the SConscript for further testing and evaluation purposes, but this may end up being an issue closed with no action.

time scons -j1 release=1 build 2>&1 | tee build.log

Patched:
real    54m52.113s
user    49m0.080s
sys 6m37.518s

Master:
real    54m57.707s
user    49m6.637s
sys 6m39.950s