### PR TITLE
Fix getop missing line

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -212,7 +212,7 @@ main(int argc, char *argv[])
         numlines -= 5;
 
         for (uint i = 0; i < pslist.size(); ++i) {
-          if (numlines > 2) {
+          if (numlines > 3) {
             outline("%s", pslist[i].c_str());
             --numlines;
           } else {

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -193,7 +193,7 @@ main(int argc, char *argv[])
         for (std::vector<TaskLists::WaitingTask>::const_iterator w =
                taskLists.waitingTasks.begin();
              w != taskLists.waitingTasks.end(); ++w) {
-          if (numlines > 5) {
+          if (numlines > 6) {
             outline("  %s", w->verref.c_str());
             --numlines;
             if (!w->activationError.isEmpty()) {
@@ -209,10 +209,10 @@ main(int argc, char *argv[])
 
         outline("");
         outline("Fusion processes on this host:");
-        numlines -= 5;
+        numlines -= 6;
 
         for (uint i = 0; i < pslist.size(); ++i) {
-          if (numlines > 3) {
+          if (numlines > 2) {
             outline("%s", pslist[i].c_str());
             --numlines;
           } else {


### PR DESCRIPTION
The recent addition of a status line to the getop display resulted in the top line getting pushed off of the screen when there were lots of processes running. This changes the hard-coded values to account for the extra line in the display.