### PR TITLE
1270 Fix xml parsing in common.sh

### DIFF
--- a/docs/geedocs/5.3.0/answer/7160007.html
+++ b/docs/geedocs/5.3.0/answer/7160007.html
@@ -178,6 +178,14 @@ gtag('config', 'UA-108632131-2');
               RPM packaging should put the build number in the <code>release</code> field of the RPM properties and not append it to the version number in the <code>version</code> field.  This was preventing point releases from properly upgrading.
             </td>
           </tr>
+          <tr>
+            <td>1270</td>
+            <td>Fusion uninstaller uses incorrect username " ------"</td>
+            <td>
+              Fixed XML parsing in common.sh that could return incorrect values.
+            </td>
+          </tr>
+
         </tbody>
       </table>
   <h5>

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -75,7 +75,7 @@ xml_file_get_xpath()
 
     # Warning: `xmllint --noent` doesn't recognize named entities like
     # "&lt;" and "&gt;":
-    xmllint --nonet --noent --nocdata --xpath "$XPATH" "$FILE"
+    echo "cat $XPATH" | xmllint --noent --nonet --shell "$FILE" | tail -2 | head -1
 }
 
 is_package_installed()

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -75,9 +75,7 @@ xml_file_get_xpath()
 
     # Warning: `xmllint --noent` doesn't recognize named entities like
     # "&lt;" and "&gt;":
-    echo "cat $XPATH" | xmllint --noent --nocdata --shell "$FILE" |
-    # Skip the first and the last line:
-        tail -n +2 | head -n -1
+    xmllint --nonet --noent --nocdata --xpath "$XPATH" "$FILE"
 }
 
 is_package_installed()


### PR DESCRIPTION
Simplified and fixed the call to xmllint that the install and uninstall scripts use to parse XML.