### PR TITLE
Move build number to release rpm

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -168,7 +168,7 @@ gtag('config', 'UA-108632131-2');
             <td>1251</td>
             <td>Build number was incorrectly being appended to the version in RPM packaging</td>
             <td>
-              RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not appended to it the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
+              RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not append it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
             </td>
           </tr>
         </tbody>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -168,7 +168,7 @@ gtag('config', 'UA-108632131-2');
             <td>1251</td>
             <td>Build number was incorrectly being appended to the version in RPM packaging</td>
             <td>
-              RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not appended to it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
+              RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not appended to it the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
             </td>
           </tr>
         </tbody>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -39,8 +39,6 @@ gtag('config', 'UA-108632131-2');
 <h1><a href="../index.html">Google Earth Enterprise Documentation Home</a> | Release notes</h1>
 <h2>Release notes: Open GEE 5.3.0</h2>
 
-<p>Open GEE 5.3.0 is currently in development</p>
-
   <h5>
     <p id="overview_5.3.0">New Features</p>
   </h5>
@@ -164,6 +162,13 @@ gtag('config', 'UA-108632131-2');
             <td>Server upgrade resets the Admin Console password</td>
             <td>
               When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
+            </td>
+          </tr>
+          <tr>
+            <td>1251</td>
+            <td>Build number was incorrectly being appended to the version in RPM packaging</td>
+            <td>
+              RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not appended to it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
             </td>
           </tr>
         </tbody>

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -85,13 +85,16 @@ def rpmPlatformString = org.opengee.os.Platform.rpmPlatformString
 def gee_long_version_txt = "${stagedInstall_path}/gee_long_version.txt"
 def openGeeVersionFile = new File( gee_long_version_txt )
 
-def getOsPackageVersionFromOpenGeeVersion(value) {
-    return value.replaceAll(/-.*release/, '').
-        replaceAll('-', '.')
+ext.getOsPackageVersionFromOpenGeeVersion = { value -> 
+    return value.split('-')[0]
 }
 
-def getOsPackageVersionFromOpenGeeVersionFile(file) {
-    return getOsPackageVersionFromOpenGeeVersion(
+ext.getOsPackageBuildFromOpenGeeVersion = { value ->
+    return value.split('-')[1]
+}
+
+def getOsPackageVersionOrBuildFromOpenGeeVersionFile(file, getString) {
+    return getString(
         file.readLines().
         collect {
             // Strip comments:
@@ -104,6 +107,20 @@ def getOsPackageVersionFromOpenGeeVersionFile(file) {
         findResult {
             it // The first string that remains is the version string.
         }
+    )
+}
+
+def getOsPackageVersionFromOpenGeeVersionFile(file) {
+    return getOsPackageVersionOrBuildFromOpenGeeVersionFile(
+        file,
+        getOsPackageVersionFromOpenGeeVersion
+    )
+}
+
+def getOsPackageBuildFromOpenGeeVersionFile(file) {
+    return getOsPackageVersionOrBuildFromOpenGeeVersionFile(
+        file,
+        getOsPackageBuildFromOpenGeeVersion
     )
 }
 
@@ -176,20 +193,34 @@ def rpmCommandFilter = {
     return rpmCapabilityMap.containsKey(it) ? rpmCapabilityMap[it] : it
 }
 
+// A lamda to figure out the best way to get the build number
+def findBuildNumber = {
+    return (!openGeeVersionFile.exists() || project.hasProperty('buildOpenGee')) ?
+        getOsPackageBuildFromOpenGeeVersion(GeeCommandLine.expand(
+                ["../src/scons/getversion.py", "--long"],
+                "Failed to get Open GEE build!"
+            )) :
+        getOsPackageBuildFromOpenGeeVersionFile(openGeeVersionFile)
+}
 
-ospackage {
-    release = "1.${rpmPlatformString}"
-    distribution = rpmPlatformString
-    packager = 'gee-oss@googlegroups.com'
-    vendor = 'The OpenGEE Contributors'
-    arch = X86_64
-    os = LINUX
-    version = (!openGeeVersionFile.exists() || project.hasProperty('buildOpenGee')) ?
+// A lamda to figure out the best way to get the version number
+def findVersionNumber = {
+    return (!openGeeVersionFile.exists() || project.hasProperty('buildOpenGee')) ?
         getOsPackageVersionFromOpenGeeVersion(GeeCommandLine.expand(
                 ["../src/scons/getversion.py", "--long"],
                 "Failed to get Open GEE version!"
             )) :
         getOsPackageVersionFromOpenGeeVersionFile(openGeeVersionFile)
+}
+
+ospackage {
+    release = "${findBuildNumber()}.${rpmPlatformString}"
+    distribution = rpmPlatformString
+    packager = 'gee-oss@googlegroups.com'
+    vendor = 'The OpenGEE Contributors'
+    arch = X86_64
+    os = LINUX
+    version = "${findVersionNumber()}"
 }
 
 logger.quiet("Open GEE version: ${ospackage.version}")
@@ -219,7 +250,7 @@ task openGeePostGisRpm(type: GeeRpm) {
     mustRunAfter stageOpenGeeInstall
 
     packageName = 'opengee-postgis'
-    release = "1.${rpmPlatformString}"
+    release = ospackage.release
     version = '2.3.4'
     user = 'root'
     permissionGroup = 'root'
@@ -250,7 +281,7 @@ task openGeePostGisDeb(type: GeeDeb) {
     mustRunAfter stageOpenGeeInstall
 
     packageName = openGeePostGisRpm.packageName
-    release = '1'
+    release = "${findBuildNumber()}"
     version = openGeePostGisRpm.version
     user = openGeePostGisRpm.user
     permissionGroup = openGeePostGisRpm.permissionGroup
@@ -308,7 +339,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeCommonInitScripts) {
 
     packageName = 'opengee-common'
     version = ospackage.version
-    release = "1.${rpmPlatformString}"
+    release = ospackage.release
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -400,7 +431,7 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeCommonInitScripts) {
 
     packageName = openGeeCommonRpm.packageName
     version = ospackage.version
-    release = '1'
+    release = ospackage.release
     user = openGeeCommonRpm.user
     permissionGroup = openGeeCommonRpm.permissionGroup
     packageGroup = 'misc'
@@ -472,7 +503,7 @@ task openGeeServerRpm(type: GeeRpm, dependsOn: openGeeServerInitScripts) {
 
     packageName = 'opengee-server'
     version = ospackage.version
-    release = "1.${rpmPlatformString}"
+    release = ospackage.release
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -575,7 +606,7 @@ task openGeeServerDeb (type: GeeDeb, dependsOn: openGeeServerInitScripts) {
 
     packageName = openGeeServerRpm.packageName
     version = ospackage.version
-    release = '1'
+    release = ospackage.release
     user = openGeeServerRpm.user
     permissionGroup = openGeeServerRpm.permissionGroup
     packageGroup = 'misc'
@@ -685,7 +716,7 @@ task openGeeFusionRpm (type: GeeRpm, dependsOn: openGeeFusionInitScripts) {
 
     packageName = 'opengee-fusion'
     version = ospackage.version
-    release = "1.${rpmPlatformString}"
+    release = ospackage.release
     user = 'root'
     permissionGroup = 'root'
     packageGroup = 'Application/Productivity'
@@ -768,7 +799,7 @@ task openGeeFusionDeb (type: GeeDeb, dependsOn: openGeeFusionInitScripts) {
 
     packageName = openGeeFusionRpm.packageName
     version = ospackage.version
-    release = '1'
+    release = ospackage.release
     user = openGeeFusionRpm.user
     permissionGroup = openGeeFusionRpm.permissionGroup
     packageGroup = 'misc'

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -193,7 +193,7 @@ def rpmCommandFilter = {
     return rpmCapabilityMap.containsKey(it) ? rpmCapabilityMap[it] : it
 }
 
-// A lamda to figure out the best way to get the build number
+// A lambda to figure out the best way to get the build number
 def findBuildNumber = {
     return (!openGeeVersionFile.exists() || project.hasProperty('buildOpenGee')) ?
         getOsPackageBuildFromOpenGeeVersion(GeeCommandLine.expand(
@@ -203,7 +203,7 @@ def findBuildNumber = {
         getOsPackageBuildFromOpenGeeVersionFile(openGeeVersionFile)
 }
 
-// A lamda to figure out the best way to get the version number
+// A lambda to figure out the best way to get the version number
 def findVersionNumber = {
     return (!openGeeVersionFile.exists() || project.hasProperty('buildOpenGee')) ?
         getOsPackageVersionFromOpenGeeVersion(GeeCommandLine.expand(


### PR DESCRIPTION
This fixes #1251 

This will not append the build number to the rpm version.  Instead build number will be put into the rpm release field and be used as a secondary version as it should be.   It is possible (but rarely done) to do multiple releases within a given version (mostly for critical bug fixes).