### PR TITLE
Speed up parallel buildindex

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1170,7 +1170,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   }
 
   // Populate packgenkids, packgenassets, and packgenvers from prelim_packgenvers
-  for(auto & packgen : prelim_packgenvers) {
+  for(const auto & packgen : prelim_packgenvers) {
     if( !packgen->GetRef().empty() ) {
       packgenkids.push_back(packgen->GetRef());
       packgenassets.push_back(packgen->GetAssetRef());

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1183,8 +1183,6 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   notify(NFY_INFO2, "BuildIndex finished looping through insets - %f seconds elapsed",
          timeDiff.count());
 
-assert(false);  // TEMP DEBUG assert: bail out before we start writing the files
-
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);
 }

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1041,8 +1041,18 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   packgenassets.reserve(numInsets);
   packgenvers.reserve(numInsets);
 
+  // Temporary versions of the vectors that will allow multiple threads to safely insert
+  // items by index. The valid values elements will be placed into the above vectors
+  // after the loop.
+  //std::vector<std::string> prelim_packgenkids;
+  //std::vector<std::string> prelim_packgenassets;
+  std::vector<AssetVersion> prelim_packgenvers;
+  //prelim_packgenkids.resize(numInsets);
+  //prelim_packgenassets.resize(numInsets);
+  prelim_packgenvers.resize(numInsets);
+
   int threadsToUse = MiscConfig::Instance().BuildIndexThreads;
-  // Create separate vectors for each thread to operate on. We'll combine them after
+/*  // Create separate vectors for each thread to operate on. We'll combine them after
   // the loop finishes.
   std::vector<std::vector<std::string>> packgenkids_vectors(threadsToUse);
   std::vector<std::vector<std::string>> packgenassets_vectors(threadsToUse);
@@ -1053,6 +1063,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     vec.reserve(numInsets/threadsToUse);
   for(auto & vec : packgenvers_vectors)
     vec.reserve(numInsets/threadsToUse);
+*/
 
 
   #pragma omp parallel for schedule(static) num_threads(threadsToUse)
@@ -1062,8 +1073,10 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     // Check if I even need to do any packet generation at all
     // Maybe the other insets will completely replace everything
     // that this one would generate
-    if (genInfo[i].coverage.numLevels() == 0)
+    if (genInfo[i].coverage.numLevels() == 0) {
+      notify(NFY_DEBUG, "Don't need to do packgen for genInfo[%d]", i);
       continue;
+    }
 
 
     // Determine which insets (0 .. i) intersect this coverage area.
@@ -1171,13 +1184,17 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
       genInfo[i].PopulatePacketLevels(packgen);
     }
 
-    // remember this new PacketGen version
+/*    // remember this new PacketGen version
     packgenkids_vectors[threadNum].push_back(packgen->GetRef());
     packgenassets_vectors[threadNum].push_back(packgen->GetAssetRef());
     packgenvers_vectors[threadNum].push_back(packgen);
+*/
+//    prelim_packgenkids[i] = packgen->GetRef();
+//    prelim_packgenassets[i] = packgen->GetAssetRef();
+    prelim_packgenvers[i] = packgen;
   }
 
-  // Concatenate all of the vectors
+/*  // Concatenate all of the vectors
   for(auto & vec : packgenkids_vectors)
     packgenkids.insert(packgenkids.end(), vec.begin(), vec.end());
   for(auto & vec : packgenassets_vectors)
@@ -1185,11 +1202,21 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   for(auto & vec : packgenvers_vectors)
     packgenvers.insert(packgenvers.end(), vec.begin(), vec.end());
   assert(packgenkids.size() == packgenassets.size() && packgenkids.siz() == packgenvers.size());
+*/
+  for(auto & packgen : prelim_packgenvers) {
+    if( !packgen->GetRef().empty() ) {
+      packgenkids.push_back(packgen->GetRef());
+      packgenassets.push_back(packgen->GetAssetRef());
+      packgenvers.push_back(packgen);
+    }
+  }
 
   curTime = std::chrono::high_resolution_clock::now();
   timeDiff = std::chrono::duration<double>(curTime - prevTime);
   notify(NFY_INFO2, "BuildIndex finished looping through insets - %f seconds elapsed",
          timeDiff.count());
+
+assert(false);  // TEMP DEBUG assert: bail out before we start writing the files
 
   // Make index subasset (RasterGEIndex).
   return MakeIndexSubAsset(packgenkids, packgenassets, packgenvers, genInfo, date);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1041,30 +1041,13 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   packgenassets.reserve(numInsets);
   packgenvers.reserve(numInsets);
 
-  // Temporary versions of the vectors that will allow multiple threads to safely insert
-  // items by index. The valid values elements will be placed into the above vectors
+  // Temporary version of the vectors that will allow multiple threads to safely insert
+  // items by index. The valid elements will be placed into the above vectors
   // after the loop.
-  //std::vector<std::string> prelim_packgenkids;
-  //std::vector<std::string> prelim_packgenassets;
   std::vector<AssetVersion> prelim_packgenvers;
-  //prelim_packgenkids.resize(numInsets);
-  //prelim_packgenassets.resize(numInsets);
   prelim_packgenvers.resize(numInsets);
 
   int threadsToUse = MiscConfig::Instance().BuildIndexThreads;
-/*  // Create separate vectors for each thread to operate on. We'll combine them after
-  // the loop finishes.
-  std::vector<std::vector<std::string>> packgenkids_vectors(threadsToUse);
-  std::vector<std::vector<std::string>> packgenassets_vectors(threadsToUse);
-  std::vector<std::vector<AssetVersion>> packgenvers_vectors(threadsToUse);
-  for(auto & vec : packgenkids_vectors)
-    vec.reserve(numInsets/threadsToUse);
-  for(auto & vec : packgenassets_vectors)
-    vec.reserve(numInsets/threadsToUse);
-  for(auto & vec : packgenvers_vectors)
-    vec.reserve(numInsets/threadsToUse);
-*/
-
 
   #pragma omp parallel for schedule(static) num_threads(threadsToUse)
   for (uint i = 0; i < genInfo.size(); ++i) {
@@ -1073,10 +1056,8 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     // Check if I even need to do any packet generation at all
     // Maybe the other insets will completely replace everything
     // that this one would generate
-    if (genInfo[i].coverage.numLevels() == 0) {
-      notify(NFY_DEBUG, "Don't need to do packgen for genInfo[%d]", i);
+    if (genInfo[i].coverage.numLevels() == 0)
       continue;
-    }
 
 
     // Determine which insets (0 .. i) intersect this coverage area.
@@ -1184,25 +1165,11 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
       genInfo[i].PopulatePacketLevels(packgen);
     }
 
-/*    // remember this new PacketGen version
-    packgenkids_vectors[threadNum].push_back(packgen->GetRef());
-    packgenassets_vectors[threadNum].push_back(packgen->GetAssetRef());
-    packgenvers_vectors[threadNum].push_back(packgen);
-*/
-//    prelim_packgenkids[i] = packgen->GetRef();
-//    prelim_packgenassets[i] = packgen->GetAssetRef();
+    // remember this new PacketGen version
     prelim_packgenvers[i] = packgen;
   }
 
-/*  // Concatenate all of the vectors
-  for(auto & vec : packgenkids_vectors)
-    packgenkids.insert(packgenkids.end(), vec.begin(), vec.end());
-  for(auto & vec : packgenassets_vectors)
-    packgenassets.insert(packgenassets.end(), vec.begin(), vec.end());
-  for(auto & vec : packgenvers_vectors)
-    packgenvers.insert(packgenvers.end(), vec.begin(), vec.end());
-  assert(packgenkids.size() == packgenassets.size() && packgenkids.siz() == packgenvers.size());
-*/
+  // Populate packgenkids, packgenassets, and packgenvers from prelim_packgenvers
   for(auto & packgen : prelim_packgenvers) {
     if( !packgen->GetRef().empty() ) {
       packgenkids.push_back(packgen->GetRef());

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1042,9 +1042,23 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
   packgenvers.reserve(numInsets);
 
   int threadsToUse = MiscConfig::Instance().BuildIndexThreads;
-  #pragma omp parallel for ordered schedule(static,1) num_threads(threadsToUse)
+  // Create separate vectors for each thread to operate on. We'll combine them after
+  // the loop finishes.
+  std::vector<std::vector<std::string>> packgenkids_vectors(threadsToUse);
+  std::vector<std::vector<std::string>> packgenassets_vectors(threadsToUse);
+  std::vector<std::vector<AssetVersion>> packgenvers_vectors(threadsToUse);
+  for(auto & vec : packgenkids_vectors)
+    vec.reserve(numInsets/threadsToUse);
+  for(auto & vec : packgenassets_vectors)
+    vec.reserve(numInsets/threadsToUse);
+  for(auto & vec : packgenvers_vectors)
+    vec.reserve(numInsets/threadsToUse);
+
+
+  #pragma omp parallel for schedule(static) num_threads(threadsToUse)
   for (uint i = 0; i < genInfo.size(); ++i) {
-    notify(NFY_DEBUG, "Starting loop %d from thread %d", i+1, omp_get_thread_num());
+    int threadNum = omp_get_thread_num();
+    notify(NFY_DEBUG, "Starting loop %d from thread %d", i+1, threadNum);
     // Check if I even need to do any packet generation at all
     // Maybe the other insets will completely replace everything
     // that this one would generate
@@ -1157,14 +1171,20 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
       genInfo[i].PopulatePacketLevels(packgen);
     }
 
-#pragma omp critical 
-    {
-      // remember this new PacketGen version
-      packgenkids.push_back(packgen->GetRef());
-      packgenassets.push_back(packgen->GetAssetRef());
-      packgenvers.push_back(packgen);
-    }
+    // remember this new PacketGen version
+    packgenkids_vectors[threadNum].push_back(packgen->GetRef());
+    packgenassets_vectors[threadNum].push_back(packgen->GetAssetRef());
+    packgenvers_vectors[threadNum].push_back(packgen);
   }
+
+  // Concatenate all of the vectors
+  for(auto & vec : packgenkids_vectors)
+    packgenkids.insert(packgenkids.end(), vec.begin(), vec.end());
+  for(auto & vec : packgenassets_vectors)
+    packgenassets.insert(packgenassets.end(), vec.begin(), vec.end());
+  for(auto & vec : packgenvers_vectors)
+    packgenvers.insert(packgenvers.end(), vec.begin(), vec.end());
+  assert(packgenkids.size() == packgenassets.size() && packgenkids.siz() == packgenvers.size());
 
   curTime = std::chrono::high_resolution_clock::now();
   timeDiff = std::chrono::duration<double>(curTime - prevTime);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/RasterProject.src
@@ -1088,7 +1088,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     curTime = std::chrono::high_resolution_clock::now();
     timeDiff = std::chrono::duration<double>(curTime - prevTime);
     notify(NFY_INFO2, "BuildIndex finished compiling %lu needed indices for inset %d - %f seconds elapsed",
-           neededIndexes.size(), i, timeDiff.count());
+           neededIndexes.size(), i+1, timeDiff.count());
     prevTime = curTime;
 
     // calculate the level range that will be minified
@@ -1138,7 +1138,7 @@ uint32 RasterProjectAssetVersionImplD::BuildIndex(
     curTime = std::chrono::high_resolution_clock::now();
     timeDiff = std::chrono::duration<double>(curTime - prevTime);
     notify(NFY_INFO2, "BuildIndex finished nested loop for inset %d - %f seconds elapsed",
-           i, timeDiff.count());
+           i+1, timeDiff.count());
     prevTime = curTime;
 
     // Build a PacketGenExtraUpdateArg


### PR DESCRIPTION
- Minor tweaks to speed up processing by avoiding the need for a critical section in the main loop in `BuildIndex`.
- One debug message was using 1-based index and all others used 0-based. Changed all to 1-based.