### PR TITLE
1302 Add new earth/metadata.json to portable files

### DIFF
--- a/docs/geedocs/5.3.1/answer/4485225.html
+++ b/docs/geedocs/5.3.1/answer/4485225.html
@@ -308,6 +308,7 @@
   --default_level=5<br/>
   --max_level=5<br/>
   --hires_qt_nodes_file=/tmp/globe_builder/LevelFive_4282_1287494655.545115/qt_nodes.txt<br/>
+  --metadata_file=/tmp/globe_builder/LevelFive_4282_1287494655.545115/earth/metadata.json<br/>
   --globe_directory=/tmp/globe_builder/LevelFive_4282_1287494655.545115/LevelFive<br/>
   --dbroot_file=/tmp/globe_builder/LevelFive_4282_1287494655.545115/dbroot.v5 &gt;<br/>
   /tmp/globe_builder/LevelFive_4282_1287494655.545115/packet_info.txt &amp; Ok<br/>
@@ -550,6 +551,10 @@
       <tr>
         <td><code>--dbroot_file=<em>filename</em></code></td>
         <td>Name of file containing the dbRoot that should be saved with the globe. Default is no file, in which case the dbRoot is read from the source.</td>
+      </tr>
+      <tr>
+        <td><code>--metadata_file=<em>filename</em></code></td>
+        <td>Name of file containing boundary metadata that should be saved with the globe. Default is no file, in which case no metadata file is included.</td>
       </tr>
       <tr>
         <td><code>--no_write</code></td>

--- a/docs/geedocs/5.3.1/answer/7160008.html
+++ b/docs/geedocs/5.3.1/answer/7160008.html
@@ -46,6 +46,7 @@ gtag('config', 'UA-108632131-2');
     <p id="overview_5.3.1">New Features</p>
   </h5>
     <p><strong>Uninstallation scripts are now copied over to the installation at <code>/opt/google/install</code>.  </strong>This will allow the user to uninstall from the installation instead of having to have a copy of the source code on hand.</p>
+    <p><strong>Cutter embeds extra metadata into portable files.</strong>  The bounding box metadata can be used to improve loading performance in some applications.
   <h5>
     <p id="supported_5.3.1">Supported Platforms</p>
   </h5>

--- a/earth_enterprise/src/fusion/portableglobe/SConscript
+++ b/earth_enterprise/src/fusion/portableglobe/SConscript
@@ -66,7 +66,7 @@ geportableglobebuilder = env.executable(
     ['geportableglobebuilder.cpp', portableglobebuilder, portablepacketwriter],
     LIBS=['sharedportablelib', 'gesimpleearthstream',
           'sgl', 'gif', 'png12', 'jpeg',
-          'freetype', 'geutil', 'gecommon', 'geqtpacket', 'geos'])
+          'freetype', 'geutil', 'gecommon', 'geqtpacket', 'geos', 'qtutils'])
 
 gecreatemetadbroot = env.executable(
     'gecreatemetadbroot',
@@ -79,7 +79,7 @@ geportablemapbuilder = env.executable(
      portableglobebuilder, portablepacketwriter],
     LIBS=['sharedportablelib', 'gesimpleearthstream',
           'sgl', 'gif', 'png12', 'jpeg',
-          'freetype', 'geutil', 'gecommon', 'geqtpacket', 'geos'])
+          'freetype', 'geutil', 'gecommon', 'geqtpacket', 'geos', 'qtutils'])
 
 geportableglobepacker = env.executable(
     'geportableglobepacker',
@@ -136,7 +136,7 @@ portableglobebuilder_test = env.test(
      portableglobebuilder, portablepacketwriter],
     LIBS=['sharedportablelib', 'gtest',
           'geutil', 'gecommon', 'geqtpacket',
-          'geos', 'gesimpleearthstream'])
+          'geos', 'gesimpleearthstream', 'qtutils'])
 
 portablemapbuilder_test = env.test(
     'portablemapbuilder_test',
@@ -144,7 +144,7 @@ portablemapbuilder_test = env.test(
      portableglobebuilder, portablepacketwriter],
      LIBS=['sharedportablelib', 'gtest',
            'geutil', 'gecommon', 'geqtpacket',
-           'geos', 'gesimpleearthstream'])
+           'geos', 'gesimpleearthstream', 'qtutils'])
 
 cutspec_test = env.test('cutspec_test',
                         ['cutspec_unittest.cpp'],

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -91,6 +91,7 @@ DBROOT_FILE2_TEMPLATE = "%s/%%s/dbroot/dbroot_%%s_%%s" % GLOBE_ENV_DIR_TEMPLATE
 POLYGON_FILE_TEMPLATE = "%s/%%s/earth/polygon.kml" % GLOBE_ENV_DIR_TEMPLATE
 PACKET_INFO_TEMPLATE = "%s/packet_info.txt" % GLOBE_ENV_DIR_TEMPLATE
 QTNODES_FILE_TEMPLATE = "%s/qt_nodes.txt" % GLOBE_ENV_DIR_TEMPLATE
+METADATA_FILE_TEMPLATE = "%s/%%s/earth/metadata.json" % GLOBE_ENV_DIR_TEMPLATE
 
 # Disk space minimum in MB before we start sending warnings.
 DISK_SPACE_WARNING_THRESHOLD = 1000.0
@@ -285,9 +286,10 @@ class GlobeBuilder(object):
     # Run this task as a background task.
     os_cmd = ("%s/geportableglobebuilder --source=\"%s\" --default_level=%d "
               "--max_level=%d --hires_qt_nodes_file=\"%s\" "
-              "--globe_directory=\"%s\" --dbroot_file=\"%s\" >\"%s\""
+              "--globe_directory=\"%s\" --dbroot_file=\"%s\" --metadata_file=\"%s\" >\"%s\""
               % (COMMAND_DIR, source, default_level, max_level,
                  self.qtnodes_file, self.globe_dir, self.dbroot_file,
+                 self.metadata_file,
                  self.packet_info_file))
     common.utils.ExecuteCmdInBackground(os_cmd, self.logger)
 
@@ -764,6 +766,7 @@ class GlobeBuilder(object):
         self.search_dir = SEARCH_DIR_TEMPLATE % (value, uid, value)
         self.globe_file = GLOBE_FILE_TEMPLATE % value
         self.map_file = MAP_FILE_TEMPLATE % value
+        self.metadata_file = METADATA_FILE_TEMPLATE % (value, uid, value)
         self.logger = common.utils.Log(LOG_FILE % (value, uid))
 
         form_keys = form_.keys()

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -306,9 +306,10 @@ class GlobeBuilder(object):
               "--source=\"%s\" "
               "--hires_qt_nodes_file=\"%s\" "
               "--map_directory=\"%s\"  --default_level=%d --max_level=%d "
+              "--metadata_file=\"%s\" "
               % (COMMAND_DIR, ignore_imagery_depth_str, source,
                  self.qtnodes_file, self.globe_dir, default_level, 
-                 max_level))
+                 max_level, self.metadata_file))
 
     common.utils.ExecuteCmdInBackground(os_cmd, self.logger)
 

--- a/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
@@ -78,7 +78,7 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "                    the total size of the globe.\n"
           "   --use_post:      Use HTTP POST (e.g. for Earth Builder) to get\n"
           "                    packets from server.\n"
-          "   --metadata_file:   Name of file that will store boundary metadata.\n"
+          "   --metadata_file: Name of file that will store boundary metadata.\n"
           "                    Default is no file.\n"
           "   --additional_args: Arguments to be added to each request to\n"
           "                    the Earth Server being cut.\n"

--- a/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2019 Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geportableglobebuilder.cpp
@@ -78,6 +78,8 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "                    the total size of the globe.\n"
           "   --use_post:      Use HTTP POST (e.g. for Earth Builder) to get\n"
           "                    packets from server.\n"
+          "   --metadata_file:   Name of file that will store boundary metadata.\n"
+          "                    Default is no file.\n"
           "   --additional_args: Arguments to be added to each request to\n"
           "                    the Earth Server being cut.\n"
           "                    Default is \"&ct=c\" indicating Cutter\n"
@@ -100,6 +102,7 @@ int main(int argc, char **argv) {
     std::string dbroot_file;
     std::string globe_directory;
     std::string qtpacket_version = "1";
+    std::string metadata_file;
     // Default indicates Cutter context.
     std::string additional_args = "&ct=c";
     uint32 default_level = 7;
@@ -118,6 +121,8 @@ int main(int argc, char **argv) {
     options.opt("hires_qt_nodes_file", hires_qt_nodes_file);
     options.opt("additional_args", additional_args);
     options.opt("dbroot_file", dbroot_file);
+    options.opt("metadata_file", metadata_file);
+
     options.setRequired("source", "globe_directory");
 
     if (!options.processAll(argc, argv, argn)
@@ -136,6 +141,7 @@ int main(int argc, char **argv) {
                       globe_directory,
                       additional_args,
                       qtpacket_version,
+                      metadata_file,
                       no_write,
                       use_post);
 

--- a/earth_enterprise/src/fusion/portableglobe/geportablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geportablemapbuilder.cpp
@@ -73,7 +73,9 @@ void usage(const std::string &progn, const char *msg = 0, ...) {
           "                    packets, even if main imagery layer has no\n"
           "                    more data.\n"
           "   --no_write:      Do not write packets, just give print out\n"
-          "                    the total size of the map.\n",
+          "                    the total size of the map.\n"
+          "   --metadata_file: Name of file that will store boundary metadata.\n"
+          "                    Default is no file.\n",
           progn.c_str());
   exit(1);
 }
@@ -90,6 +92,8 @@ int main(int argc, char **argv) {
     std::string source;
     std::string hires_qt_nodes_file;
     std::string map_directory;
+    std::string metadata_file;
+
     // Default indicates Cutter context.
     std::string additional_args = "&ct=c";
     uint32 default_level = 7;
@@ -106,6 +110,8 @@ int main(int argc, char **argv) {
     options.opt("max_level", max_level);
     options.opt("hires_qt_nodes_file", hires_qt_nodes_file);
     options.opt("additional_args", additional_args);
+    options.opt("metadata_file", metadata_file);
+
     options.setRequired("source", "map_directory");
 
     if (!options.processAll(argc, argv, argn)
@@ -122,6 +128,7 @@ int main(int argc, char **argv) {
                     hires_qt_nodes_file,
                     map_directory,
                     additional_args,
+                    metadata_file,
                     ignore_imagery_depth,
                     no_write);
 

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
@@ -648,11 +648,10 @@ void PortableGlobeBuilder::ProcessDataInQtPacketNodes(
     WriteTerrainPacket(qtpath, node->terrain_version);
   }
   if (node->children.GetDrawableBit()) {
-    bounds_tracker_.update(2, kVectorPacket, qtpath);
-
     for (size_t i = 0; i < node->num_channels(); ++i) {
       // Assuming that channel_type is in increasing order,
       // otherwise we are going to need to sort.
+      bounds_tracker_.update(node->channel_type[i], kVectorPacket, qtpath);
       WriteVectorPacket(qtpath,
                         node->channel_type[i],
                         node->channel_version[i]);

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2019 Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
@@ -417,21 +417,25 @@ void PortableGlobeBuilder::write_bounds_file() {
   }
   khEnsureParentDir(metadata_file_);
   std::ofstream fout(metadata_file_.c_str());
-  fout << "{\n"
-       << "  \"top\": " << layer_bounds_.top << ",\n"
-       << "  \"bottom\": " << layer_bounds_.bottom << ",\n"
-       << "  \"left\": " << layer_bounds_.left << ",\n"
-       << "  \"right\": " << layer_bounds_.right << ",\n"
-       << "  \"min_image_level\": " << layer_bounds_.min_image_level << ",\n"
-       << "  \"max_image_level\": " << layer_bounds_.max_image_level << ",\n"
-       << "  \"min_terrain_level\": " << layer_bounds_.min_terrain_level << ",\n"
-       << "  \"max_terrain_level\": " << layer_bounds_.max_terrain_level << ",\n"
-       << "  \"min_vector_level\": " << layer_bounds_.min_vector_level << ",\n"
-       << "  \"max_vector_level\": " << layer_bounds_.max_vector_level << ",\n"
-       << "  \"imageTileChannel\": " << layer_bounds_.imageTileChannel << ",\n"
-       << "  \"terrainTileChannel\": " << layer_bounds_.terrainTileChannel << ",\n"
-       << "  \"vectorTileChannel\": " << layer_bounds_.vectorTileChannel << ",\n"
-       << "}\n";
+  fout << "[\n"
+       << "  {\n"
+       << "    \"layer_id\": 0\n"
+       << "    \"top\": " << layer_bounds_.top << ",\n"
+       << "    \"bottom\": " << layer_bounds_.bottom << ",\n"
+       << "    \"left\": " << layer_bounds_.left << ",\n"
+       << "    \"right\": " << layer_bounds_.right << ",\n"
+       << "    \"min_image_level\": " << layer_bounds_.min_image_level << ",\n"
+       << "    \"max_image_level\": " << layer_bounds_.max_image_level << ",\n"
+       << "    \"min_terrain_level\": " << layer_bounds_.min_terrain_level << ",\n"
+       << "    \"max_terrain_level\": " << layer_bounds_.max_terrain_level << ",\n"
+       << "    \"min_vector_level\": " << layer_bounds_.min_vector_level << ",\n"
+       << "    \"max_vector_level\": " << layer_bounds_.max_vector_level << ",\n"
+       << "    \"image_tile_channel\": " << layer_bounds_.image_tile_channel << ",\n"
+       << "    \"terrain_tile_channel\": " << layer_bounds_.terrain_tile_channel << ",\n"
+       << "    \"vector_tile_channel\": " << layer_bounds_.vector_tile_channel << ",\n"
+       << "  }\n"
+       << "]\n";
+
   fout.close();
 }
 

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
@@ -639,15 +639,16 @@ void PortableGlobeBuilder::ProcessDataInQtPacketNodes(
   // If packet_level == 0 there is no data, it is only for children.
   // For this qt_path the data was there at packet_level == 4 rather.
   if (node->children.GetImageBit()) {
-    bounds_tracker_.update(qtpath, PacketType::kImagePacket, kGEImageryChannelId);
+    bounds_tracker_.update(kGEImageryChannelId, kImagePacket, qtpath);
     WriteImagePacket(qtpath, node->image_version);
   }
   if (node->children.GetTerrainBit()) {
-    bounds_tracker_.update(qtpath, PacketType::kTerrainPacket, kGETerrainChannelId - 1);
+    bounds_tracker_.update(kGETerrainChannelId - 1, kTerrainPacket, qtpath);
     WriteTerrainPacket(qtpath, node->terrain_version);
   }
   if (node->children.GetDrawableBit()) {
-    bounds_tracker_.update(qtpath, PacketType::kVectorPacket, 2);
+    bounds_tracker_.update(2, kVectorPacket, qtpath);
+
     for (size_t i = 0; i < node->num_channels(); ++i) {
       // Assuming that channel_type is in increasing order,
       // otherwise we are going to need to sort.

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.cpp
@@ -639,15 +639,15 @@ void PortableGlobeBuilder::ProcessDataInQtPacketNodes(
   // If packet_level == 0 there is no data, it is only for children.
   // For this qt_path the data was there at packet_level == 4 rather.
   if (node->children.GetImageBit()) {
-    bounds_tracker_.update_imagery(qtpath);
+    bounds_tracker_.update(qtpath, PacketType::kImagePacket, kGEImageryChannelId);
     WriteImagePacket(qtpath, node->image_version);
   }
   if (node->children.GetTerrainBit()) {
-    bounds_tracker_.update_terrain(qtpath);
+    bounds_tracker_.update(qtpath, PacketType::kTerrainPacket, kGETerrainChannelId - 1);
     WriteTerrainPacket(qtpath, node->terrain_version);
   }
   if (node->children.GetDrawableBit()) {
-    bounds_tracker_.update_vector(qtpath);
+    bounds_tracker_.update(qtpath, PacketType::kVectorPacket, 2);
     for (size_t i = 0; i < node->num_channels(); ++i) {
       // Assuming that channel_type is in increasing order,
       // otherwise we are going to need to sort.

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
@@ -29,6 +29,7 @@
 #include <vector>
 #include "common/qtpacket/quadtreepacket.h"
 #include "fusion/gst/gstSimpleEarthStream.h"
+#include "fusion/portableglobe/shared/bounds_tracker.h"
 #include "fusion/portableglobe/shared/packetbundle_reader.h"
 #include "fusion/portableglobe/shared/packetbundle_writer.h"
 #include "fusion/portableglobe/portablepacketwriter.h"
@@ -198,31 +199,6 @@ class QtPacketLookAheadRequestor {
   size_t cache_index_;
   size_t prefetched_;
   std::vector<QuadtreePath> paths_with_qt_packets_;
-};
-
-struct layer_bounds {
-  uint32_t top = 0;
-  uint32_t left = UINT32_MAX;
-  uint32_t bottom = UINT32_MAX;
-  uint32_t right = 0;
-
-  uint32_t min_image_level = 32;
-  uint32_t max_image_level = 0;
-
-  uint32_t min_terrain_level = 32;
-  uint32_t max_terrain_level = 0;
-
-  uint32_t min_vector_level = 32;
-  uint32_t max_vector_level = 0;
-
-  // save off the location and size of the first packet encountered at the highest level we
-  // find, so that we can check if there is another layer after that
-  uint64_t terrain_packet_offset = UINT64_MAX;
-  uint32_t terrain_packet_size = UINT32_MAX;
-
-  uint16_t image_tile_channel = UINT16_MAX;
-  uint16_t terrain_tile_channel = UINT16_MAX;
-  uint16_t vector_tile_channel = UINT16_MAX;
 };
 
 /**
@@ -404,16 +380,10 @@ class PortableGlobeBuilder : public PortableBuilder {
   RequestBundlerForPacketSize<PortableGlobeBuilder> terrain_pac_size_req_cache_;
   RequestBundlerForPacketSize<PortableGlobeBuilder> vector_pac_size_req_cache_;
 
-  // Path to file that will hold metadata
+  // Path to file that will hold metadata.
   std::string metadata_file_;
-  // Map to hold metadata as globe is built.
-  layer_bounds layer_bounds_;
-
-  void update_bounds(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update=false);
-  void update_imagery_bounds(const std::string& qtpath);
-  void update_terrain_bounds(const std::string& qtpath);
-  void update_vector_bounds(const std::string& qtpath);
-  void write_bounds_file();
+  // Structure to keep track of globe boundaries.
+  BoundsTracker bounds_tracker_;
 
   DISALLOW_COPY_AND_ASSIGN(PortableGlobeBuilder);
 };

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Google Inc.
+ * Copyright 2019 Open GEE Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
@@ -409,7 +409,7 @@ class PortableGlobeBuilder : public PortableBuilder {
   // Map to hold metadata as globe is built.
   layer_bounds layer_bounds_;
 
-  uint32_t update_bounds(const std::string& qtpath);
+  void update_bounds(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update=false);
   void update_imagery_bounds(const std::string& qtpath);
   void update_terrain_bounds(const std::string& qtpath);
   void update_vector_bounds(const std::string& qtpath);

--- a/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
+++ b/earth_enterprise/src/fusion/portableglobe/portableglobebuilder.h
@@ -220,9 +220,9 @@ struct layer_bounds {
   uint64_t terrain_packet_offset = UINT64_MAX;
   uint32_t terrain_packet_size = UINT32_MAX;
 
-  uint16_t imageTileChannel = UINT16_MAX;
-  uint16_t terrainTileChannel = UINT16_MAX;
-  uint16_t vectorTileChannel = UINT16_MAX;
+  uint16_t image_tile_channel = UINT16_MAX;
+  uint16_t terrain_tile_channel = UINT16_MAX;
+  uint16_t vector_tile_channel = UINT16_MAX;
 };
 
 /**

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -35,6 +35,7 @@
 #include "fusion/gst/gstSimpleEarthStream.h"
 #include "fusion/gst/gstSimpleStream.h"
 #include "fusion/portableglobe/portableglobebuilder.h"
+#include "fusion/portableglobe/quadtree/qtutils.h"
 #include "fusion/portableglobe/shared/packetbundle.h"
 #include "fusion/portableglobe/shared/packetbundle_reader.h"
 #include "fusion/portableglobe/shared/packetbundle_writer.h"
@@ -63,6 +64,7 @@ PortableMapBuilder::PortableMapBuilder(
     const std::string& hires_qt_nodes_file,
     const std::string& map_directory,
     const std::string& additional_args,
+    const std::string& metadata_file,
     bool ignore_imagery_depth,
     bool no_write)
     : map_directory_(map_directory),
@@ -70,6 +72,7 @@ PortableMapBuilder::PortableMapBuilder(
     max_level_(max_level),
     source_(source),
     additional_args_(additional_args),
+    metadata_file_(metadata_file),
     ignore_imagery_depth_(ignore_imagery_depth),
     is_no_write_(no_write) {
   // Build a structure for filtering quadtree addresses.
@@ -176,6 +179,8 @@ void PortableMapBuilder::BuildMap() {
   // Finish up writing all of the packet bundles.
   DeleteWriter();
 
+  
+  
   // The "+1" for max_level_traversed is because the code uses zero
   // for the first level but the cutter page and most humans use one.
   if (max_level_traversed+1 < max_level_) {

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -176,11 +176,13 @@ void PortableMapBuilder::BuildMap() {
     }
   }
 
+  if (!metadata_file_.empty()) {
+    bounds_tracker_.write_json_file(metadata_file_);
+  }
+
   // Finish up writing all of the packet bundles.
   DeleteWriter();
 
-  
-  
   // The "+1" for max_level_traversed is because the code uses zero
   // for the first level but the cutter page and most humans use one.
   if (max_level_traversed+1 < max_level_) {
@@ -423,6 +425,10 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
         // (1 x 1 clear pngs) to unnecessarily deep levels.
         found_something = true;
       }
+
+      bounds_tracker_.update(qtpath_str,
+                             static_cast<PacketType>(packet_type),
+                             layers_[i]->channel_num);
 
       std::string full_qtpath = "0" + qtpath_str;
       writer_->AppendPacket(full_qtpath, packet_type, layers_[i]->channel_num,

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.cpp
@@ -426,9 +426,9 @@ bool PortableMapBuilder::WriteMapPackets(const std::string& qtpath_str,
         found_something = true;
       }
 
-      bounds_tracker_.update(qtpath_str,
+      bounds_tracker_.update(layers_[i]->channel_num,
                              static_cast<PacketType>(packet_type),
-                             layers_[i]->channel_num);
+                             qtpath_str);
 
       std::string full_qtpath = "0" + qtpath_str;
       writer_->AppendPacket(full_qtpath, packet_type, layers_[i]->channel_num,

--- a/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.h
+++ b/earth_enterprise/src/fusion/portableglobe/portablemapbuilder.h
@@ -94,6 +94,7 @@ class PortableMapBuilder {
                      const std::string& hires_qt_nodes_file,
                      const std::string& map_directory,
                      const std::string& additional_args,
+                     const std::string& metadata_file,
                      bool ignore_imagery_depth,
                      bool no_write);
 
@@ -101,12 +102,6 @@ class PortableMapBuilder {
   PortableMapBuilder():server_(NULL) {}
 
   ~PortableMapBuilder();
-
-  /**
-   * Build packet bundles for all specified data types. Add data based on
-   * whether corresponding quadtree nodes is to be kept in the globe.
-   */
-  void BuildGlobe();
 
   /**
    * Build packet bundles for all specified data types. Add data based on
@@ -182,11 +177,18 @@ class PortableMapBuilder {
 
   // Packet bundle writers for the different asset types.
   PacketBundleWriter* writer_;
+
+  // Path to file that will hold metadata.
+  std::string metadata_file_;
+  // Structure to keep track of map boundaries.
+  BoundsTracker bounds_tracker_;
+
   // Flag indicating whether Cutter should continue looking for (vector) data
   // or stop cut in that region when end of imagery data is found.
   bool ignore_imagery_depth_;
   // Flag indicating whether data shouldn't be written, just checked for size.
   bool is_no_write_;
+
 
   DISALLOW_COPY_AND_ASSIGN(PortableMapBuilder);
 };

--- a/earth_enterprise/src/fusion/portableglobe/shared/SConscript
+++ b/earth_enterprise/src/fusion/portableglobe/shared/SConscript
@@ -47,3 +47,8 @@ packetbundle_test = env.test('packetbundle_test',
 file_packer_test = env.test('file_packer_test',
                             ['file_packer_unittest.cpp'],
                              LIBS=['sharedportablelib', 'gtest', 'gecommon'])
+
+bounds_tracker_test = env.test('bounds_tracker_test',
+                             ['bounds_tracker_unittest.cpp'],
+                              LIBS=['sharedportablelib', 'gtest', 'gecommon', 'qtutils'])
+

--- a/earth_enterprise/src/fusion/portableglobe/shared/SConscript
+++ b/earth_enterprise/src/fusion/portableglobe/shared/SConscript
@@ -24,12 +24,13 @@ portablelib_sources = ['packetbundle.cpp',
                        'packetbundle_reader.cpp',
                        'packetbundle_writer.cpp',
                        'packetbundle_finder.cpp',
+                       'bounds_tracker.cpp',
                        'file_package.cpp',
                        'file_packer.cpp',
                        'file_unpacker.cpp',
                        ]
 
-sharedportablelib = env.sharedLib('sharedportablelib', portablelib_sources)
+sharedportablelib = env.sharedLib('sharedportablelib', portablelib_sources, LIBS=['qtutils'])
 
 servereader_sources = ['serverreader.cpp',
                        ]
@@ -41,7 +42,7 @@ env.install('server_lib', [serverreaderlib, sharedportablelib])
 
 packetbundle_test = env.test('packetbundle_test',
                              ['packetbundle_unittest.cpp'],
-                              LIBS=['sharedportablelib', 'gtest', 'gecommon'])
+                              LIBS=['sharedportablelib', 'gtest', 'gecommon', 'qtutils'])
 
 file_packer_test = env.test('file_packer_test',
                             ['file_packer_unittest.cpp'],

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
@@ -89,13 +89,13 @@ void BoundsTracker::write_json_file(const std::string& filename) const {
 
     fout << "  {\n"
          << "    \"channel_id\": "      << channel.channel_id << ",\n"
-         << "    \"type\": \""          << channel_type_strings[channel.type] << "\"\n"
+         << "    \"type\": \""          << channel_type_strings[channel.type] << "\",\n"
          << "    \"top\": "             << channel.top << ",\n"
          << "    \"bottom\": "          << channel.bottom << ",\n"
          << "    \"left\": "            << channel.left << ",\n"
          << "    \"right\": "           << channel.right << ",\n"
-         << "    \"min_image_level\": " << channel.min_level << ",\n"
-         << "    \"max_image_level\": " << channel.max_level << ",\n"
+         << "    \"min_level\": "       << channel.min_level << ",\n"
+         << "    \"max_level\": "       << channel.max_level << "\n"
          << "  }";
 
     if (iter != last_entry) {

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
@@ -56,7 +56,7 @@ void BoundsTracker::write_json_file(const std::string& filename) {
   std::ofstream fout(filename.c_str());
   fout << "[\n"
        << "  {\n"
-       << "    \"layer_id\": 0\n"
+       << "    \"layer_id\": 0,\n"
        << "    \"top\": " << this->top << ",\n"
        << "    \"bottom\": " << this->bottom << ",\n"
        << "    \"left\": " << this->left << ",\n"
@@ -69,7 +69,7 @@ void BoundsTracker::write_json_file(const std::string& filename) {
        << "    \"max_vector_level\": " << this->max_vector_level << ",\n"
        << "    \"image_tile_channel\": " << this->image_tile_channel << ",\n"
        << "    \"terrain_tile_channel\": " << this->terrain_tile_channel << ",\n"
-       << "    \"vector_tile_channel\": " << this->vector_tile_channel << ",\n"
+       << "    \"vector_tile_channel\": " << this->vector_tile_channel << "\n"
        << "  }\n"
        << "]\n";
 
@@ -81,12 +81,12 @@ void BoundsTracker::update(const std::string& qtpath, uint32_t& min_level, uint3
 
   uint32_t column, row, zoom;
   ConvertFromQtNode(real_path, &column, &row, &zoom);
-
-  if (zoom < min_level) {
+  uint32_t level = qtpath.size();
+  if (level < min_level) {
     min_level = zoom;
   }
-  if (zoom > max_level) {
-    max_level = zoom;
+  if (level > max_level) {
+    max_level = level;
     if (update_bounding_box) {
       this->left = column;
       this->right = column;
@@ -95,7 +95,7 @@ void BoundsTracker::update(const std::string& qtpath, uint32_t& min_level, uint3
     }
   }
 
-  if (zoom == max_level && update_bounding_box) {
+  if (level == max_level && update_bounding_box) {
     this->left = std::min(column, this->left);
     this->right = std::max(column, this->right);
 

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
@@ -1,0 +1,97 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Methods keeping track of quadtree bounds and writing to a JSON file.
+
+#include "fusion/portableglobe/shared/bounds_tracker.h"
+#include <fstream>  // NOLINT(readability/streams)
+#include <iostream>  // NOLINT(readability/streams)
+#include <string>
+#include "common/khFileUtils.h"
+#include "fusion/portableglobe/quadtree/qtutils.h"
+
+namespace fusion_portableglobe {
+
+BoundsTracker::BoundsTracker() {}
+
+void BoundsTracker::update_imagery(const std::string& qtpath) {
+  update(qtpath, this->min_image_level, this->max_image_level, true);
+}
+
+void BoundsTracker::update_terrain(const std::string& qtpath) {
+  update(qtpath, this->min_terrain_level, this->max_terrain_level);
+}
+
+void BoundsTracker::update_vector(const std::string& qtpath) {
+  update(qtpath, this->min_vector_level, this->max_vector_level);
+}
+
+void BoundsTracker::write_json_file(const std::string& filename) {
+  khEnsureParentDir(filename);
+  std::ofstream fout(filename.c_str());
+  fout << "[\n"
+       << "  {\n"
+       << "    \"layer_id\": 0\n"
+       << "    \"top\": " << this->top << ",\n"
+       << "    \"bottom\": " << this->bottom << ",\n"
+       << "    \"left\": " << this->left << ",\n"
+       << "    \"right\": " << this->right << ",\n"
+       << "    \"min_image_level\": " << this->min_image_level << ",\n"
+       << "    \"max_image_level\": " << this->max_image_level << ",\n"
+       << "    \"min_terrain_level\": " << this->min_terrain_level << ",\n"
+       << "    \"max_terrain_level\": " << this->max_terrain_level << ",\n"
+       << "    \"min_vector_level\": " << this->min_vector_level << ",\n"
+       << "    \"max_vector_level\": " << this->max_vector_level << ",\n"
+       << "    \"image_tile_channel\": " << this->image_tile_channel << ",\n"
+       << "    \"terrain_tile_channel\": " << this->terrain_tile_channel << ",\n"
+       << "    \"vector_tile_channel\": " << this->vector_tile_channel << ",\n"
+       << "  }\n"
+       << "]\n";
+
+  fout.close();
+}
+
+inline void BoundsTracker::update(const std::string& qtpath,
+                                  uint32_t& min_level,
+                                  uint32_t& max_level,
+                                  bool update) {
+  std::string real_path = "0" + qtpath;
+
+  uint32_t column, row, zoom;
+  ConvertFromQtNode(real_path, &column, &row, &zoom);
+
+  if (zoom < min_level) {
+    min_level = zoom;
+  }
+  if (zoom > max_level) {
+    max_level = zoom;
+    if (update) {
+      this->left = column;
+      this->right = column;
+      this->top = row;
+      this->bottom = row;
+    }
+  }
+
+  if (zoom == max_level && update) {
+    this->left = std::min(column, this->left);
+    this->right = std::max(column, this->right);
+
+    this->top = std::min(row, this->top);
+    this->bottom = std::max(row, this->bottom);
+  }
+}
+  
+}  // namespace fusion_portableglobe

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
@@ -89,7 +89,7 @@ void BoundsTracker::write_json_file(const std::string& filename) const {
 
     fout << "  {\n"
          << "    \"channel_id\": "      << channel.channel_id << ",\n"
-         << "    \"type\": \""          << channel_type_strings[channel.type] << "\",\n"
+         << "    \"type\": \""          << channel_type_strings.at(channel.type) << "\",\n"
          << "    \"top\": "             << channel.top << ",\n"
          << "    \"bottom\": "          << channel.bottom << ",\n"
          << "    \"left\": "            << channel.left << ",\n"

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ void BoundsTracker::update(uint16_t channel_id, PacketType type, const std::stri
 void BoundsTracker::write_json_file(const std::string& filename) const {
   khEnsureParentDir(filename);
 
-  static std::map<PacketType, std::string> channel_type_strings =
+  static const std::map<PacketType, std::string> channel_type_strings =
     {{ kDbRootPacket,  "DbRoot"},
      { kDbRoot2Packet, "DbRoot2"},
      { kQtpPacket,     "Qtp"},
@@ -84,7 +84,7 @@ void BoundsTracker::write_json_file(const std::string& filename) const {
   fout << "[\n";
   for (auto iter =  channels.begin(); iter != channels.end(); ++iter) {
 
-    const std::pair<uint16_t, channel_info> channel_pair = *iter;
+    const std::pair<uint16_t, channel_info> &channel_pair = *iter;
     const auto &channel = channel_pair.second;
 
     fout << "  {\n"

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
@@ -22,45 +22,58 @@
 #include <vector>
 #include "common/base/macros.h"
 #include "common/khTypes.h"
+#include "fusion/portableglobe/shared/packetbundle.h"
 
 namespace fusion_portableglobe {
 
+/**
+   A class to keep track of imagery, terrain, and vector boundaries while
+   building maps and globes.
+ */
 class BoundsTracker {
 public:
   BoundsTracker();
 
-  void update_imagery(const std::string& qtpath);
-  void update_terrain(const std::string& qtpath);
-  void update_vector(const std::string& qtpath);
+  /**
+     Update min_level and max_level in/out parameters to incorporate qtpath.
+     If update is true, also update the top, bottom, left, and right boundaries.
+     @param qtpath The quadtree path to incorporate
+     @param type   The type of node being added.
+  */
+  void update(const std::string& qtpath, PacketType type, uint16_t channel);
 
+  /**
+     Write current boundary information to a JSON file.
+     @param filename The name of the file to create.
+  */
   void write_json_file(const std::string& filename);
 
 public:
+  // top, left, bottom, and right keep track of the bounding box for imagery
   uint32_t top = 0;
-  uint32_t left = UINT32_MAX;
   uint32_t bottom = UINT32_MAX;
+  uint32_t left = UINT32_MAX;
   uint32_t right = 0;
 
+  // Minimum and maximum zoom levels with imagery packets
   uint32_t min_image_level = 32;
   uint32_t max_image_level = 0;
 
+  // Minimum and maximum zoom levels with terrain packets
   uint32_t min_terrain_level = 32;
   uint32_t max_terrain_level = 0;
 
+  // Minimum and maximum zoom levels with vector packets
   uint32_t min_vector_level = 32;
   uint32_t max_vector_level = 0;
 
-  // save off the location and size of the first packet encountered at the highest level we
-  // find, so that we can check if there is another layer after that
-  uint64_t terrain_packet_offset = UINT64_MAX;
-  uint32_t terrain_packet_size = UINT32_MAX;
-
+  // Keep track of which channels contain imagery, terrain, and vector data.
   uint16_t image_tile_channel = UINT16_MAX;
   uint16_t terrain_tile_channel = UINT16_MAX;
   uint16_t vector_tile_channel = UINT16_MAX;
 
 private:
-  void update(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update=false);
+  void update(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update_bounding_box=false);
 
   DISALLOW_COPY_AND_ASSIGN(BoundsTracker);
 };

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
@@ -27,65 +27,101 @@
 
 namespace fusion_portableglobe {
 
-
+/**
+   The boundary and zoom level information for a channel/layer.
+*/
 struct channel_info {
+  // Channel ID and type
+  uint16_t channel_id = UINT16_MAX;
+  PacketType type;
+
+  // Map tile bounding box
   uint32_t top = 0;
   uint32_t bottom = UINT32_MAX;
   uint32_t left = UINT32_MAX;
   uint32_t right = 0;
 
+  // Zoom levels where this channel is available
   uint32_t min_level = UINT32_MAX;
   uint32_t max_level = 0;
-  uint16_t channel = UINT16_MAX;
-  PacketType type;
-  channel_info() : top(0),
+
+  /**
+     Default constructor that creates an empty bounds, where
+     bottom > top, left > right, and min_level > max_level.
+  */
+  channel_info() : channel_id(UINT16_MAX),
+                   top(0),
                    bottom(UINT32_MAX),
                    left(UINT32_MAX),
                    right(0),
                    min_level(UINT32_MAX),
-                   max_level(0),
-                   channel(UINT16_MAX)
+                   max_level(0)
   {};
-  channel_info(uint32_t row,
+
+  /**
+     Create a channel_info with the given channel_id and type, bounding the
+     given row, column, and level.
+     @param channel
+     @param type
+     @param row
+     @param column
+     @param level
+  */
+  channel_info(uint16_t channel_id,
+               PacketType type,
+               uint32_t row,
                uint32_t column,
-               uint32_t level,
-               uint16_t channel,
-               PacketType type) :
+               uint32_t level) :
+    channel_id(channel_id),
+    type(type),
     top(row), bottom(row),
     left(column), right(column),
-    min_level(level), max_level(level),
-    channel(channel),
-    type(type)
+    min_level(level), max_level(level)
   {}
 };
 
 /**
-   A class to keep track of imagery, terrain, and vector boundaries while
-   building maps and globes.
+   A class for tracking the map tile boundaries and zoom levels of a portable file
+   as it's being built. Once the globe is finished, the information is saved to
+   earth/metadata.json and included in the final *.glb or *.glm file.
+
+   Only the tile boundaries at max_level are stored by the tracker.
  */
+
 class BoundsTracker {
 public:
+
+  /// Default constructor
   BoundsTracker();
 
   /**
-     Update min_level and max_level in/out parameters to incorporate qtpath.
-     If update is true, also update the top, bottom, left, and right boundaries.
-     @param qtpath The quadtree path to incorporate
-     @param type   The type of node being added.
+     Update the channel_info for the specified channel to be of the given type and
+     include qtpath in its bounds.
+     @param channel ID of the channel to be updated.
+     @param type    The packet type of the channel.
+     @param qtpath  The quadtree address to update.
   */
-  void update(const std::string& qtpath, PacketType type, uint16_t channel);
+  void update(uint16_t channel, PacketType type, const std::string& qtpath);
 
   /**
-     Write current boundary information to a JSON file.
-     @param filename The name of the file to create.
+     Write current boundary information to the specified JSON file.
+     @param filename
   */
-  void write_json_file(const std::string& filename);
+  void write_json_file(const std::string& filename) const;
 
-public:
+  /**
+     Return a const reference to the specified channel_info object.
+     Throws a khSimpleException if the channel isn't found.
+     @param channel_id
+  */
+  const channel_info& channel(uint16_t channel_id) const;
+
+
+private:
+
   // Minimum and maximum zoom level and channel for imagery, terrain, and vector data
   std::map<uint16_t, channel_info> channels;
 
-private:
   DISALLOW_COPY_AND_ASSIGN(BoundsTracker);
 };
 

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
@@ -20,11 +20,44 @@
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>
+#include <map>
 #include "common/base/macros.h"
 #include "common/khTypes.h"
 #include "fusion/portableglobe/shared/packetbundle.h"
 
 namespace fusion_portableglobe {
+
+
+struct channel_info {
+  uint32_t top = 0;
+  uint32_t bottom = UINT32_MAX;
+  uint32_t left = UINT32_MAX;
+  uint32_t right = 0;
+
+  uint32_t min_level = UINT32_MAX;
+  uint32_t max_level = 0;
+  uint16_t channel = UINT16_MAX;
+  PacketType type;
+  channel_info() : top(0),
+                   bottom(UINT32_MAX),
+                   left(UINT32_MAX),
+                   right(0),
+                   min_level(UINT32_MAX),
+                   max_level(0),
+                   channel(UINT16_MAX)
+  {};
+  channel_info(uint32_t row,
+               uint32_t column,
+               uint32_t level,
+               uint16_t channel,
+               PacketType type) :
+    top(row), bottom(row),
+    left(column), right(column),
+    min_level(level), max_level(level),
+    channel(channel),
+    type(type)
+  {}
+};
 
 /**
    A class to keep track of imagery, terrain, and vector boundaries while
@@ -49,32 +82,10 @@ public:
   void write_json_file(const std::string& filename);
 
 public:
-  // top, left, bottom, and right keep track of the bounding box for imagery
-  uint32_t top = 0;
-  uint32_t bottom = UINT32_MAX;
-  uint32_t left = UINT32_MAX;
-  uint32_t right = 0;
-
-  // Minimum and maximum zoom levels with imagery packets
-  uint32_t min_image_level = 32;
-  uint32_t max_image_level = 0;
-
-  // Minimum and maximum zoom levels with terrain packets
-  uint32_t min_terrain_level = 32;
-  uint32_t max_terrain_level = 0;
-
-  // Minimum and maximum zoom levels with vector packets
-  uint32_t min_vector_level = 32;
-  uint32_t max_vector_level = 0;
-
-  // Keep track of which channels contain imagery, terrain, and vector data.
-  uint16_t image_tile_channel = UINT16_MAX;
-  uint16_t terrain_tile_channel = UINT16_MAX;
-  uint16_t vector_tile_channel = UINT16_MAX;
+  // Minimum and maximum zoom level and channel for imagery, terrain, and vector data
+  std::map<uint16_t, channel_info> channels;
 
 private:
-  void update(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update_bounding_box=false);
-
   DISALLOW_COPY_AND_ASSIGN(BoundsTracker);
 };
 

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Open GEE Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GEO_EARTH_ENTERPRISE_SRC_FUSION_PORTABLEGLOBE_SHARED_BOUNDS_TRACKER_H_
+#define GEO_EARTH_ENTERPRISE_SRC_FUSION_PORTABLEGLOBE_SHARED_BOUNDS_TRACKER_H_
+
+#include <fstream>  // NOLINT(readability/streams)
+#include <string>
+#include <vector>
+#include "common/base/macros.h"
+#include "common/khTypes.h"
+
+namespace fusion_portableglobe {
+
+class BoundsTracker {
+public:
+  BoundsTracker();
+
+  void update_imagery(const std::string& qtpath);
+  void update_terrain(const std::string& qtpath);
+  void update_vector(const std::string& qtpath);
+
+  void write_json_file(const std::string& filename);
+
+public:
+  uint32_t top = 0;
+  uint32_t left = UINT32_MAX;
+  uint32_t bottom = UINT32_MAX;
+  uint32_t right = 0;
+
+  uint32_t min_image_level = 32;
+  uint32_t max_image_level = 0;
+
+  uint32_t min_terrain_level = 32;
+  uint32_t max_terrain_level = 0;
+
+  uint32_t min_vector_level = 32;
+  uint32_t max_vector_level = 0;
+
+  // save off the location and size of the first packet encountered at the highest level we
+  // find, so that we can check if there is another layer after that
+  uint64_t terrain_packet_offset = UINT64_MAX;
+  uint32_t terrain_packet_size = UINT32_MAX;
+
+  uint16_t image_tile_channel = UINT16_MAX;
+  uint16_t terrain_tile_channel = UINT16_MAX;
+  uint16_t vector_tile_channel = UINT16_MAX;
+
+private:
+  void update(const std::string& qtpath, uint32_t& min_level, uint32_t& max_level, bool update=false);
+
+  DISALLOW_COPY_AND_ASSIGN(BoundsTracker);
+};
+
+}  // namespace fusion_portableglobe
+
+#endif  // GEO_EARTH_ENTERPRISE_SRC_FUSION_PORTABLEGLOBE_PORTABLEGLOBEBUILDER_H_

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
@@ -40,175 +40,177 @@ class BoundsTrackerTest : public testing::Test {
   }
 };
 
+void populateSimpleBoundsTracker(BoundsTracker& bt, PacketType type) {
+  bt.update(123, type, "0");
+  bt.update(123, type, "00");
+  bt.update(123, type, "01");
+  bt.update(123, type, "02");
+}
+
+void populateBoundsTracker(BoundsTracker& bt) {
+  bt.update(123, kImagePacket, "0");
+  bt.update(123, kImagePacket, "00");
+  bt.update(123, kImagePacket, "01");
+  bt.update(123, kImagePacket, "02");
+  bt.update(123, kImagePacket, "023");
+  bt.update(123, kImagePacket, "0231");
+  bt.update(123, kImagePacket, "0232");
+
+  bt.update(24, kVectorPacket, "0");
+  bt.update(24, kVectorPacket, "00");
+  bt.update(24, kVectorPacket, "01");
+  bt.update(24, kVectorPacket, "02");
+  bt.update(24, kVectorPacket, "023");
+  bt.update(24, kVectorPacket, "0231");
+  bt.update(24, kVectorPacket, "0232");
+
+  // Terrain stops at a lower level than vector and imagery.
+  bt.update(1, kTerrainPacket, "0");
+  bt.update(1, kTerrainPacket, "00");
+  bt.update(1, kTerrainPacket, "01");
+  bt.update(1, kTerrainPacket, "02");
+}
+
 TEST_F(BoundsTrackerTest, SimpleImageryBounds) {
   BoundsTracker bt;
-  bt.update("0", kImagePacket, 123);
-  bt.update("00", kImagePacket, 123);
-  bt.update("01", kImagePacket, 123);
-  bt.update("02", kImagePacket, 123);
+  populateSimpleBoundsTracker(bt, kImagePacket);
 
-  EXPECT_TRUE(bt.channels.find(123) != bt.channels.end());
+  const channel_info& channel = bt.channel(123);
+  EXPECT_EQ(channel.channel_id, 123);
+  EXPECT_EQ(channel.type, kImagePacket);
 
-  EXPECT_EQ(bt.channels[123].top, 2);
-  EXPECT_EQ(bt.channels[123].bottom, 3);
-  EXPECT_EQ(bt.channels[123].left, 0);
-  EXPECT_EQ(bt.channels[123].right, 1);
+  EXPECT_EQ(channel.top, 2);
+  EXPECT_EQ(channel.bottom, 3);
+  EXPECT_EQ(channel.left, 0);
+  EXPECT_EQ(channel.right, 1);
 
-  EXPECT_EQ(bt.channels[123].min_level, 1);
-  EXPECT_EQ(bt.channels[123].max_level, 2);
-  EXPECT_EQ(bt.channels[123].channel, 123);
-  EXPECT_EQ(bt.channels[123].type, kImagePacket);
+  EXPECT_EQ(channel.min_level, 1);
+  EXPECT_EQ(channel.max_level, 2);
 }
 
 TEST_F(BoundsTrackerTest, SimpleVectorBounds) {
   BoundsTracker bt;
-  bt.update("0",  kVectorPacket, 123);
-  bt.update("00", kVectorPacket, 123);
-  bt.update("01", kVectorPacket, 123);
-  bt.update("02", kVectorPacket, 123);
+  populateSimpleBoundsTracker(bt, kVectorPacket);
 
-  EXPECT_EQ(bt.channels[123].top, 2);
-  EXPECT_EQ(bt.channels[123].bottom, 3);
-  EXPECT_EQ(bt.channels[123].left, 0);
-  EXPECT_EQ(bt.channels[123].right, 1);
+  const channel_info& channel = bt.channel(123);
+  EXPECT_EQ(channel.channel_id, 123);
+  EXPECT_EQ(channel.type, kVectorPacket);
 
-  EXPECT_EQ(bt.channels[123].min_level, 1);
-  EXPECT_EQ(bt.channels[123].max_level, 2);
-  EXPECT_EQ(bt.channels[123].channel, 123);
-  EXPECT_EQ(bt.channels[123].type, kVectorPacket);
+  EXPECT_EQ(channel.top, 2);
+  EXPECT_EQ(channel.bottom, 3);
+  EXPECT_EQ(channel.left, 0);
+  EXPECT_EQ(channel.right, 1);
+
+  EXPECT_EQ(channel.min_level, 1);
+  EXPECT_EQ(channel.max_level, 2);
 }
 
 TEST_F(BoundsTrackerTest, SimpleTerrainBounds) {
   BoundsTracker bt;
-  bt.update("0",  kTerrainPacket, 123);
-  bt.update("00", kTerrainPacket, 123);
-  bt.update("01", kTerrainPacket, 123);
-  bt.update("02", kTerrainPacket, 123);
+  populateSimpleBoundsTracker(bt, kTerrainPacket);
 
-  EXPECT_EQ(bt.channels[123].top, 2);
-  EXPECT_EQ(bt.channels[123].bottom, 3);
-  EXPECT_EQ(bt.channels[123].left, 0);
-  EXPECT_EQ(bt.channels[123].right, 1);
+  const channel_info& channel = bt.channel(123);
+  EXPECT_EQ(channel.channel_id, 123);
+  EXPECT_EQ(channel.type, kTerrainPacket);
 
-  EXPECT_EQ(bt.channels[123].min_level, 1);
-  EXPECT_EQ(bt.channels[123].max_level, 2);
-  EXPECT_EQ(bt.channels[123].channel, 123);
-  EXPECT_EQ(bt.channels[123].type, kTerrainPacket);
-}
+  EXPECT_EQ(channel.top, 2);
+  EXPECT_EQ(channel.bottom, 3);
+  EXPECT_EQ(channel.left, 0);
+  EXPECT_EQ(channel.right, 1);
 
-void populateBoundsTracker(BoundsTracker& bt) {
-    bt.update("0", kImagePacket, 123);
-    bt.update("00", kImagePacket, 123);
-    bt.update("01", kImagePacket, 123);
-    bt.update("02", kImagePacket, 123);
-    bt.update("023", kImagePacket, 123);
-    bt.update("0231", kImagePacket, 123);
-    bt.update("0232", kImagePacket, 123);
-
-    bt.update("0", kVectorPacket, 24);
-    bt.update("00", kVectorPacket, 24);
-    bt.update("01", kVectorPacket, 24);
-    bt.update("02", kVectorPacket, 24);
-    bt.update("023", kVectorPacket, 24);
-    bt.update("0231", kVectorPacket, 24);
-    bt.update("0232", kVectorPacket, 24);
-
-    // Terrain stops at a lower level than vector and imagery.
-    bt.update("0", kTerrainPacket, 1);
-    bt.update("00", kTerrainPacket, 1);
-    bt.update("01", kTerrainPacket, 1);
-    bt.update("02", kTerrainPacket, 1);
+  EXPECT_EQ(channel.min_level, 1);
+  EXPECT_EQ(channel.max_level, 2);
 }
 
 TEST_F(BoundsTrackerTest, MultipleBounds) {
-    BoundsTracker bt;
-    populateBoundsTracker(bt);
+  BoundsTracker bt;
+  populateBoundsTracker(bt);
 
-    EXPECT_EQ(bt.channels[123].top, 8);
-    EXPECT_EQ(bt.channels[123].bottom, 9);
-    EXPECT_EQ(bt.channels[123].left, 5);
-    EXPECT_EQ(bt.channels[123].right, 5);
+  const channel_info& imagery = bt.channel(123);
+  EXPECT_EQ(imagery.channel_id, 123);
+  EXPECT_EQ(imagery.type, kImagePacket);
 
-    EXPECT_EQ(bt.channels[123].min_level, 1);
-    EXPECT_EQ(bt.channels[123].max_level, 4);
-    EXPECT_EQ(bt.channels[123].channel, 123);
-    EXPECT_EQ(bt.channels[123].type, kImagePacket);
+  EXPECT_EQ(imagery.top, 8);
+  EXPECT_EQ(imagery.bottom, 9);
+  EXPECT_EQ(imagery.left, 5);
+  EXPECT_EQ(imagery.right, 5);
 
+  EXPECT_EQ(imagery.min_level, 1);
+  EXPECT_EQ(imagery.max_level, 4);
 
-    EXPECT_EQ(bt.channels[24].top, 8);
-    EXPECT_EQ(bt.channels[24].bottom, 9);
-    EXPECT_EQ(bt.channels[24].left, 5);
-    EXPECT_EQ(bt.channels[24].right, 5);
+  const channel_info& vector = bt.channel(24);
+  EXPECT_EQ(vector.channel_id, 24);
+  EXPECT_EQ(vector.type, kVectorPacket);
 
-    EXPECT_EQ(bt.channels[24].min_level, 1);
-    EXPECT_EQ(bt.channels[24].max_level, 4);
-    EXPECT_EQ(bt.channels[24].channel, 24);
-    EXPECT_EQ(bt.channels[24].type, kVectorPacket);
+  EXPECT_EQ(vector.top, 8);
+  EXPECT_EQ(vector.bottom, 9);
+  EXPECT_EQ(vector.left, 5);
+  EXPECT_EQ(vector.right, 5);
 
-    EXPECT_EQ(bt.channels[1].top, 2);
-    EXPECT_EQ(bt.channels[1].bottom, 3);
-    EXPECT_EQ(bt.channels[1].left, 0);
-    EXPECT_EQ(bt.channels[1].right, 1);
+  EXPECT_EQ(vector.min_level, 1);
+  EXPECT_EQ(vector.max_level, 4);
 
-    EXPECT_EQ(bt.channels[1].min_level, 1);
-    EXPECT_EQ(bt.channels[1].max_level, 2);
-    EXPECT_EQ(bt.channels[1].channel, 1);
-    EXPECT_EQ(bt.channels[1].type, kTerrainPacket);
+  const channel_info& terrain = bt.channel(1);
+  EXPECT_EQ(terrain.channel_id, 1);
+  EXPECT_EQ(terrain.type, kTerrainPacket);
+
+  EXPECT_EQ(terrain.top, 2);
+  EXPECT_EQ(terrain.bottom, 3);
+  EXPECT_EQ(terrain.left, 0);
+  EXPECT_EQ(terrain.right, 1);
+
+  EXPECT_EQ(terrain.min_level, 1);
+  EXPECT_EQ(terrain.max_level, 2);
 }
 
-  TEST_F(BoundsTrackerTest, TestWriteJson) {
+TEST_F(BoundsTrackerTest, TestWriteJson) {
+  // This is lame, but easier than adding a new JSON parser dependency.
+  const std::string expected_json = "[\n"
+    "  {\n"
+    "    \"channel_id\": 1,\n"
+    "    \"type\": \"Terrain\"\n"
+    "    \"top\": 2,\n"
+    "    \"bottom\": 3,\n"
+    "    \"left\": 0,\n"
+    "    \"right\": 1,\n"
+    "    \"min_image_level\": 1,\n"
+    "    \"max_image_level\": 2,\n"
+    "  },\n"
+    "  {\n"
+    "    \"channel_id\": 24,\n"
+    "    \"type\": \"Vector\"\n"
+    "    \"top\": 8,\n"
+    "    \"bottom\": 9,\n"
+    "    \"left\": 5,\n"
+    "    \"right\": 5,\n"
+    "    \"min_image_level\": 1,\n"
+    "    \"max_image_level\": 4,\n"
+    "  },\n"
+    "  {\n"
+    "    \"channel_id\": 123,\n"
+    "    \"type\": \"Image\"\n"
+    "    \"top\": 8,\n"
+    "    \"bottom\": 9,\n"
+    "    \"left\": 5,\n"
+    "    \"right\": 5,\n"
+    "    \"min_image_level\": 1,\n"
+    "    \"max_image_level\": 4,\n"
+    "  }\n"
+    "]\n";
 
-    // This is kind of hacky, but easier than adding a new JSON parser dependency.
-    const std::string expected_json = "[\n"
-      "  {\n"
-      "    \"layer_id\": 1,\n"
-      "    \"top\": 2,\n"
-      "    \"bottom\": 3,\n"
-      "    \"left\": 0,\n"
-      "    \"right\": 1,\n"
-      "    \"min_image_level\": 1,\n"
-      "    \"max_image_level\": 2,\n"
-      "    \"channel\": 1,\n"
-      "    \"type\": \"Terrain\"\n"
-      "  },\n"
-      "  {\n"
-      "    \"layer_id\": 24,\n"
-      "    \"top\": 8,\n"
-      "    \"bottom\": 9,\n"
-      "    \"left\": 5,\n"
-      "    \"right\": 5,\n"
-      "    \"min_image_level\": 1,\n"
-      "    \"max_image_level\": 4,\n"
-      "    \"channel\": 24,\n"
-      "    \"type\": \"Vector\"\n"
-      "  },\n"
-      "  {\n"
-      "    \"layer_id\": 123,\n"
-      "    \"top\": 8,\n"
-      "    \"bottom\": 9,\n"
-      "    \"left\": 5,\n"
-      "    \"right\": 5,\n"
-      "    \"min_image_level\": 1,\n"
-      "    \"max_image_level\": 4,\n"
-      "    \"channel\": 123,\n"
-      "    \"type\": \"Image\"\n"
-      "  }\n"
-      "]\n";
+  BoundsTracker bt;
+  populateBoundsTracker(bt);
 
-    BoundsTracker bt;
-    populateBoundsTracker(bt);
+  std::string filename = test_directory + "test.json";
 
-    std::string filename = test_directory + "test.json";
-    
-    bt.write_json_file(filename);
-    std::ifstream ins(filename.c_str());
+  bt.write_json_file(filename);
 
-    std::string str{ std::istreambuf_iterator<char>(ins),
-                     std::istreambuf_iterator<char>()};
+  std::ifstream ins(filename.c_str());
+  std::string str{ std::istreambuf_iterator<char>(ins),
+                   std::istreambuf_iterator<char>()};
 
-
-    EXPECT_EQ(str, expected_json);
-  }
+  EXPECT_EQ(str, expected_json);
+}
 
 }  // namespace fusion_portableglobe
 

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
@@ -1,0 +1,203 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit Tests for bounds tracker class
+
+#include <limits.h>
+#include <iostream>  // NOLINT(readability/streams)
+#include <string>
+#include <utility>
+#include <vector>
+#include <gtest/gtest.h>
+#include "common/khFileUtils.h"
+#include "fusion/portableglobe/shared/bounds_tracker.h"
+
+namespace fusion_portableglobe {
+
+// Test class for the BoundsTracker
+class BoundsTrackerTest : public testing::Test {
+ protected:
+  std::string test_directory;
+
+  virtual void SetUp() {
+    test_directory = khTmpDirPath() + "/bounds_tracker_test/";
+    khEnsureParentDir(test_directory);
+  }
+
+  virtual void TearDown() {
+    khPruneDir(test_directory);
+  }
+};
+
+TEST_F(BoundsTrackerTest, SimpleImageryBounds) {
+  BoundsTracker bt;
+  bt.update("0", kImagePacket, 123);
+  bt.update("00", kImagePacket, 123);
+  bt.update("01", kImagePacket, 123);
+  bt.update("02", kImagePacket, 123);
+
+  EXPECT_EQ(bt.top, 2);
+  EXPECT_EQ(bt.bottom, 3);
+  EXPECT_EQ(bt.left, 0);
+  EXPECT_EQ(bt.right, 1);
+
+  EXPECT_EQ(bt.min_image_level, 1);
+  EXPECT_EQ(bt.max_image_level, 2);
+  EXPECT_EQ(bt.image_tile_channel, 123);
+
+  // Expect default values everywhere else
+  EXPECT_EQ(bt.terrain_tile_channel, UINT16_MAX);
+  EXPECT_EQ(bt.vector_tile_channel, UINT16_MAX);
+
+  EXPECT_EQ(bt.min_terrain_level, 32);
+  EXPECT_EQ(bt.max_terrain_level, 0);
+  EXPECT_EQ(bt.min_vector_level, 32);
+  EXPECT_EQ(bt.max_vector_level, 0);
+}
+
+TEST_F(BoundsTrackerTest, SimpleVectorBounds) {
+  BoundsTracker bt;
+  bt.update("0",  kVectorPacket, 123);
+  bt.update("00", kVectorPacket, 123);
+  bt.update("01", kVectorPacket, 123);
+  bt.update("02", kVectorPacket, 123);
+
+  EXPECT_EQ(bt.min_vector_level, 1);
+  EXPECT_EQ(bt.max_vector_level, 2);
+  EXPECT_EQ(bt.vector_tile_channel, 123);
+
+  // Expect default values everywhere else
+  EXPECT_EQ(bt.top, 0);
+  EXPECT_EQ(bt.bottom, UINT32_MAX);
+  EXPECT_EQ(bt.left, UINT32_MAX);
+  EXPECT_EQ(bt.right, 0);
+
+  EXPECT_EQ(bt.image_tile_channel, UINT16_MAX);
+  EXPECT_EQ(bt.terrain_tile_channel, UINT16_MAX);
+
+  EXPECT_EQ(bt.min_image_level, 32);
+  EXPECT_EQ(bt.max_image_level, 0);
+  EXPECT_EQ(bt.min_terrain_level, 32);
+  EXPECT_EQ(bt.max_terrain_level, 0);
+}
+
+TEST_F(BoundsTrackerTest, SimpleTerrainBounds) {
+  BoundsTracker bt;
+  bt.update("0",  kTerrainPacket, 123);
+  bt.update("00", kTerrainPacket, 123);
+  bt.update("01", kTerrainPacket, 123);
+  bt.update("02", kTerrainPacket, 123);
+
+  EXPECT_EQ(bt.min_terrain_level, 1);
+  EXPECT_EQ(bt.max_terrain_level, 2);
+  EXPECT_EQ(bt.terrain_tile_channel, 123);
+
+  // Expect default values everywhere else
+  EXPECT_EQ(bt.top, 0);
+  EXPECT_EQ(bt.bottom, UINT32_MAX);
+  EXPECT_EQ(bt.left, UINT32_MAX);
+  EXPECT_EQ(bt.right, 0);
+
+  EXPECT_EQ(bt.image_tile_channel, UINT16_MAX);
+  EXPECT_EQ(bt.vector_tile_channel, UINT16_MAX);
+
+  EXPECT_EQ(bt.min_image_level, 32);
+  EXPECT_EQ(bt.max_image_level, 0);
+  EXPECT_EQ(bt.min_vector_level, 32);
+  EXPECT_EQ(bt.max_vector_level, 0);
+}
+
+void populateBoundsTracker(BoundsTracker& bt) {
+    bt.update("0", kImagePacket, 123);
+    bt.update("00", kImagePacket, 123);
+    bt.update("01", kImagePacket, 123);
+    bt.update("02", kImagePacket, 123);
+    bt.update("023", kImagePacket, 123);
+    bt.update("0231", kImagePacket, 123);
+    bt.update("0232", kImagePacket, 123);
+
+    bt.update("0", kVectorPacket, 24);
+    bt.update("00", kVectorPacket, 24);
+    bt.update("01", kVectorPacket, 24);
+    bt.update("02", kVectorPacket, 24);
+    bt.update("023", kVectorPacket, 24);
+    bt.update("0231", kVectorPacket, 24);
+    bt.update("0232", kVectorPacket, 24);
+
+    // Terrain stops at a lower level than vector and imagery.
+    bt.update("0", kTerrainPacket, 1);
+    bt.update("00", kTerrainPacket, 1);
+    bt.update("01", kTerrainPacket, 1);
+    bt.update("02", kTerrainPacket, 1);
+}
+
+TEST_F(BoundsTrackerTest, MultipleBounds) {
+    BoundsTracker bt;
+    populateBoundsTracker(bt);
+
+    EXPECT_EQ(bt.top, 8);
+    EXPECT_EQ(bt.bottom, 9);
+    EXPECT_EQ(bt.left, 5);
+    EXPECT_EQ(bt.right, 5);
+
+    EXPECT_EQ(bt.min_image_level, 1);
+    EXPECT_EQ(bt.max_image_level, 4);
+    EXPECT_EQ(bt.min_terrain_level, 1);
+    EXPECT_EQ(bt.max_terrain_level, 2);
+    EXPECT_EQ(bt.min_vector_level, 1);
+    EXPECT_EQ(bt.max_vector_level, 4);
+
+    EXPECT_EQ(bt.image_tile_channel, 123);
+    EXPECT_EQ(bt.terrain_tile_channel, 1);
+    EXPECT_EQ(bt.vector_tile_channel, 24);
+}
+
+TEST_F(BoundsTrackerTest, TestWriteJson) {
+    BoundsTracker bt;
+    populateBoundsTracker(bt);
+
+    std::string filename = test_directory + "test.json";
+    
+    bt.write_json_file(filename);
+
+    std::ifstream ins(filename.c_str());
+    std::string str((std::istreambuf_iterator<char>(ins)),
+                    std::istreambuf_iterator<char>());
+    const std::string expected_json = "[\n"
+      "  {\n"
+      "    \"layer_id\": 0,\n"
+      "    \"top\": 8,\n"
+      "    \"bottom\": 9,\n"
+      "    \"left\": 5,\n"
+      "    \"right\": 5,\n"
+      "    \"min_image_level\": 1,\n"
+      "    \"max_image_level\": 4,\n"
+      "    \"min_terrain_level\": 1,\n"
+      "    \"max_terrain_level\": 2,\n"
+      "    \"min_vector_level\": 1,\n"
+      "    \"max_vector_level\": 4,\n"
+      "    \"image_tile_channel\": 123,\n"
+      "    \"terrain_tile_channel\": 1,\n"
+      "    \"vector_tile_channel\": 24\n"
+      "  }\n"
+      "]\n";
+    EXPECT_EQ(str, expected_json);
+}
+
+}  // namespace fusion_portableglobe
+
+int main(int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
@@ -47,23 +47,17 @@ TEST_F(BoundsTrackerTest, SimpleImageryBounds) {
   bt.update("01", kImagePacket, 123);
   bt.update("02", kImagePacket, 123);
 
-  EXPECT_EQ(bt.top, 2);
-  EXPECT_EQ(bt.bottom, 3);
-  EXPECT_EQ(bt.left, 0);
-  EXPECT_EQ(bt.right, 1);
+  EXPECT_TRUE(bt.channels.find(123) != bt.channels.end());
 
-  EXPECT_EQ(bt.min_image_level, 1);
-  EXPECT_EQ(bt.max_image_level, 2);
-  EXPECT_EQ(bt.image_tile_channel, 123);
+  EXPECT_EQ(bt.channels[123].top, 2);
+  EXPECT_EQ(bt.channels[123].bottom, 3);
+  EXPECT_EQ(bt.channels[123].left, 0);
+  EXPECT_EQ(bt.channels[123].right, 1);
 
-  // Expect default values everywhere else
-  EXPECT_EQ(bt.terrain_tile_channel, UINT16_MAX);
-  EXPECT_EQ(bt.vector_tile_channel, UINT16_MAX);
-
-  EXPECT_EQ(bt.min_terrain_level, 32);
-  EXPECT_EQ(bt.max_terrain_level, 0);
-  EXPECT_EQ(bt.min_vector_level, 32);
-  EXPECT_EQ(bt.max_vector_level, 0);
+  EXPECT_EQ(bt.channels[123].min_level, 1);
+  EXPECT_EQ(bt.channels[123].max_level, 2);
+  EXPECT_EQ(bt.channels[123].channel, 123);
+  EXPECT_EQ(bt.channels[123].type, kImagePacket);
 }
 
 TEST_F(BoundsTrackerTest, SimpleVectorBounds) {
@@ -73,23 +67,15 @@ TEST_F(BoundsTrackerTest, SimpleVectorBounds) {
   bt.update("01", kVectorPacket, 123);
   bt.update("02", kVectorPacket, 123);
 
-  EXPECT_EQ(bt.min_vector_level, 1);
-  EXPECT_EQ(bt.max_vector_level, 2);
-  EXPECT_EQ(bt.vector_tile_channel, 123);
+  EXPECT_EQ(bt.channels[123].top, 2);
+  EXPECT_EQ(bt.channels[123].bottom, 3);
+  EXPECT_EQ(bt.channels[123].left, 0);
+  EXPECT_EQ(bt.channels[123].right, 1);
 
-  // Expect default values everywhere else
-  EXPECT_EQ(bt.top, 0);
-  EXPECT_EQ(bt.bottom, UINT32_MAX);
-  EXPECT_EQ(bt.left, UINT32_MAX);
-  EXPECT_EQ(bt.right, 0);
-
-  EXPECT_EQ(bt.image_tile_channel, UINT16_MAX);
-  EXPECT_EQ(bt.terrain_tile_channel, UINT16_MAX);
-
-  EXPECT_EQ(bt.min_image_level, 32);
-  EXPECT_EQ(bt.max_image_level, 0);
-  EXPECT_EQ(bt.min_terrain_level, 32);
-  EXPECT_EQ(bt.max_terrain_level, 0);
+  EXPECT_EQ(bt.channels[123].min_level, 1);
+  EXPECT_EQ(bt.channels[123].max_level, 2);
+  EXPECT_EQ(bt.channels[123].channel, 123);
+  EXPECT_EQ(bt.channels[123].type, kVectorPacket);
 }
 
 TEST_F(BoundsTrackerTest, SimpleTerrainBounds) {
@@ -99,23 +85,15 @@ TEST_F(BoundsTrackerTest, SimpleTerrainBounds) {
   bt.update("01", kTerrainPacket, 123);
   bt.update("02", kTerrainPacket, 123);
 
-  EXPECT_EQ(bt.min_terrain_level, 1);
-  EXPECT_EQ(bt.max_terrain_level, 2);
-  EXPECT_EQ(bt.terrain_tile_channel, 123);
+  EXPECT_EQ(bt.channels[123].top, 2);
+  EXPECT_EQ(bt.channels[123].bottom, 3);
+  EXPECT_EQ(bt.channels[123].left, 0);
+  EXPECT_EQ(bt.channels[123].right, 1);
 
-  // Expect default values everywhere else
-  EXPECT_EQ(bt.top, 0);
-  EXPECT_EQ(bt.bottom, UINT32_MAX);
-  EXPECT_EQ(bt.left, UINT32_MAX);
-  EXPECT_EQ(bt.right, 0);
-
-  EXPECT_EQ(bt.image_tile_channel, UINT16_MAX);
-  EXPECT_EQ(bt.vector_tile_channel, UINT16_MAX);
-
-  EXPECT_EQ(bt.min_image_level, 32);
-  EXPECT_EQ(bt.max_image_level, 0);
-  EXPECT_EQ(bt.min_vector_level, 32);
-  EXPECT_EQ(bt.max_vector_level, 0);
+  EXPECT_EQ(bt.channels[123].min_level, 1);
+  EXPECT_EQ(bt.channels[123].max_level, 2);
+  EXPECT_EQ(bt.channels[123].channel, 123);
+  EXPECT_EQ(bt.channels[123].type, kTerrainPacket);
 }
 
 void populateBoundsTracker(BoundsTracker& bt) {
@@ -146,54 +124,91 @@ TEST_F(BoundsTrackerTest, MultipleBounds) {
     BoundsTracker bt;
     populateBoundsTracker(bt);
 
-    EXPECT_EQ(bt.top, 8);
-    EXPECT_EQ(bt.bottom, 9);
-    EXPECT_EQ(bt.left, 5);
-    EXPECT_EQ(bt.right, 5);
+    EXPECT_EQ(bt.channels[123].top, 8);
+    EXPECT_EQ(bt.channels[123].bottom, 9);
+    EXPECT_EQ(bt.channels[123].left, 5);
+    EXPECT_EQ(bt.channels[123].right, 5);
 
-    EXPECT_EQ(bt.min_image_level, 1);
-    EXPECT_EQ(bt.max_image_level, 4);
-    EXPECT_EQ(bt.min_terrain_level, 1);
-    EXPECT_EQ(bt.max_terrain_level, 2);
-    EXPECT_EQ(bt.min_vector_level, 1);
-    EXPECT_EQ(bt.max_vector_level, 4);
+    EXPECT_EQ(bt.channels[123].min_level, 1);
+    EXPECT_EQ(bt.channels[123].max_level, 4);
+    EXPECT_EQ(bt.channels[123].channel, 123);
+    EXPECT_EQ(bt.channels[123].type, kImagePacket);
 
-    EXPECT_EQ(bt.image_tile_channel, 123);
-    EXPECT_EQ(bt.terrain_tile_channel, 1);
-    EXPECT_EQ(bt.vector_tile_channel, 24);
+
+    EXPECT_EQ(bt.channels[24].top, 8);
+    EXPECT_EQ(bt.channels[24].bottom, 9);
+    EXPECT_EQ(bt.channels[24].left, 5);
+    EXPECT_EQ(bt.channels[24].right, 5);
+
+    EXPECT_EQ(bt.channels[24].min_level, 1);
+    EXPECT_EQ(bt.channels[24].max_level, 4);
+    EXPECT_EQ(bt.channels[24].channel, 24);
+    EXPECT_EQ(bt.channels[24].type, kVectorPacket);
+
+    EXPECT_EQ(bt.channels[1].top, 2);
+    EXPECT_EQ(bt.channels[1].bottom, 3);
+    EXPECT_EQ(bt.channels[1].left, 0);
+    EXPECT_EQ(bt.channels[1].right, 1);
+
+    EXPECT_EQ(bt.channels[1].min_level, 1);
+    EXPECT_EQ(bt.channels[1].max_level, 2);
+    EXPECT_EQ(bt.channels[1].channel, 1);
+    EXPECT_EQ(bt.channels[1].type, kTerrainPacket);
 }
 
-TEST_F(BoundsTrackerTest, TestWriteJson) {
-    BoundsTracker bt;
-    populateBoundsTracker(bt);
+  TEST_F(BoundsTrackerTest, TestWriteJson) {
 
-    std::string filename = test_directory + "test.json";
-    
-    bt.write_json_file(filename);
-
-    std::ifstream ins(filename.c_str());
-    std::string str((std::istreambuf_iterator<char>(ins)),
-                    std::istreambuf_iterator<char>());
+    // This is kind of hacky, but easier than adding a new JSON parser dependency.
     const std::string expected_json = "[\n"
       "  {\n"
-      "    \"layer_id\": 0,\n"
+      "    \"layer_id\": 1,\n"
+      "    \"top\": 2,\n"
+      "    \"bottom\": 3,\n"
+      "    \"left\": 0,\n"
+      "    \"right\": 1,\n"
+      "    \"min_image_level\": 1,\n"
+      "    \"max_image_level\": 2,\n"
+      "    \"channel\": 1,\n"
+      "    \"type\": \"Terrain\"\n"
+      "  },\n"
+      "  {\n"
+      "    \"layer_id\": 24,\n"
       "    \"top\": 8,\n"
       "    \"bottom\": 9,\n"
       "    \"left\": 5,\n"
       "    \"right\": 5,\n"
       "    \"min_image_level\": 1,\n"
       "    \"max_image_level\": 4,\n"
-      "    \"min_terrain_level\": 1,\n"
-      "    \"max_terrain_level\": 2,\n"
-      "    \"min_vector_level\": 1,\n"
-      "    \"max_vector_level\": 4,\n"
-      "    \"image_tile_channel\": 123,\n"
-      "    \"terrain_tile_channel\": 1,\n"
-      "    \"vector_tile_channel\": 24\n"
+      "    \"channel\": 24,\n"
+      "    \"type\": \"Vector\"\n"
+      "  },\n"
+      "  {\n"
+      "    \"layer_id\": 123,\n"
+      "    \"top\": 8,\n"
+      "    \"bottom\": 9,\n"
+      "    \"left\": 5,\n"
+      "    \"right\": 5,\n"
+      "    \"min_image_level\": 1,\n"
+      "    \"max_image_level\": 4,\n"
+      "    \"channel\": 123,\n"
+      "    \"type\": \"Image\"\n"
       "  }\n"
       "]\n";
+
+    BoundsTracker bt;
+    populateBoundsTracker(bt);
+
+    std::string filename = test_directory + "test.json";
+    
+    bt.write_json_file(filename);
+    std::ifstream ins(filename.c_str());
+
+    std::string str{ std::istreambuf_iterator<char>(ins),
+                     std::istreambuf_iterator<char>()};
+
+
     EXPECT_EQ(str, expected_json);
-}
+  }
 
 }  // namespace fusion_portableglobe
 

--- a/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/shared/bounds_tracker_unittest.cpp
@@ -168,33 +168,33 @@ TEST_F(BoundsTrackerTest, TestWriteJson) {
   const std::string expected_json = "[\n"
     "  {\n"
     "    \"channel_id\": 1,\n"
-    "    \"type\": \"Terrain\"\n"
+    "    \"type\": \"Terrain\",\n"
     "    \"top\": 2,\n"
     "    \"bottom\": 3,\n"
     "    \"left\": 0,\n"
     "    \"right\": 1,\n"
-    "    \"min_image_level\": 1,\n"
-    "    \"max_image_level\": 2,\n"
+    "    \"min_level\": 1,\n"
+    "    \"max_level\": 2\n"
     "  },\n"
     "  {\n"
     "    \"channel_id\": 24,\n"
-    "    \"type\": \"Vector\"\n"
+    "    \"type\": \"Vector\",\n"
     "    \"top\": 8,\n"
     "    \"bottom\": 9,\n"
     "    \"left\": 5,\n"
     "    \"right\": 5,\n"
-    "    \"min_image_level\": 1,\n"
-    "    \"max_image_level\": 4,\n"
+    "    \"min_level\": 1,\n"
+    "    \"max_level\": 4\n"
     "  },\n"
     "  {\n"
     "    \"channel_id\": 123,\n"
-    "    \"type\": \"Image\"\n"
+    "    \"type\": \"Image\",\n"
     "    \"top\": 8,\n"
     "    \"bottom\": 9,\n"
     "    \"left\": 5,\n"
     "    \"right\": 5,\n"
-    "    \"min_image_level\": 1,\n"
-    "    \"max_image_level\": 4,\n"
+    "    \"min_level\": 1,\n"
+    "    \"max_level\": 4\n"
     "  }\n"
     "]\n";
 
@@ -208,7 +208,7 @@ TEST_F(BoundsTrackerTest, TestWriteJson) {
   std::ifstream ins(filename.c_str());
   std::string str{ std::istreambuf_iterator<char>(ins),
                    std::istreambuf_iterator<char>()};
-
+  bt.write_json_file("/home/jlarocco/testing.json");
   EXPECT_EQ(str, expected_json);
 }
 


### PR DESCRIPTION
These changes add a new earth/metadata.json file embedded into *.glb and *.glm files. It address #1302.  

The contents of metadata.json describe the min and max zoom level, map boundaries in tile coordinates, and the channel ID and type for each channel of the file.

The purpose of the new file is to speed up import and display of portable files in applications that need boundary and zoom level information before displaying the map or globe.