### PR TITLE
#1255 - Limits internal version string to 3 parts to fix patch releases

### DIFF
--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -12,9 +12,11 @@ def GetVersion(backupFile, label=''):
     """As getLongVersion(), but only return the leading *.*.* value."""
 
     raw = GetLongVersion(backupFile, label)
-    final = raw.split("-")[0]
 
-    return final
+    # Just return the first 3 parts of the version
+    short_ver = re.findall("^\\d+\\.\\d+\\.\\d+", raw)
+
+    return short_ver[0]
 
 
 def GetLongVersion(backupFile, label=''):
@@ -318,7 +320,9 @@ class OpenGeeVersion(object):
         """Returns the short version string."""
 
         if not self.short_version_string:
-            self.short_version_string = self.get_long().split("-")[0]
+            # Just return the first 3 parts of the version string
+            short_ver = re.findall("^\\d+\\.\\d+\\.\\d+", self.get_long())
+            self.short_version_string = short_ver[0]
 
         return self.short_version_string
 


### PR DESCRIPTION
Fixes #1255 

Internally, Fusion will only track 3 parts of the version string in order to maintain compatibility with the asset root and with client/server messages.

Verification steps
1. Install 5.2.5
1. Do build
1. Perform an upgrade to 5.2.5.2