### PR TITLE
WIP: Parallelize a smaller section of packgen processing

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/AssetChanges.idl
+++ b/earth_enterprise/src/fusion/autoingest/AssetChanges.idl
@@ -16,11 +16,12 @@
 #include <string>
 #include <vector>
 #include <sys/types.h>
+#include "common/SharedString.h"
 
 class AssetChanges
 {
   class Item {
-    std::string ref;
+    SharedString ref;
     std::string desc;
   };
   typedef std::vector<Item> Items;

--- a/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
+++ b/earth_enterprise/src/fusion/autoingest/MiscConfigStorage.idl
@@ -22,13 +22,11 @@ class MiscConfigStorage {
   // delay between writing a file and reading it from NFS in order to
   // help work around the delayed NFS visibility problem.
   uint        NFSVisibilityDelay = uint(0);
-
   uint        AssetCacheSize = uint(128000);
   uint        VersionCacheSize = uint(128000);
-
   bool        GenerateProductPreviews = true;
-
   uint        MutexTimedWaitSec = uint(30);
+  uint        PackGenThreads = uint(1);
 
 #pragma LoadAndSave
 

--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -59,9 +59,9 @@ class StorageManager
     inline void NoLongerNeeded(const AssetKey &, bool = true);
     HandleType Get(const AssetHandleInterface<AssetType> *, bool, bool, bool);
     void Abort();
-    bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<std::string> *);
+    bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<SharedString> *);
   private:
-    using CacheType = khCache<std::string, HandleType>;
+    using CacheType = khCache<AssetKey, HandleType>;
 
     static const bool check_timestamps;
 
@@ -203,7 +203,7 @@ void StorageManager<AssetType>::Abort() {
 template<class AssetType>
 bool StorageManager<AssetType>::SaveDirtyToDotNew(
     khFilesTransaction &savetrans,
-    std::vector<std::string> *saved) {
+    std::vector<SharedString> *saved) {
   notify(NFY_INFO, "Writing %lu %s records", dirtyMap.size(), assetType.c_str());
   std::lock_guard<std::mutex> lock(storageMutex);
   typename std::map<AssetKey, HandleType>::iterator entry = dirtyMap.begin();

--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -18,6 +18,7 @@
 #define STORAGEMANAGER_H
 
 #include <map>
+#include <mutex>
 #include <string>
 #include <time.h>
 #include <vector>
@@ -50,20 +51,21 @@ class StorageManager
         assetType(type) {}
     ~StorageManager() = default;
 
-    inline uint32 CacheSize() const { return cache.size(); }
-    inline uint32 CacheCapacity() const { return cache.capacity(); }
-    inline uint32 DirtySize() const { return dirtyMap.size(); }
+    inline uint32 CacheSize() const;
+    inline uint32 CacheCapacity() const;
+    inline uint32 DirtySize() const;
     inline void AddNew(const AssetKey &, const HandleType &);
     inline void AddExisting(const AssetKey &, const HandleType &);
     inline void NoLongerNeeded(const AssetKey &, bool = true);
+    HandleType Get(const AssetHandleInterface<AssetType> *, bool, bool, bool);
     void Abort();
     bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<std::string> *);
-    HandleType Get(const AssetHandleInterface<AssetType> *, bool, bool, bool);
   private:
     using CacheType = khCache<std::string, HandleType>;
 
     static const bool check_timestamps;
 
+    mutable std::mutex storageMutex;
     CacheType cache;
     std::map<AssetKey, HandleType> dirtyMap;
     std::string assetType;
@@ -83,8 +85,27 @@ class AssetHandleInterface {
 };
 
 template<class AssetType>
+inline uint32 StorageManager<AssetType>::CacheSize() const {
+  std::lock_guard<std::mutex> lock(storageMutex);
+  return cache.size();
+}
+
+template<class AssetType>
+inline uint32 StorageManager<AssetType>::CacheCapacity() const {
+  std::lock_guard<std::mutex> lock(storageMutex);
+  return cache.capacity();
+}
+
+template<class AssetType>
+inline uint32 StorageManager<AssetType>::DirtySize() const {
+  std::lock_guard<std::mutex> lock(storageMutex);
+  return dirtyMap.size();
+}
+
+template<class AssetType>
 inline void
 StorageManager<AssetType>::AddNew(const AssetKey & key, const HandleType & value) {
+  std::lock_guard<std::mutex> lock(storageMutex);
   cache.Add(key, value);
   // New assets are automatically dirty
   dirtyMap.emplace(key, value);
@@ -93,12 +114,14 @@ StorageManager<AssetType>::AddNew(const AssetKey & key, const HandleType & value
 template<class AssetType>
 inline void
 StorageManager<AssetType>::AddExisting(const AssetKey & key, const HandleType & value) {
+  std::lock_guard<std::mutex> lock(storageMutex);
   cache.Add(key, value);
 }
 
 template<class AssetType>
 inline void
 StorageManager<AssetType>::NoLongerNeeded(const AssetKey & key, bool prune) {
+  std::lock_guard<std::mutex> lock(storageMutex);
   cache.Remove(key, prune);
 }
 
@@ -111,6 +134,8 @@ StorageManager<AssetType>::Get(
     bool makeMutable) {
   const AssetKey key = handle->Key();
   const std::string filename = handle->Filename();
+
+  std::lock_guard<std::mutex> lock(storageMutex);
 
   // Check in cache.
   HandleType entry;
@@ -164,6 +189,7 @@ StorageManager<AssetType>::Get(
 
 template<class AssetType>
 void StorageManager<AssetType>::Abort() {
+  std::lock_guard<std::mutex> lock(storageMutex);
   // remove all the dirty Impls from the cache
   for (const std::pair<AssetKey, HandleType> & entry : dirtyMap) {
     cache.Remove(entry.first, false); // false -> don't prune
@@ -179,6 +205,7 @@ bool StorageManager<AssetType>::SaveDirtyToDotNew(
     khFilesTransaction &savetrans,
     std::vector<std::string> *saved) {
   notify(NFY_INFO, "Writing %lu %s records", dirtyMap.size(), assetType.c_str());
+  std::lock_guard<std::mutex> lock(storageMutex);
   typename std::map<AssetKey, HandleType>::iterator entry = dirtyMap.begin();
   while (entry != dirtyMap.end()) {
     std::string filename = entry->second->XMLFilename() + ".new";

--- a/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
@@ -274,7 +274,7 @@ TEST_F(StorageManagerTest, SaveDirtyToVector) {
   getAssetsForDirtyTest(storageManager, handles);
   
   khFilesTransaction trans;
-  vector<string> saved;
+  vector<SharedString> saved;
   storageManager.SaveDirtyToDotNew(trans, &saved);
   ASSERT_EQ(saved.size(), 2) << "Wrong number of items in saved vector";
   ASSERT_TRUE(find(saved.begin(), saved.end(), "mutable2") != saved.end()) << "Dirty item missing from saved vector";

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -248,7 +248,6 @@ void PacketGenAssetVersionImplD::UpdateChildren(
          (level <= config.endMinifyLevel));
 
       const uint minifySrcLevel = level + 1;
-      bool highestResMinify = (level+1 == config.endMinifyLevel);
 
       // for attribution we care about everybody
       packetLevelConfig.attributions.reserve(neededIndexes.size() + 1);
@@ -313,11 +312,18 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                 inset.alphaRPFile,
                 SharedString(), /* cached blend */
                 SharedString()  /* cached blend alpha */));
-        } else if (highestResMinify) {
-          // This is the first merge (from cached blends)
-          // It is possible that some of the cached blends are only
-          // partially populated. So we pull from both the cached
-          // blend and the product
+        } else {
+          // This covers two cases:
+          // 1) If level+1 == config.endMinifyLevel:
+          //   This is the first merge (from cached blends)
+          //   It is possible that some of the cached blends are only
+          //   partially populated. So we pull from both the cached
+          //   blend and the product.
+          // 2) Otherwise:
+          //   This is a subsequent merge (from cached merges) It's
+          //   possible that earlier merges also short circuited the
+          //   merge with opaque top tiles. So we may need to pull
+          //   from the product too.
           levInputs.push_back(inset.combinedrp_.Ref());
           levInputVers.push_back(inset.combinedrp_);
           levInputs.push_back(blendVer.Ref());
@@ -338,36 +344,6 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                 blendVer.Ref(), /* cached blend */
                 cache_alpha_exist ?
                     blendVer.Ref() : SharedString() /* cached blend alpha */));
-        } else {
-          // This is a subsequent merge (from cached merges) It's
-          // possible that earlier merges also short circuited the
-          // merge with opaque top tiles. So we may need to pull
-          // from the product too.
-
-          // NOTE: For now this case should be identical to the
-          // one above. Maybe later we can put some more smarts
-          // here to limit dependencies on the products?
-
-          levInputs.push_back(inset.combinedrp_.Ref());
-          levInputVers.push_back(inset.combinedrp_);
-          levInputs.push_back(blendVer.Ref());
-          levInputVers.push_back(blendVer);
-
-          // Note: Before creating a merge inset, we check if the cached alpha
-          // blend directory exists for the asset since in GEE-5.x we need to
-          // pick up the GEE-4.x Imagery/Terrain Projects (the PacketLevel
-          // assets) that have no alpha blend cached.
-          const std::string cache_alpha_path =
-              blendVer->GetOutputFilename(0) + "/cache_alpha.pack";
-          const bool cache_alpha_exist = khExists(cache_alpha_path);
-
-          packetLevelConfig.insets.push_back
-            (PacketLevelConfig::Inset(
-                inset.dataRPFile,
-                inset.alphaRPFile,
-                blendVer.Ref(), /* cached blend */
-                cache_alpha_exist ?
-                    blendVer.Ref() : SharedString()  /* cached blend alpha */));
         }
       }
 

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -288,7 +288,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       packetLevelConfig.insets.resize(mergeIndexes.size());
       std::vector<AssetVersion> combRps(mergeIndexes.size());
       std::vector<AssetVersion> blendVers(mergeIndexes.size());
-      int threadsToUse = 4;
+      int threadsToUse = MiscConfig::Instance().PackGenThreads;
       #pragma omp parallel for schedule(static) num_threads(threadsToUse)
       for (size_t idx = 0; idx < mergeIndexes.size(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[mergeIndexes[idx]]);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -284,25 +284,22 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       prevTime = curTime;
 
       // populate inputs and inputVers & config.insets
-      levInputs.reserve(mergeIndexes.size() * 2 + 1);
-      levInputVers.reserve(mergeIndexes.size() * 2 + 1);
       packetLevelConfig.insets.reserve(mergeIndexes.size() + 1);
       packetLevelConfig.insets.resize(mergeIndexes.size());
+      std::vector<AssetVersion> combRps(mergeIndexes.size());
+      std::vector<AssetVersion> blendVers(mergeIndexes.size());
       for (size_t idx = 0; idx < mergeIndexes.size(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[mergeIndexes[idx]]);
         const PacketGenInfo &genInfo(*extra.genInfo[mergeIndexes[idx]]);
-        AssetVersion blendVer;
         if (!inset.alphaRPFile.empty() &&
             (genInfo.packetLevels.size() > minifySrcLevel)) {
-          blendVer = genInfo.packetLevels[minifySrcLevel];
+          blendVers[idx] = genInfo.packetLevels[minifySrcLevel];
         }
-
-        levInputs.push_back(inset.combinedrp_.Ref());
-        levInputVers.push_back(inset.combinedrp_);
+        combRps[idx] = inset.combinedrp_;
 
         SharedString cached_blend;
         SharedString cached_blend_alpha;
-        if (blendVer) {
+        if (blendVers[idx]) {
           // This covers two cases:
           // 1) If level+1 == config.endMinifyLevel:
           //   This is the first merge (from cached blends)
@@ -320,19 +317,17 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // In these cases we pull directly from the product. It
           // will also happen for the last thing on the stack who
           // hasn't had his blendvers filled in yet.
-          levInputs.push_back(blendVer.Ref());
-          levInputVers.push_back(blendVer);
 
           // Note: Before creating a merge inset, we check if the cached alpha
           // blend directory exists for the asset since in GEE-5.x we need to
           // pick up the GEE-4.x Imagery/Terrain Projects (the PacketLevel
           // assets) that have no alpha blend cached.
           const std::string cache_alpha_path =
-              blendVer->GetOutputFilename(0) + "/cache_alpha.pack";
+              blendVers[idx]->GetOutputFilename(0) + "/cache_alpha.pack";
           if (khExists(cache_alpha_path)) {
-            cached_blend_alpha = blendVer.Ref();
+            cached_blend_alpha = blendVers[idx].Ref();
           }
-          cached_blend = blendVer.Ref();
+          cached_blend = blendVers[idx].Ref();
         }
 
         packetLevelConfig.insets[idx] = 
@@ -341,6 +336,17 @@ void PacketGenAssetVersionImplD::UpdateChildren(
                 inset.alphaRPFile,
                 cached_blend,
                 cached_blend_alpha);
+      }
+
+      levInputs.reserve(mergeIndexes.size() * 2 + 1);
+      levInputVers.reserve(mergeIndexes.size() * 2 + 1);
+      for (size_t idx = 0; idx < mergeIndexes.size(); ++idx) {
+        levInputs.push_back(combRps[idx].Ref());
+        levInputVers.push_back(combRps[idx]);
+        if (blendVers[idx]) {
+          levInputs.push_back(blendVers[idx].Ref());
+          levInputVers.push_back(blendVers[idx]);
+        }
       }
 
       curTime = std::chrono::high_resolution_clock::now();

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -207,7 +207,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       for (std::vector<uint>::const_iterator idx = neededIndexes.begin();
            idx != neededIndexes.end(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[*idx]);
-        levInputs.push_back(inset.combinedrp_->GetRef());
+        levInputs.push_back(inset.combinedrp_.Ref());
         levInputVers.push_back(inset.combinedrp_);
         packetLevelConfig.insets.push_back
           (PacketLevelConfig::Inset(inset.dataRPFile,
@@ -304,7 +304,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // In these cases we pull directly from the product. It
           // will also happen for the last thing on the stack who
           // hasn't had his blendvers filled in yet.
-          levInputs.push_back(inset.combinedrp_->GetRef());
+          levInputs.push_back(inset.combinedrp_.Ref());
           levInputVers.push_back(inset.combinedrp_);
 
           packetLevelConfig.insets.push_back
@@ -318,7 +318,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // It is possible that some of the cached blends are only
           // partially populated. So we pull from both the cached
           // blend and the product
-          levInputs.push_back(inset.combinedrp_->GetRef());
+          levInputs.push_back(inset.combinedrp_.Ref());
           levInputVers.push_back(inset.combinedrp_);
           levInputs.push_back(blendVer.Ref());
           levInputVers.push_back(blendVer);
@@ -348,7 +348,7 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // one above. Maybe later we can put some more smarts
           // here to limit dependencies on the products?
 
-          levInputs.push_back(inset.combinedrp_->GetRef());
+          levInputs.push_back(inset.combinedrp_.Ref());
           levInputVers.push_back(inset.combinedrp_);
           levInputs.push_back(blendVer.Ref());
           levInputVers.push_back(blendVer);

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -287,32 +287,22 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       levInputs.reserve(mergeIndexes.size() * 2 + 1);
       levInputVers.reserve(mergeIndexes.size() * 2 + 1);
       packetLevelConfig.insets.reserve(mergeIndexes.size() + 1);
-      for (std::vector<uint>::const_iterator idx = mergeIndexes.begin();
-           idx != mergeIndexes.end(); ++idx) {
-        const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[*idx]);
-        const PacketGenInfo &genInfo(*extra.genInfo[*idx]);
+      packetLevelConfig.insets.resize(mergeIndexes.size());
+      for (size_t idx = 0; idx < mergeIndexes.size(); ++idx) {
+        const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[mergeIndexes[idx]]);
+        const PacketGenInfo &genInfo(*extra.genInfo[mergeIndexes[idx]]);
         AssetVersion blendVer;
         if (!inset.alphaRPFile.empty() &&
             (genInfo.packetLevels.size() > minifySrcLevel)) {
           blendVer = genInfo.packetLevels[minifySrcLevel];
         }
 
-        if (!blendVer) {
-          // This inset doesn't have a cached blend file. This
-          // will only happen for things that have no alpha mask.
-          // In these cases we pull directly from the product. It
-          // will also happen for the last thing on the stack who
-          // hasn't had his blendvers filled in yet.
-          levInputs.push_back(inset.combinedrp_.Ref());
-          levInputVers.push_back(inset.combinedrp_);
+        levInputs.push_back(inset.combinedrp_.Ref());
+        levInputVers.push_back(inset.combinedrp_);
 
-          packetLevelConfig.insets.push_back
-            (PacketLevelConfig::Inset(
-                inset.dataRPFile,
-                inset.alphaRPFile,
-                SharedString(), /* cached blend */
-                SharedString()  /* cached blend alpha */));
-        } else {
+        SharedString cached_blend;
+        SharedString cached_blend_alpha;
+        if (blendVer) {
           // This covers two cases:
           // 1) If level+1 == config.endMinifyLevel:
           //   This is the first merge (from cached blends)
@@ -324,8 +314,12 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           //   possible that earlier merges also short circuited the
           //   merge with opaque top tiles. So we may need to pull
           //   from the product too.
-          levInputs.push_back(inset.combinedrp_.Ref());
-          levInputVers.push_back(inset.combinedrp_);
+          // If we do not enter this if statment, then
+          // this inset doesn't have a cached blend file. This
+          // will only happen for things that have no alpha mask.
+          // In these cases we pull directly from the product. It
+          // will also happen for the last thing on the stack who
+          // hasn't had his blendvers filled in yet.
           levInputs.push_back(blendVer.Ref());
           levInputVers.push_back(blendVer);
 
@@ -335,16 +329,18 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // assets) that have no alpha blend cached.
           const std::string cache_alpha_path =
               blendVer->GetOutputFilename(0) + "/cache_alpha.pack";
-          const bool cache_alpha_exist = khExists(cache_alpha_path);
+          if (khExists(cache_alpha_path)) {
+            cached_blend_alpha = blendVer.Ref();
+          }
+          cached_blend = blendVer.Ref();
+        }
 
-          packetLevelConfig.insets.push_back
-            (PacketLevelConfig::Inset(
+        packetLevelConfig.insets[idx] = 
+            PacketLevelConfig::Inset(
                 inset.dataRPFile,
                 inset.alphaRPFile,
-                blendVer.Ref(), /* cached blend */
-                cache_alpha_exist ?
-                    blendVer.Ref() : SharedString() /* cached blend alpha */));
-        }
+                cached_blend,
+                cached_blend_alpha);
       }
 
       curTime = std::chrono::high_resolution_clock::now();

--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -288,6 +288,8 @@ void PacketGenAssetVersionImplD::UpdateChildren(
       packetLevelConfig.insets.resize(mergeIndexes.size());
       std::vector<AssetVersion> combRps(mergeIndexes.size());
       std::vector<AssetVersion> blendVers(mergeIndexes.size());
+      int threadsToUse = 4;
+      #pragma omp parallel for schedule(static) num_threads(threadsToUse)
       for (size_t idx = 0; idx < mergeIndexes.size(); ++idx) {
         const InsetInfo<ProductAssetVersion> &inset(*extra.insetInfo[mergeIndexes[idx]]);
         const PacketGenInfo &genInfo(*extra.genInfo[mergeIndexes[idx]]);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetHandleD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetHandleD.h
@@ -153,7 +153,7 @@ class MutableAssetHandleD_ : public virtual Base_ {
   }
 
   static bool SaveDirtyToDotNew(khFilesTransaction &savetrans,
-                                std::vector<std::string> *saveDirty) {
+                                std::vector<SharedString> *saveDirty) {
     return Base::storageManager().SaveDirtyToDotNew(savetrans, saveDirty);
   }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/SConscript
@@ -23,6 +23,9 @@ env = env.Clone();
 env.Append(CPPPATH = ['#fusion/autoingest/sysman', # static headers
                       ])
 
+env.Append( CPPFLAGS=["-fopenmp"] )
+env.Append( LINKFLAGS=["-fopenmp"] )
+
 idlfiles = [ 'NextTaskId', 'JobStorage', 'TaskStorage', 'TaskRule',
              'FusionUniqueId' ]
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
@@ -101,7 +101,7 @@ khAssetManager::ApplyPending(void)
   // The actual list saved may be smaller than what's
   // in the dirty set. Some things can be in the dirty set
   // even if it really didn't change
-  std::vector<std::string> savedAssets;
+  std::vector<SharedString> savedAssets;
 
 
   QTime timer;
@@ -149,7 +149,7 @@ khAssetManager::ApplyPending(void)
 
   // build a list of AssetChanges
   AssetChanges changes;
-  for (std::vector<std::string>::const_iterator i = savedAssets.begin();
+  for (std::vector<SharedString>::const_iterator i = savedAssets.begin();
        i != savedAssets.end(); ++i) {
     changes.items.push_back(AssetChanges::Item(*i, "Modified"));
   }


### PR DESCRIPTION
This is a second attempt at parallelizing part of the packgen metadata processing in system manager. It parallelizes a relatively small section of the code so that we can make sure the paralleization is safe.