### PR TITLE
Issue 1308: Purge XML by default

### DIFF
--- a/docs/geedocs/5.3.0/answer/176738.html
+++ b/docs/geedocs/5.3.0/answer/176738.html
@@ -280,16 +280,12 @@ MAX_HEAP_SIZE=&lt;value&gt;
 BLOCK_SIZE=&lt;value&gt;
 <br><br>
 # whether or not to purge the XML cache; valid values are 0 or 1<br>
-# default is 0<br>
-PURGE=0
+# default is 1<br>
+PURGE=1
 <br><br>
 # the level at which to purge the XML cache; can be 1 (most often) to 5 (least often)<br>
 # default is 3<br>
 PURGE_LEVEL=3
-<br><br>
-# deallocate all memory allocated by Xerces when the Xerces cache is purged; valid values are 0 or 1<br>
-# default is 0<br>
-DEALLOCATE_ALL=0
 </code>
 <h2 id="status_request_timeout">Status request timeout</h2>
 <p>Status requests to the system manager from clients like <code>getop</code> must wait to be fulfilled if the system manager

--- a/earth_enterprise/src/common/khxml/khxml.h
+++ b/earth_enterprise/src/common/khxml/khxml.h
@@ -132,6 +132,8 @@ class GEXMLObject {
     const static std::string BLOCK_SIZE;
     const static std::string PURGE;
     const static std::string PURGE_LEVEL;
+    // The DEALLOCATE_ALL option does nothing now, but it is still accepted for
+    // backwards compatibility.
     const static std::string DEALLOCATE_ALL;
     const static std::string XMLConfigFile;
     const static std::array<std::string,6> options;
@@ -143,7 +145,6 @@ class GEXMLObject {
     static bool doPurge;
     static int purgeLevel;
     static XMLSize_t purgeThreshold;
-    static bool deallocateAll;
     static bool xercesInitialized;
 
     static uint32_t activeObjects;


### PR DESCRIPTION
This makes XML purging the default behavior. The end result is that 5.3.0 starts with higher memory utilization than 5.2.5, but it's memory usage remains steady, whereas in 5.2.5 memory usage climbs continually.

Fixes #1308.