### PR TITLE
Issue #1292: qtpacket status incorrect

### DIFF
--- a/earth_enterprise/integration_test/specs/state_propagation.spec
+++ b/earth_enterprise/integration_test/specs/state_propagation.spec
@@ -287,8 +287,6 @@ Rebuild Project
 
 ## Resources Belonging to Multiple Projects
 Tags: multiproject, build, cancel, clean, rebuild
-This is the longest test (in terms of time) because it includes buliding a
-terrain resource.
 
 Set up
 * Create imagery project "StatePropagationTest_MultiProject1"
@@ -504,7 +502,7 @@ Set up
 
 Build database
 * Build database "Database_Mercator"
-* Verify that the state of database "Database_Mercator" is "Waiting"
+* Verify that the state of mercator database "Database_Mercator" is "Waiting"
 * Verify that the state of map project "StatePropagationTest_Mercator" is "Waiting"
 * Verify that the state of map layer "StatePropagationTest_Mercator" is in
   | State      |
@@ -512,17 +510,17 @@ Build database
   | InProgress |
   | Queued     |
 * Verify that the state of vector resource "CA_POIs_Merc" is "Succeeded"
-* Verify that the state of imagery project "StatePropagationTest_Mercator" is "Waiting"
-* Verify that the state of imagery resource "BlueMarble_Mercator" is "InProgress"
+* Verify that the state of mercator imagery project "StatePropagationTest_Mercator" is "Waiting"
+* Verify that the state of mercator imagery resource "BlueMarble_Mercator" is "InProgress"
 
 Wait for success
-* Wait for database "Database_Mercator" to reach state "Succeeded"
-* Verify that the state of database "Database_Mercator" is "Succeeded"
+* Wait for mercator database "Database_Mercator" to reach state "Succeeded"
+* Verify that the state of mercator database "Database_Mercator" is "Succeeded"
 * Verify that the state of map project "StatePropagationTest_Mercator" is "Succeeded"
 * Verify that the state of map layer "StatePropagationTest_Mercator" is "Succeeded"
 * Verify that the state of vector resource "CA_POIs_Merc" is "Succeeded"
-* Verify that the state of imagery project "StatePropagationTest_Mercator" is "Succeeded"
-* Verify that the state of imagery resource "BlueMarble_Mercator" is "Succeeded"
+* Verify that the state of mercator imagery project "StatePropagationTest_Mercator" is "Succeeded"
+* Verify that the state of mercator imagery resource "BlueMarble_Mercator" is "Succeeded"
 
 ## Database, Terrain, and Vector Tests
 Tags: terrain, vector, build

--- a/earth_enterprise/integration_test/step_impl/assets.py
+++ b/earth_enterprise/integration_test/step_impl/assets.py
@@ -427,7 +427,7 @@ def verify_state_database(database, state):
     # Check the states of the database's children
     verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "gedb"), state)
     verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "unifiedindex"), state)
-    #verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "qtpacket"), state)
+    verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "qtpacket"), state)
     terrainPath = os.path.join(DATABASE_PATH, database + ".kdatabase", "terrain")
     if os.path.isdir(terrainPath + ".kta"):
       # Only check for the terrain task if it's there. Not all databases have terrain.

--- a/earth_enterprise/integration_test/step_impl/assets.py
+++ b/earth_enterprise/integration_test/step_impl/assets.py
@@ -1,8 +1,10 @@
 from getgauge.python import step
 import os
+import re
 import subprocess
 import time
 
+ASSET_ROOT = "/gevol/assets"
 BASE_ASSET_PATH = "gauge_tests"
 DATABASE_PATH = os.path.join(BASE_ASSET_PATH, "Databases")
 MAP_LAYER_PATH = os.path.join(BASE_ASSET_PATH, "MapLayers")
@@ -139,6 +141,7 @@ def create_vector_resource_add_to_proj(resource, srcPath, project):
   # Vector resources must be built before they can be added to projects
   build_vector_resource(resource)
   wait_for_vector_resource_state(resource, "Succeeded")
+  verify_state_vector_resource(resource, "Succeeded")
   add_vector_resource_to_project(resource, project)
 
 @step("Verify that imagery project <project> has no versions")
@@ -249,32 +252,92 @@ def wait_until_state(asset, statuses):
 @step("Wait for imagery project <project> to reach state <state>")
 def wait_for_imagery_project_state(project, state):
   wait_until_state(os.path.join(IMAGERY_PROJECT_PATH, project), state)
+  verify_state_imagery_proj(project, state)
 
 @step("Wait for vector resource <resource> to reach state <state>")
 def wait_for_vector_resource_state(resource, state):
   wait_until_state(os.path.join(VECTOR_RESOURCE_PATH, resource), state)
+  verify_state_vector_resource(resource, state)
 
 @step("Wait for database <database> to reach state <state>")
 def wait_for_database_state(database, state):
   wait_until_state(os.path.join(DATABASE_PATH, database), state)
+  verify_state_database(database, state)
+
+@step("Wait for mercator database <database> to reach state <state>")
+def wait_for_mercator_database_state(database, state):
+  wait_until_state(os.path.join(DATABASE_PATH, database), state)
+  verify_state_mercator_database(database, state)
 
 def verify_state(path, states):
   states = make_list(states)
   status = get_status(path)
   assert status in states, "Asset %s in unexpected state. Expected: %s, actual: %s" % (path, " ".join(states), status)
 
+def get_one_input(path, project, extension):
+  hasInput = re.compile(r".*/(\w*\." + extension + ").*")
+  deps = subprocess.check_output(["/opt/google/bin/gequery", "--dependencies", os.path.join(path, project)])
+  depsIter = iter(deps.splitlines())
+  for line in depsIter:
+    match = hasInput.match(line)
+    if match:
+      return match.group(1)
+  assert False, "Could not find input for " + project
+
+def get_one_packlevel(path, resource, ext):
+  fullPath = os.path.join(ASSET_ROOT, path, resource, "CombinedRP." + ext, "packgen." + ext)
+  files = os.listdir(fullPath)
+  for f in files:
+    if f.startswith("packlevel"):
+      return f
+  assert False, "Could not find packlevel for " + resource
+
+def verify_state_imagery_proj_helper(project, state, projExt, resExt):
+  verify_state(os.path.join(IMAGERY_PROJECT_PATH, project), state)
+  if state == "Succeeded":
+    # Check the states of the project's children
+    verify_state(os.path.join(IMAGERY_PROJECT_PATH, project + "." + projExt, "layerjs"), state)
+    verify_state(os.path.join(IMAGERY_PROJECT_PATH, project + "." + projExt, "dbroot"), state)
+    verify_state(os.path.join(IMAGERY_PROJECT_PATH, project + "." + projExt, "geindex"), state)
+    # Check the tasks that are built under the resource but only when the project is built (only check one resource)
+    resource = get_one_input(IMAGERY_PROJECT_PATH, project, resExt)
+    # In one test the CombinedRP ends up in a "cleaned" state even though the packgens
+    # succeeded. I'm not sure why that happens, but if it's a bug it's been there for a while.
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource, "CombinedRP"), ["Succeeded", "Cleaned"])
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource, "CombinedRP.kia", "packgen"), state)
+    # Only check one pack level
+    packlev = get_one_packlevel(IMAGERY_RESOURCE_PATH, resource, "kia")
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource, "CombinedRP.kia", "packgen.kia", packlev), state)
+
 @step("Verify that the state of imagery project <project> is <state>")
 def verify_state_imagery_proj(project, state):
-  verify_state(os.path.join(IMAGERY_PROJECT_PATH, project), state)
+  verify_state_imagery_proj_helper(project, state, "kiproject", "kiasset")
+
+@step("Verify that the state of mercator imagery project <project> is <state>")
+def verify_state_mercator_imagery_proj(project, state):
+  verify_state_imagery_proj_helper(project, state, "kimproject", "kimasset")
 
 @step("Verify that the state of imagery project <project> is in <table>")
 def verify_state_imagery_project_table(project, table):
   states = list_from_table(table)
   verify_state(os.path.join(IMAGERY_PROJECT_PATH, project), states)
-  
+
+def verify_state_imagery_resource_helper(resource, state, resExt):
+  verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource), state)
+  if state == "Succeeded":
+    # Check the states of the resource's children
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource + "." + resExt, "maskgen"), state)
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource + "." + resExt, "maskproduct"), state)
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource + "." + resExt, "product"), state)
+    verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource + "." + resExt, "source"), state)
+
 @step("Verify that the state of imagery resource <resource> is <state>")
 def verify_state_imagery_resource(resource, state):
-  verify_state(os.path.join(IMAGERY_RESOURCE_PATH, resource), state)
+  verify_state_imagery_resource_helper(resource, state, "kiasset")
+
+@step("Verify that the state of mercator imagery resource <resource> is <state>")
+def verify_state_mercator_imagery_resource(resource, state):
+  verify_state_imagery_resource_helper(resource, state, "kimasset")
 
 @step("Verify that the state of imagery resource <resource> is in <table>")
 def verify_state_imagery_resource_table(resource, table):
@@ -297,6 +360,17 @@ def verify_state_default_images_table(project, table):
 @step("Verify that the state of terrain project <project> is <state>")
 def verify_state_terrain_proj(project, state):
   verify_state(os.path.join(TERRAIN_PROJECT_PATH, project), state)
+  if state == "Succeeded":
+    # Check the states of the project's children
+    verify_state(os.path.join(TERRAIN_PROJECT_PATH, project + ".ktproject", "dbroot"), state)
+    verify_state(os.path.join(TERRAIN_PROJECT_PATH, project + ".ktproject", "geindex"), state)
+    # Check the tasks that are built under the resource but only when the project is built (only check one resource)
+    resource = get_one_input(TERRAIN_PROJECT_PATH, project, "ktasset")
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource, "CombinedRP"), state)
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource, "CombinedRP.kta", "packgen"), state)
+    # Only check one pack level
+    packlev = get_one_packlevel(TERRAIN_RESOURCE_PATH, resource, "kta")
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource, "CombinedRP.kta", "packgen.kta", packlev), state)
 
 @step("Verify that the state of terrain project <project> is in <table>")
 def verify_state_terrain_project_table(project, table):
@@ -306,6 +380,12 @@ def verify_state_terrain_project_table(project, table):
 @step("Verify that the state of terrain resource <resource> is <state>")
 def verify_state_terrain_resource(resource, state):
   verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource), state)
+  if state == "Succeeded":
+    # Check the states of the resource's children
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource + ".ktasset", "maskgen"), state)
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource + ".ktasset", "maskproduct"), state)
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource + ".ktasset", "product"), state)
+    verify_state(os.path.join(TERRAIN_RESOURCE_PATH, resource + ".ktasset", "source"), state)
 
 @step("Verify that the state of terrain resource <resource> is in <table>")
 def verify_state_terrain_resource_table(resource, table):
@@ -315,6 +395,13 @@ def verify_state_terrain_resource_table(resource, table):
 @step("Verify that the state of vector project <project> is <state>")
 def verify_state_vector_proj(project, state):
   verify_state(os.path.join(VECTOR_PROJECT_PATH, project), state)
+  if state == "Succeeded":
+    # Check the states of the project's children
+    verify_state(os.path.join(VECTOR_PROJECT_PATH, project + ".kvproject", "dbroot"), state)
+    verify_state(os.path.join(VECTOR_PROJECT_PATH, project + ".kvproject", "geindex"), state)
+    verify_state(os.path.join(VECTOR_PROJECT_PATH, project + ".kvproject", "layer005"), state)
+    verify_state(os.path.join(VECTOR_PROJECT_PATH, project + ".kvproject", "layer005.kva", "layer005packet"), state)
+    verify_state(os.path.join(VECTOR_PROJECT_PATH, project + ".kvproject", "layer005.kva", "query"), state)
 
 @step("Verify that the state of vector project <project> is in <table>")
 def verify_state_vector_project_table(project, table):
@@ -324,6 +411,9 @@ def verify_state_vector_project_table(project, table):
 @step("Verify that the state of vector resource <resource> is <state>")
 def verify_state_vector_resource(resource, state):
   verify_state(os.path.join(VECTOR_RESOURCE_PATH, resource), state)
+  if state == "Succeeded":
+    # Check the states of the resource's children
+    verify_state(os.path.join(VECTOR_RESOURCE_PATH, resource + ".kvasset", "source"), state)
 
 @step("Verify that the state of vector resource <resource> is in <table>")
 def verify_state_vector_resource_table(resource, table):
@@ -333,6 +423,23 @@ def verify_state_vector_resource_table(resource, table):
 @step("Verify that the state of database <database> is <state>")
 def verify_state_database(database, state):
   verify_state(os.path.join(DATABASE_PATH, database), state)
+  if state == "Succeeded":
+    # Check the states of the database's children
+    verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "gedb"), state)
+    verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "unifiedindex"), state)
+    #verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "qtpacket"), state)
+    terrainPath = os.path.join(DATABASE_PATH, database + ".kdatabase", "terrain")
+    if os.path.isdir(terrainPath + ".kta"):
+      # Only check for the terrain task if it's there. Not all databases have terrain.
+      verify_state(os.path.join(DATABASE_PATH, database + ".kdatabase", "terrain"), state)
+
+@step("Verify that the state of mercator database <database> is <state>")
+def verify_state_mercator_database(database, state):
+  verify_state(os.path.join(DATABASE_PATH, database), state)
+  if state == "Succeeded":
+    # Check the states of the database's children
+    verify_state(os.path.join(DATABASE_PATH, database + ".kmmdatabase", "mapdb"), state)
+    verify_state(os.path.join(DATABASE_PATH, database + ".kmmdatabase", "unifiedindex"), state)
 
 @step("Verify that the state of map layer <layer> is <state>")
 def verify_state_map_layer(layer, state):

--- a/earth_enterprise/src/common/SharedString.h
+++ b/earth_enterprise/src/common/SharedString.h
@@ -128,4 +128,8 @@ inline std::ostream & operator<<(std::ostream &out, const SharedString & str) {
   return out;
 }
 
+inline std::string ToString(const SharedString & str) {
+  return str.toString();
+}
+
 #endif

--- a/earth_enterprise/src/common/khxml/khdom.h
+++ b/earth_enterprise/src/common/khxml/khdom.h
@@ -44,6 +44,7 @@
 #include "common/Defaultable.h"
 #include "common/EncryptedQString.h"
 #include "common/geRange.h"
+#include "common/SharedString.h"
 
 
 /******************************************************************************
@@ -165,6 +166,10 @@ ToElement(khxml::DOMElement *elem, const std::map<std::string, U> &map);
 template <class U>
 void
 ToElement(khxml::DOMElement *elem, const std::map<QString, U> &map);
+
+template <class U>
+void
+ToElement(khxml::DOMElement *elem, const std::map<SharedString, U> &map);
 
 template <class T>
 void
@@ -328,10 +333,9 @@ ToElement(khxml::DOMElement *elem, const std::map<T, U> &map)
   }
 }
 
-template <class U>
-void
-ToElement(khxml::DOMElement *elem, const std::map<std::string, U> &map)
-{
+template <class String, class U>
+inline void
+ToElementForStringMap(khxml::DOMElement *elem, const std::map<String, U> &map) {
   for (const auto& iter : map)
   {
     khxml::DOMElement* item =
@@ -344,16 +348,23 @@ ToElement(khxml::DOMElement *elem, const std::map<std::string, U> &map)
 
 template <class U>
 void
+ToElement(khxml::DOMElement *elem, const std::map<std::string, U> &map)
+{
+  ToElementForStringMap(elem, map);
+}
+
+template <class U>
+void
 ToElement(khxml::DOMElement *elem, const std::map<QString, U> &map)
 {
-  for (const auto& iter : map)
-  {
-    khxml::DOMElement* item =
-        elem->getOwnerDocument()->createElement(ToXMLStr("item"));
-    AddAttribute(item, "key", iter.first);
-    ToElement(item, iter.second);
-    elem->appendChild(item);
-  }
+  ToElementForStringMap(elem, map);
+}
+
+template <class U>
+void
+ToElement(khxml::DOMElement *elem, const std::map<SharedString, U> &map)
+{
+  ToElementForStringMap(elem, map);
 }
 
 template <class T>
@@ -543,6 +554,10 @@ FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map);
 template <class U>
 void
 FromElement(khxml::DOMElement *elem, std::map<QString, U> &map);
+
+template <class U>
+void
+FromElement(khxml::DOMElement *elem, std::map<SharedString, U> &map);
 
 template <class T>
 void
@@ -846,6 +861,15 @@ FromElement(khxml::DOMElement *elem, std::string &val)
   }
 }
 
+inline
+void
+FromElement(khxml::DOMElement *elem, SharedString &val)
+{
+  std::string valStr;
+  FromElement(elem, valStr);
+  val = valStr;
+}
+
 template <class T>
 void
 FromElementWithChildName(khxml::DOMElement *elem,
@@ -982,9 +1006,30 @@ FromElement(khxml::DOMElement *elem, std::map<T, U> &map)
   }
 }
 
-template <class U>
+template<class String>
+String FromXMLStrForMap(const XMLCh *xmlch);
+
+template<>
+inline std::string
+FromXMLStrForMap(const XMLCh *xmlch) {
+  return FromXMLStr(xmlch);
+}
+
+template<>
+inline QString
+FromXMLStrForMap(const XMLCh *xmlch) {
+  return QString::fromUcs2(xmlch);
+}
+
+template<>
+inline SharedString
+FromXMLStrForMap(const XMLCh *xmlch) {
+  return FromXMLStr(xmlch);
+}
+
+template <class String, class U>
 void
-FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map)
+FromElementForStringMap(khxml::DOMElement *elem, std::map<String, U> &map)
 {
   map.clear();
   // see if this is the old way or the new way
@@ -997,7 +1042,7 @@ FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map)
 
     for (const auto& iter : kids)
     {
-      std::string key;
+      String key;
       U value;
       GetAttribute(iter, "key", key);
       FromElement(iter, value);
@@ -1009,10 +1054,10 @@ FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map)
     while (node) {
       if (node->getNodeType() == khxml::DOMNode::ELEMENT_NODE) {
         khxml::DOMElement *elem = static_cast<khxml::DOMElement*>(node);
-        std::string name = FromXMLStr(elem->getTagName());
+        String name = FromXMLStrForMap<String>(elem->getTagName());
         U value;
         FromElement(elem, value);
-        map.insert(make_pair(name, value));
+        map.insert(std::make_pair(name, value));
       }
       node = node->getNextSibling();
     }
@@ -1021,40 +1066,22 @@ FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map)
 
 template <class U>
 void
+FromElement(khxml::DOMElement *elem, std::map<std::string, U> &map) {
+  FromElementForStringMap(elem, map);
+}
+
+template <class U>
+void
 FromElement(khxml::DOMElement *elem, std::map<QString, U> &map)
 {
-  map.clear();
+  FromElementForStringMap(elem, map);
+}
 
-  // see if this is the old way or the new way
-  // Old way used keys for tagnames. New way has "item" elements w/
-  // "key" attributes
-  khxml::DOMElement *item = GetFirstNamedChild(elem, "item");
-  if (item && GetNamedAttr(item, "key")) {
-    // new way
-    khDOMElemList kids = GetChildrenByTagName(elem, "item");
-
-    for (const auto& iter : kids)
-    {
-      QString key;
-      U value;
-      GetAttribute(iter, "key", key);
-      FromElement(iter, value);
-      map.insert(std::make_pair(key, value));
-    }
-  } else {
-    // old way
-    khxml::DOMNode *node = elem->getFirstChild();
-    while (node) {
-      if (node->getNodeType() == khxml::DOMNode::ELEMENT_NODE) {
-        khxml::DOMElement *elem = static_cast<khxml::DOMElement*>(node);
-        QString name = QString::fromUcs2(elem->getTagName());
-        U value;
-        FromElement(elem, value);
-        map.insert(std::make_pair(name, value));
-      }
-      node = node->getNextSibling();
-    }
-  }
+template <class U>
+void
+FromElement(khxml::DOMElement *elem, std::map<SharedString, U> &map)
+{
+  FromElementForStringMap(elem, map);
 }
 
 template <class T>

--- a/earth_enterprise/src/common/khxml/khxml_unittest.cpp
+++ b/earth_enterprise/src/common/khxml/khxml_unittest.cpp
@@ -228,7 +228,7 @@ void runXmlToStringMapTest(const std::string & xml) {
 }
 
 template <class String>
-void toStringMap() {
+void toStringMapTest() {
   // There are two methods of parsing maps from XML. We test both.
   string newxml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n"
       "<data>\n"
@@ -245,15 +245,15 @@ void toStringMap() {
 }
 
 TEST_F(KhxmlTest, StdStringReadMap) {
-  toStringMap<string>();
+  toStringMapTest<string>();
 }
 
 TEST_F(KhxmlTest, SharedStringReadMap) {
-  toStringMap<SharedString>();
+  toStringMapTest<SharedString>();
 }
 
 TEST_F(KhxmlTest, QStringReadMap) {
-  toStringMap<QString>();
+  toStringMapTest<QString>();
 }
 
 template <class String>
@@ -278,6 +278,30 @@ TEST_F(KhxmlTest, SharedStringReadEmpty) {
 
 TEST_F(KhxmlTest, QStringReadEmpty) {
   readEmptyStringFromXml<QString>();
+}
+
+template <class String>
+void readNonEmptyStringFromXml() {
+  string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n"
+      "<value>qwertyuiop</value>\n";
+  unique_ptr<GEDocument> doc = ReadDocumentFromString(xml, "dummy");
+  DOMElement * elem = doc->getDocumentElement();
+  ASSERT_EQ(FromXMLStr(elem->getTagName()), "value") << "Invalid tag name when reading empty string from XML";
+  String val;
+  FromElement(elem, val);
+  ASSERT_EQ(val, String("qwertyuiop")) << "Error reading empty string from XML";
+}
+
+TEST_F(KhxmlTest, StdStringReadNonEmpty) {
+  readNonEmptyStringFromXml<string>();
+}
+
+TEST_F(KhxmlTest, SharedStringReadNonEmpty) {
+  readNonEmptyStringFromXml<SharedString>();
+}
+
+TEST_F(KhxmlTest, QStringReadNonEmpty) {
+  readNonEmptyStringFromXml<QString>();
 }
 
 int main(int argc, char** argv)

--- a/earth_enterprise/src/common/khxml/khxml_unittest.cpp
+++ b/earth_enterprise/src/common/khxml/khxml_unittest.cpp
@@ -199,8 +199,8 @@ void toStringTest() {
   unique_ptr<GEDocument> doc = ReadDocumentFromString(xml, "dummy");
   DOMElement * elem = doc->getDocumentElement();
   ASSERT_EQ(FromXMLStr(elem->getTagName()), "test") << "Invalid tag name when reading string from XML";
-  DOMNode * node = elem->getFirstChild();
-  String value = FromXMLStr(((khxml::DOMText*)node)->getData());
+  String value;
+  FromElement(elem, value);
   ASSERT_EQ(value, "expected_value") << "Could not read string value from XML correctly";
 }
 
@@ -214,6 +214,70 @@ TEST_F(KhxmlTest, SharedStringReadString) {
 
 TEST_F(KhxmlTest, QStringReadString) {
   toStringTest<QString>();
+}
+
+template <class String>
+void runXmlToStringMapTest(const std::string & xml) {
+  unique_ptr<GEDocument> doc = ReadDocumentFromString(xml, "dummy");
+  DOMElement * elem = doc->getDocumentElement();
+  ASSERT_EQ(FromXMLStr(elem->getTagName()), "data") << "Invalid tag name when reading string from XML";
+  map<String, int> results;
+  FromElement(elem, results);
+  ASSERT_EQ(results["xyz"], 42) << "Error reading map of strings from XML";
+  ASSERT_EQ(results["wvu"], 12) << "Error reading map of strings from XML";
+}
+
+template <class String>
+void toStringMap() {
+  // There are two methods of parsing maps from XML. We test both.
+  string newxml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n"
+      "<data>\n"
+         "<item key=\"xyz\">42</item>\n"
+         "<item key=\"wvu\">12</item>\n"
+      "</data>\n";
+  runXmlToStringMapTest<String>(newxml);
+  string oldxml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n"
+      "<data>\n"
+        "<xyz>42</xyz>\n"
+        "<wvu>12</wvu>\n"
+      "</data>\n";
+  runXmlToStringMapTest<String>(oldxml);
+}
+
+TEST_F(KhxmlTest, StdStringReadMap) {
+  toStringMap<string>();
+}
+
+TEST_F(KhxmlTest, SharedStringReadMap) {
+  toStringMap<SharedString>();
+}
+
+TEST_F(KhxmlTest, QStringReadMap) {
+  toStringMap<QString>();
+}
+
+template <class String>
+void readEmptyStringFromXml() {
+  string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n"
+      "<value></value>\n";
+  unique_ptr<GEDocument> doc = ReadDocumentFromString(xml, "dummy");
+  DOMElement * elem = doc->getDocumentElement();
+  ASSERT_EQ(FromXMLStr(elem->getTagName()), "value") << "Invalid tag name when reading empty string from XML";
+  String val;
+  FromElement(elem, val);
+  ASSERT_EQ(val, String("")) << "Error reading empty string from XML";
+}
+
+TEST_F(KhxmlTest, StdStringReadEmpty) {
+  readEmptyStringFromXml<string>();
+}
+
+TEST_F(KhxmlTest, SharedStringReadEmpty) {
+  readEmptyStringFromXml<SharedString>();
+}
+
+TEST_F(KhxmlTest, QStringReadEmpty) {
+  readEmptyStringFromXml<QString>();
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Fixes an issue with the qtpacket status being reported incorrectly due to the recent update to add SharedStrings. Also adds integration tests for checking the status of child tasks like qtpacket and unit tests for reading SharedStrings from XML.

The general idea behind the updated tests is as follows:
1. Whenever we wait for an asset to reach a certain state we immediately verify the state afterwards.
1. Whenever we verify the state of an asset and the state is Succeeded we also verify the state of its child assets. We don't verify in other states because it's unclear what the state of the child should be. If you cancel an asset should its children be canceled? blocked? Is there ever a case where the child asset would have a different state than the parent? I could have figured all that out but it didn't seem worth the effort at this point.
1. There are now some functions to handle mercator assets differently than regular assets since they have different folder names and different children.
1. I didn't change anything for the calls to verify if a state is in a list of expected states. In those cases it's harder to be sure what the state of the children assets should be, and in most tests we check that the state is Succeeded at the end of the test anyway, so we'll catch it then.