### PR TITLE
I1258 b update release notes

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -148,7 +148,7 @@ gtag('config', 'UA-108632131-2');
             <td>1166</td>
             <td>Imagery resources can be created with invalid dates.</td>
             <td>
-              Added a validity check that ensures a valid date is entered. A date of 0000-00-00 can also be entered as a default value. The user will not be allowed to save with an invalid date entered.
+              Added a validity check that ensures a valid date is entered. A date of 0000-00-00 can also be entered as a default value. The user will not be allowed to save with an invalid date entered.  This applies only to the GUI.
             </td>
           </tr>
           <tr>
@@ -345,11 +345,6 @@ gtag('config', 'UA-108632131-2');
           <td>Re-open Fusion and avoid opening unsupported file types.</td>
         </tr>
         <tr>
-          <td>343</td>
-          <td>gefusion: File ->open->*.kiasset*,*.ktasset*,*.kip does not work</td>
-          <td>kip is not a supported format. Avoid opening files with .kip extension.</td>
-        </tr>
-        <tr>
           <td>380</td>
           <td>Provider field in resource-view is blank</td>
           <td>Open the individual resource to see the provider.</td>
@@ -442,7 +437,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>474</td>
           <td>Running gee_check on some supported platforms reports that the platform is not supported</td>
-          <td>You can ignore the failed test if using a supported platform (Ubuntu 14.04, Ubuntu 16.04, RHEL 7, and CentOS 7).</td>
+          <td>You can ignore the failed test if using a supported platform (Ubuntu 14.04, Ubuntu 16.04, RHEL 6 and 7, and CentOS 6 and 7).</td>
         </tr>
         <tr>
           <td>477</td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -50,14 +50,12 @@ gtag('config', 'UA-108632131-2');
       This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
     <p><strong>Added a <code>long_version</code> parameter to the SCons build. </strong>This will allow the user to override the long version string.</p>
 
-<p><strong>Added options to the Server install script</strong>
+<p><strong>Added options to the Server install script.</strong>
        The server install script now checks the size of the publish root and allows the user to set custom user and group names.
 </p>
 
 <p><strong>Improved system manager performance for large builds.</strong> This release eliminates some duplicate processing in system manager, which reduces the amount of time it takes to initiate large builds.
 </p>
-
-    <p><strong>Google has developed updated kmlrender libraries.</strong></p>
 
   <h5>
     <p id="supported_5.3.0">Supported Platforms</p>
@@ -212,6 +210,13 @@ gtag('config', 'UA-108632131-2');
             <td>Build number was incorrectly being appended to the version in RPM packaging</td>
             <td>
               RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not append it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
+            </td>
+          </tr>
+          <tr>
+            <td>1275</td>
+            <td>Search results from KML layers do not display properly in Earth Client.</td>
+            <td>
+               Updated KML rendering libraries with new versions provided by Google.
             </td>
           </tr>
           <tr>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -50,12 +50,12 @@ gtag('config', 'UA-108632131-2');
       This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
     <p><strong>Added a <code>long_version</code> parameter to the SCons build. </strong>This will allow the user to override the long version string.</p>
 
-    <p><strong>Added PUBLISHER_ROOT size checking.</strong>
-       ASSET_ROOT checking is performed in fusion installer - not duplicated in server installer.
-       Added <code>-pgu pguser</code>, <code>-au apacheuser</code>, and <code>-g group</code> options.
-       Added prompt and summary output similar to fusion installer.</p>
+<p><strong>Added options to the Server install script</strong>
+       The server install script now checks the size of the publish root and allows the user to set custom user and group names.
+</p>
 
-    <p><strong>We have improved the performance of large builds</strong> by consolidating some of the notifications that an asset's child or input has changed. By preventing (some) duplicate notifications we reduce the number of times each asset has to calculate its state, significantly improving performance.
+<p><strong>Improved system manager performance for large builds.</strong> This release eliminates some duplicate processing in system manager, which reduces the amount of time it takes to initiate large builds.
+</p>
 
     <p><strong>Google has developed updated kmlrender libraries.</strong></p>
 
@@ -140,13 +140,6 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
-            <td>1138</td>
-            <td>A recent merge introduced memory test code that fails to build on older compilers</td>
-            <td>
-              Add libyaml-cpp-dev to build requirements and remove some old includes.
-            </td>
-          </tr>
-          <tr>
             <td>1158</td>
             <td><code>geeServerDefs</code> are not returned by Portable Server after being requested, once the globe has been viewed by a client. It is not possible to request <code>geeServerDefs</code> for globes other than the current <code>selectedGlobe</code>.</td>
             <td>
@@ -185,15 +178,7 @@ gtag('config', 'UA-108632131-2');
             <td>1192</td>
             <td>There appears to be a regression issue in OpenJpeg 2000 lib version 2.3.0 (that Fusion uses), causing an error when fusing jp2 files.</td>
             <td>
-               This OpenJpeg 2000 issue is fixed in OpenJpeg master but since the fix was made there was no new released version of OpenJpeg 2000 library (as per today: 2/8/2019).
-               <br> Two workarounds:
-               <ll>
-               <li>
-                   Uses QGIS tool to convert the jp2 file into Geotiff. QGIS would uses Erdas jp2 driver to do the jp2 reading in order to convert to Geotiff. Then use the produced Geotiff in Fusion.
-               </li>
-               <li>
-                   Get OpenJpeg 2000 master and uses that .zip after converting it to .tar.gz to replace current OpenJpeg 2000 shipped with OpenGEE. Build OpenGEE (with updated OpenJpeg 2000) and fuse the jp2 that had the issue.
-               </li>
+               We have upgraded to OpenJpeg 2.3.1.
             </td>
           </tr>
           <tr>
@@ -523,6 +508,16 @@ gtag('config', 'UA-108632131-2');
           <td>825</td>
           <td>Geserver fails to startup fully due to conflicting protobuf library</td>
           <td>Run <code>pip uninstall protobuf</code> to uninstall the protobuf library installed by pip. </td>
+        </tr>
+        <tr>
+          <td>1202</td>
+          <td>Can't select .kip, .ktp, or .kvp as source for resource using Fusion UI.</td>
+          <td>Add the resource from the command line.</td>
+        </tr>
+        <tr>
+          <td>1257</td>
+          <td>Fusion CLI allows users to enter an invalid date/time for Imagery Resources.</td>
+          <td>Ensure you use a valid date when creating resources from the command line.</td>
         </tr>
       </tbody>
     </table>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -54,8 +54,9 @@ gtag('config', 'UA-108632131-2');
        The server install script now checks the size of the publish root and allows the user to set custom user and group names.
 </p>
 
-<p><strong>Improved system manager performance for large builds.</strong> This release eliminates some duplicate processing in system manager, which reduces the amount of time it takes to initiate large builds.
-</p>
+<p><strong>Improved system manager performance for large builds.</strong> This release eliminates some duplicate processing in system manager, which reduces the amount of time it takes to initiate large builds.</p>
+
+<p><strong>Upgraded to OpenJPEG 2000 2.3.1.</strong> This upgrade brings bugs fixes and improvements.</p>
 
   <h5>
     <p id="supported_5.3.0">Supported Platforms</p>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -104,26 +104,19 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
+            <td>279</td>
+            <td>Server upgrade resets the Admin Console password</td>
+            <td>
+              When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
+            </td>
+          </tr>
+          <tr>
             <td>799</td>
             <td>The GEE Portable Server does not return valid JSON when queried with <code>http://&lt;server&gt;/&lt;map&gt;/query?request=Json</code>.</td>
             <td>
               Added a <code>v</code> parameter to the query; when its value is 2, the GEE Portable Server will return proper JSON.  Currently, it defaults to 1 if not specified.
             </td>
           </tr> 
-           <tr>
-            <td>1158</td>
-            <td><code>geeServerDefs</code> are not returned by Portable Server after being requested, once the globe has been viewed by a client. It is not possible to request <code>geeServerDefs</code> for globes other than the current <code>selectedGlobe</code>.</td>
-            <td>
-              <code>geeServerDefs</code> are returned correctly and can be requested for any valid globe at any time.
-            </td>
-          </tr>
-          <tr>
-            <td>1187</td>
-            <td>RPM upgrades change owner and permissions on symlinked portable globes directories</td>
-            <td>
-              Symlinked portable globe directories are not modified during geserver upgrades
-            </td>
-          </tr>
           <tr>
             <td>1093</td>
             <td>The <code>geselectpublishroot</code> server command line tool offers no help, and appears to take some action when the <code>--help</code> flag is specified</td>
@@ -132,15 +125,71 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
-            <td>1194</td>
-            <td>Sockets build up during large project builds</td>
-            <td>gesystemmanager now has a timeout when trying to respond to a request for status. This prevents a backlog of requests that could build up while it is busy handling a long-running request. The timeout is configurable.</td>
+            <td>1098</td>
+            <td>TravisCI can pass when compilation fails</td>
+            <td>
+              Add logic to cause compilation failures to be detected and reported
+            </td>
+          </tr>
+          <tr>
+            <td>1122</td>
+            <td>Check for PIL (Python Imager Library) returns an error</td>
+            <td>
+              Change how PIL is included.
+            </td>
+          </tr>
+          <tr>
+            <td>1138</td>
+            <td>A recent merge introduced memory test code that fails to build on older compilers</td>
+            <td>
+              Add libyaml-cpp-dev to build requirements and remove some old includes.
+            </td>
+          </tr>
+          <tr>
+            <td>1158</td>
+            <td><code>geeServerDefs</code> are not returned by Portable Server after being requested, once the globe has been viewed by a client. It is not possible to request <code>geeServerDefs</code> for globes other than the current <code>selectedGlobe</code>.</td>
+            <td>
+              <code>geeServerDefs</code> are returned correctly and can be requested for any valid globe at any time.
+            </td>
           </tr>
           <tr>
             <td>1166</td>
             <td>Imagery resources can be created with invalid dates</td>
             <td>
               Added a validity check that ensures a valid date is entered. A date of 0000-00-00 can also be entered as a default value. The user will not be allowed to save with an invalid date entered.
+            </td>
+          </tr>
+          <tr>
+            <td>1169</td>
+            <td>Cutting a globe with historical imagery embeds a link to the original Google Earth Server that served the historical imagery.</td>
+            <td>
+              There is an advanced option to include historical imagery links or not. The default option will be to NOT include links to historical imagery, and the links will be stripped from the cut globe.  When the historical imagery links are enabled, the existing behavior will be preserved.
+            </td>
+          </tr>
+          <tr>
+            <td>1187</td>
+            <td>RPM upgrades change owner and permissions on symlinked portable globes directories</td>
+            <td>
+              Symlinked portable globe directories are not modified during geserver upgrades.
+            </td>
+          </tr>
+          <tr>
+            <td>1190</td>
+            <td>Some 32-bit platforms are unable to open files of size >2GB</td>
+            <td>
+              Use POSIX file API to support large files on some 32-bit platforms.
+            </td>
+          </tr>
+          <tr>
+            <td>1194</td>
+            <td>Sockets build up during large project builds</td>
+            <td>gesystemmanager now has a timeout when trying to respond to a request for status. This prevents a backlog of requests that could build up while it is busy handling a long-running request. The timeout is configurable.</td>
+          </tr>
+          <tr>
+            <td>1201</td>
+            <td>Fusion uses incorrect or no date if using .kip files as source</td>
+            <td>
+              Fusion now uses acquisition data correctly.
             </td>
           </tr>
           <tr>
@@ -151,24 +200,10 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
-            <td>1226</td>
-            <td>Ubuntu 14.04 Installation Requires Boost</td>
-            <td>
-              Documented this required dependency.
-            </td>
-          </tr>          
-          <tr>
             <td>1228</td>
-            <td>Assemble button is not fully visible, making it difficult to use the GLC assembly tool</td>
+            <td>Assemble button is not fully visible, making it difficult to use the GLC assembly tool.</td>
             <td>
               Added a scroll-bar to glc_assemble webpage to allow scrolling to 'Assemble' button.
-            </td>
-          </tr>
-          <tr>
-            <td>279</td>
-            <td>Server upgrade resets the Admin Console password</td>
-            <td>
-              When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
             </td>
           </tr>
           <tr>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -49,6 +49,16 @@ gtag('config', 'UA-108632131-2');
       This can be done by configuring the <code>PURGE</code> and <code>PURGE_LEVEL</code> settings in <code>/etc/opt/google/XMLparams</code>. 
       This file must be created manually. View the <a href="../answer/176738.html">Configure Fusion performance</a> document for more details.</p>
     <p><strong>Added a <code>long_version</code> parameter to the SCons build. </strong>This will allow the user to override the long version string.</p>
+
+    <p><strong>Added PUBLISHER_ROOT size checking.</strong>
+       ASSET_ROOT checking is performed in fusion installer - not duplicated in server installer.
+       Added <code>-pgu pguser</code>, <code>-au apacheuser</code>, and <code>-g group</code> options.
+       Added prompt and summary output similar to fusion installer.</p>
+
+    <p><strong>We have improved the performance of large builds</strong> by consolidating some of the notifications that an asset's child or input has changed. By preventing (some) duplicate notifications we reduce the number of times each asset has to calculate its state, significantly improving performance.
+
+    <p><strong>Google has developed updated kmlrender libraries.</strong></p>
+
   <h5>
     <p id="supported_5.3.0">Supported Platforms</p>
   </h5>
@@ -77,22 +87,6 @@ gtag('config', 'UA-108632131-2');
             <td>Incorrect error messages from Fusion installer</td>
             <td>
               Stop incorrect error from showing when re-installing with<code> -u </code>flag
-            </td>
-          </tr>
-          <tr>
-          <tr>
-            <td><br><br>171</td>
-            <td>
-                PUBLISH_ROOT_VOLUME size checking<br>
-                ASSET_ROOT and PUBLISH_ROOT volume checking<br>
-                Some script parameters - parsing and execution (based on those provided by the Fusion installer)<br>
-                Prompts and summary output similar Fusion installer
-            </td>
-            <td>
-              Added PUBLISHER_ROOT size checking.<br>
-              ASSET_ROOT checking is performed in fusion installer - not duplicated in server installer<br>
-              Added <code>-pgu pguser</code>, <code>-au apacheuser</code>, and <code>-g group</code> options.<br>
-              Added prompt and summary output similar to fusion installer.
             </td>
           </tr>
           <tr>
@@ -129,6 +123,13 @@ gtag('config', 'UA-108632131-2');
             <td>TravisCI can pass when compilation fails</td>
             <td>
               Add logic to cause compilation failures to be detected and reported
+            </td>
+          </tr>
+          <tr>
+            <td>1104</td>
+            <td>Centos 7 (and maybe others) fails to build OpenGEE. Build seems to fail when building third party parts of Qt. This appears to be an issue with libpng.</td>
+            <td>
+              Fixed by including <code>libpng12</code> in the build script.
             </td>
           </tr>
           <tr>
@@ -181,6 +182,21 @@ gtag('config', 'UA-108632131-2');
             </td>
           </tr>
           <tr>
+            <td>1192</td>
+            <td>There appears to be a regression issue in OpenJpeg 2000 lib version 2.3.0 (that Fusion uses), causing an error when fusing jp2 files.</td>
+            <td>
+               This OpenJpeg 2000 issue is fixed in OpenJpeg master but since the fix was made there was no new released version of OpenJpeg 2000 library (as per today: 2/8/2019).
+               <br> Two workarounds:
+               <ll>
+               <li>
+                   Uses QGIS tool to convert the jp2 file into Geotiff. QGIS would uses Erdas jp2 driver to do the jp2 reading in order to convert to Geotiff. Then use the produced Geotiff in Fusion.
+               </li>
+               <li>
+                   Get OpenJpeg 2000 master and uses that .zip after converting it to .tar.gz to replace current OpenJpeg 2000 shipped with OpenGEE. Build OpenGEE (with updated OpenJpeg 2000) and fuse the jp2 that had the issue.
+               </li>
+            </td>
+          </tr>
+          <tr>
             <td>1194</td>
             <td>Sockets build up during large project builds</td>
             <td>gesystemmanager now has a timeout when trying to respond to a request for status. This prevents a backlog of requests that could build up while it is busy handling a long-running request. The timeout is configurable.</td>
@@ -211,6 +227,13 @@ gtag('config', 'UA-108632131-2');
             <td>Build number was incorrectly being appended to the version in RPM packaging</td>
             <td>
               RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not append it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
+            </td>
+          </tr>
+          <tr>
+            <td>1276</td>
+            <td>System manager purges the asset and asset version caches unnecessarily during builds. For large builds this can evict most of the items from the cache.</td>
+            <td>
+               Remove the calls to these purge functions.
             </td>
           </tr>
         </tbody>
@@ -254,7 +277,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>126</td>
           <td>The Fusion installer creates a backup on the first run</td>
-          <td>No current work around. The created backup can be deleted.</td>
+          <td>The created backup can be deleted.</td>
         </tr>
         <tr>
           <td>190</td>
@@ -334,7 +357,7 @@ gtag('config', 'UA-108632131-2');
         <tr>
           <td>343</td>
           <td>gefusion: File ->open->*.kiasset*,*.ktasset*,*.kip does not work</td>
-          <td>kip is not a supported format. Void opening files with .kip extension.</td>
+          <td>kip is not a supported format. Avoid opening files with .kip extension.</td>
         </tr>
         <tr>
           <td>380</td>

--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -82,22 +82,22 @@ gtag('config', 'UA-108632131-2');
           </tr>
           <tr>
             <td>127</td>
-            <td>Incorrect error messages from Fusion installer</td>
+            <td>Incorrect error messages from Fusion installer.</td>
             <td>
-              Stop incorrect error from showing when re-installing with<code> -u </code>flag
+              Stop incorrect error from showing when re-installing with<code> -u </code>flag.
             </td>
           </tr>
           <tr>
             <td>200</td>
             <td><code>stage_install</code> fails on the tutorial files when <code>/home</code>
-              and <code>/tmp</code> are on different file systems</td>
+              and <code>/tmp</code> are on different file systems.</td>
             <td>
               Files are linked in <code>/tmp</code> using symbolic links back to original locations.
             </td>
           </tr>
           <tr>
             <td>279</td>
-            <td>Server upgrade resets the Admin Console password</td>
+            <td>Server upgrade resets the Admin Console password.</td>
             <td>
               When the GEE server is upgraded, either through the <code>install_server.sh</code> script or the RPMs, the Admin Console password will be preserved if the password file is found at the expected location.
             </td>
@@ -111,28 +111,28 @@ gtag('config', 'UA-108632131-2');
           </tr> 
           <tr>
             <td>1093</td>
-            <td>The <code>geselectpublishroot</code> server command line tool offers no help, and appears to take some action when the <code>--help</code> flag is specified</td>
+            <td>The <code>geselectpublishroot</code> server command line tool offers no help, and appears to take some action when the <code>--help</code> flag is specified.</td>
             <td>
-              Help has been added through the <code>--help</code> option, or if any invalid parameter is given
+              Help has been added through the <code>--help</code> option, or if any invalid parameter is given.
             </td>
           </tr>
           <tr>
             <td>1098</td>
-            <td>TravisCI can pass when compilation fails</td>
+            <td>TravisCI can pass when compilation fails.</td>
             <td>
-              Add logic to cause compilation failures to be detected and reported
+              Add logic to cause compilation failures to be detected and reported.
             </td>
           </tr>
           <tr>
             <td>1104</td>
-            <td>Centos 7 (and maybe others) fails to build OpenGEE. Build seems to fail when building third party parts of Qt. This appears to be an issue with libpng.</td>
+            <td>CentOS 7 (and maybe others) fails to build OpenGEE. Build seems to fail when building third party parts of Qt. This appears to be an issue with libpng.</td>
             <td>
               Fixed by including <code>libpng12</code> in the build script.
             </td>
           </tr>
           <tr>
             <td>1122</td>
-            <td>Check for PIL (Python Imager Library) returns an error</td>
+            <td>Check for PIL (Python Imaging Library) returns an error.</td>
             <td>
               Change how PIL is included.
             </td>
@@ -146,7 +146,7 @@ gtag('config', 'UA-108632131-2');
           </tr>
           <tr>
             <td>1166</td>
-            <td>Imagery resources can be created with invalid dates</td>
+            <td>Imagery resources can be created with invalid dates.</td>
             <td>
               Added a validity check that ensures a valid date is entered. A date of 0000-00-00 can also be entered as a default value. The user will not be allowed to save with an invalid date entered.
             </td>
@@ -160,40 +160,40 @@ gtag('config', 'UA-108632131-2');
           </tr>
           <tr>
             <td>1187</td>
-            <td>RPM upgrades change owner and permissions on symlinked portable globes directories</td>
+            <td>RPM upgrades change owner and permissions on symlinked portable globe directories.</td>
             <td>
               Symlinked portable globe directories are not modified during geserver upgrades.
             </td>
           </tr>
           <tr>
             <td>1190</td>
-            <td>Some 32-bit platforms are unable to open files of size >2GB</td>
+            <td>Some 32-bit platforms are unable to open files of size >2GB.</td>
             <td>
               Use POSIX file API to support large files on some 32-bit platforms.
             </td>
           </tr>
           <tr>
             <td>1192</td>
-            <td>There appears to be a regression issue in OpenJpeg 2000 lib version 2.3.0 (that Fusion uses), causing an error when fusing jp2 files.</td>
+            <td>There appears to be a regression issue in OpenJPEG 2000 lib version 2.3.0 (that Fusion uses), causing an error when fusing jp2 files.</td>
             <td>
-               We have upgraded to OpenJpeg 2.3.1.
+               We have upgraded to OpenJPEG 2.3.1.
             </td>
           </tr>
           <tr>
             <td>1194</td>
-            <td>Sockets build up during large project builds</td>
+            <td>Sockets build up during large project builds.</td>
             <td>gesystemmanager now has a timeout when trying to respond to a request for status. This prevents a backlog of requests that could build up while it is busy handling a long-running request. The timeout is configurable.</td>
           </tr>
           <tr>
             <td>1201</td>
-            <td>Fusion uses incorrect or no date if using .kip files as source</td>
+            <td>Fusion uses incorrect or no date if using .kip files as source.</td>
             <td>
               Fusion now uses acquisition data correctly.
             </td>
           </tr>
           <tr>
             <td>1210</td>
-            <td>Fix Xerces-related memory leaks</td>
+            <td>Fix Xerces-related memory leaks.</td>
             <td>
               Added an experimental option that fixes several memory leaks related to our usage of the Xerces library.
             </td>
@@ -207,7 +207,7 @@ gtag('config', 'UA-108632131-2');
           </tr>
           <tr>
             <td>1251</td>
-            <td>Build number was incorrectly being appended to the version in RPM packaging</td>
+            <td>Build number was incorrectly being appended to the version in RPM packaging.</td>
             <td>
               RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not append it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
             </td>
@@ -246,12 +246,12 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>8</td>
-          <td>Ensure GEE Portable Cutter Job Completes</td>
+          <td>Ensure GEE Portable Cutter job completes</td>
           <td>No current work around.</td>
         </tr>
         <tr>
           <td>9</td>
-          <td>Improve FileUnpacker Handling of Invalid Files</td>
+          <td>Improve FileUnpacker handling of invalid files</td>
           <td>No current work around.</td>
         </tr>
         <tr>
@@ -261,7 +261,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>34</td>
-          <td>Scons build creates temporary directories named “0” </td>
+          <td>SCons build creates temporary directories named “0” </td>
           <td>No current work around.</td>
         </tr>
         <tr>
@@ -386,7 +386,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>419</td>
-          <td>Fix Fusion Graphics Acceleration in Ubuntu 14 Docker Container Hosted on Ubuntu 16</td>
+          <td>Fix Fusion graphics acceleration in Ubuntu 14 Docker container hosted on Ubuntu 16</td>
           <td>No current work around.</td>
         </tr>
         <tr>
@@ -496,7 +496,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>686</td>
-          <td>Scons fails to detect libpng library on CentOS 6</td>
+          <td>SCons fails to detect libpng library on CentOS 6</td>
           <td>Ensure that a default <code>g++</code> compiler is installed.</td>
         </tr>
         <tr>
@@ -511,7 +511,7 @@ gtag('config', 'UA-108632131-2');
         </tr>
         <tr>
           <td>825</td>
-          <td>Geserver fails to startup fully due to conflicting protobuf library</td>
+          <td>Geserver fails to start up fully due to conflicting protobuf library</td>
           <td>Run <code>pip uninstall protobuf</code> to uninstall the protobuf library installed by pip. </td>
         </tr>
         <tr>


### PR DESCRIPTION
The is a second attempt to push changes to 7160007.html - update release notes.

Fixes #1258 

Release notes can be viewed at:
https://tst-eclamar.github.io/earthenterprise/geedocs/5.3.0/answer/7160007.html