### PR TITLE
1279 Fix getversion.py for Windows and update OpenGEE copyright year.

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/local/preview/developers/terms.html
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/preview/developers/terms.html
@@ -1,6 +1,6 @@
 <!--
   Copyright 2017 Google Inc.
-  Copyright 2018 the OpenGEE Contributors.
+  Copyright 2018-2019 the OpenGEE Contributors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@
       <p>
 	Copyright 2017 Google Inc.
     <br>
-    Copyright 2018 the OpenGEE Contributors.
+    Copyright 2018-2019 the OpenGEE Contributors.
       <p>
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
@@ -1,6 +1,6 @@
 <!--
   Copyright 2017 Google Inc.
-  Copyright 2018 the OpenGEE Contributors.
+  Copyright 2018-2019 the OpenGEE Contributors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -104,9 +104,9 @@
         Version: <span id="BuildVersion"></span>
         <br>
         <br>
-        &copy; 2010-2015 Google.
+        &copy; 2010-2017 Google.
         <br>
-        &copy; 2015-2018 the OpenGEE Contributors.
+        &copy; 2018-2019 the OpenGEE Contributors.
         <br>
         <a href="/local/preview/developers/terms.html">Portable Terms of Service</a>
         <iframe class="IframeAbout" id="IframeAbout" frameborder="0" scrolling="no" style="display: none;">

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -125,10 +125,24 @@ def _GitPreviousReleaseTag(tailTagName):
     return ''
 
 
+def _GitTagRealCommitIdWindows(tagName):
+    """use shell command to retrieve commit id of where the tag points to (Windows version)"""
+    # for some reason .hexsha was not returning the same id....
+    commitId = os.popen("git rev-list -n 1 \"{0}\"".format(tagName.replace("\"", "\\\""))).read().strip()
+    return commitId
+
+def _GitTagRealCommitIdLinux(tagName):
+    """use shell command to retrieve commit id of where the tag points to (Linux version)"""
+    # for some reason .hexsha was not returning the same id....
+    commitId = os.popen("git rev-list -n 1 '{0}'".format(tagName.replace("'", "'\"'\"'"))).read().strip()
+    return commitId
+
 def _GitTagRealCommitId(tagName):
     """use shell command to retrieve commit id of where the tag points to"""
-    # for some reason .hexsha was not returning the same id....
-    return os.popen("git rev-list -n 1 '{0}'".format(tagName.replace("'", "'\"'\"'"))).read().strip()
+    if os.name is 'nt':
+        return _GitTagRealCommitIdWindows(tagName)
+    else:
+        return _GitTagRealCommitIdLinux(tagName)
 
 def _git_tag_list():
     """use shell command to retrieve a list of tags"""


### PR DESCRIPTION
Address #1279

Need a different parameters for _GitTagRealCommitId() depending on which platform getversion.py is running on.  Also during Portable Server testing on Windows I found that the copyright year needed to be updated.

To verify the change, checkout this PR and run it's getversion.py on both Linux and Windows.  For this branch it should return `5.3.0`.