### PR TITLE
Issue #1339: Handle DelayedBuildChildren error variant

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -323,8 +323,8 @@ ${name}Factory::ReuseOrMakeAndUpdate(
                 for (std::vector<std::string>::const_iterator iv =
                      version->inputs.begin();
                      iv != version->inputs.end(); ++iv) {
-                     notify(NFY_NOTICE, "             %s", iv->c_str());
-                  }
+                    notify(NFY_NOTICE, "             %s", iv->c_str());
+                }
 #endif
                 // Tell the storage manager that we're going to use this
                 // version again.

--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -337,8 +337,8 @@ ${name}Factory::ReuseOrMakeAndUpdate(
               }
            }
            catch (...) {
-             notify(NFY_WARN, "${name}: ReuseOrMakeAndUpdate could not reuse
-                   a version." )
+             notify(NFY_WARN,
+                    "${name}: ReuseOrMakeAndUpdate could not reuse a version." );
            }
         }
         asset->Modify($forwardinputarg meta_, config_);

--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -302,38 +302,44 @@ ${name}Factory::ReuseOrMakeAndUpdate(
 	for (AssetStorage::VersionList::const_iterator v
                 = asset->versions.begin();
              v != asset->versions.end(); ++v) {
-            ${name}AssetVersionD version(*v);
-            // Load an asset version without caching since we may not need it
-            // (offline, obsolete and so on).
-            version.LoadAsTemporary();
-            if ((version->state != AssetDefs::Offline) &&
-                (version->inputs == boundInputs) &&
-                ::IsUpToDate(config_, version->config)) {
+            try {
+              ${name}AssetVersionD version(*v);
+              // Load an asset version without caching since we may not need it
+              // (offline, obsolete and so on).
+              version.LoadAsTemporary();
+              if ((version->state != AssetDefs::Offline) &&
+                  (version->inputs == boundInputs) &&
+                  ::IsUpToDate(config_, version->config)) {
 
 #if 0
-                notify(NFY_NOTICE,
-                       "${name}: ReuseOrMakeAndUpdate (reusing %s)",
-                       version->GetRef().c_str());
-                notify(NFY_NOTICE, "         boundinputs:");
-                for (const auto & bi : boundInputs) {
-                    notify(NFY_NOTICE, "             %s", bi.c_str());
-                }
-                notify(NFY_NOTICE, "         version inputs:");
-                for (std::vector<std::string>::const_iterator iv =
-                     version->inputs.begin();
-                     iv != version->inputs.end(); ++iv) {
-                    notify(NFY_NOTICE, "             %s", iv->c_str());
-                }
+                  notify(NFY_NOTICE,
+                         "${name}: ReuseOrMakeAndUpdate (reusing %s)",
+                         version->GetRef().c_str());
+                  notify(NFY_NOTICE, "         boundinputs:");
+                  for (const auto & bi : boundInputs) {
+                      notify(NFY_NOTICE, "             %s", bi.c_str());
+                  }
+                  notify(NFY_NOTICE, "         version inputs:");
+                  for (std::vector<std::string>::const_iterator iv =
+                       version->inputs.begin();
+                       iv != version->inputs.end(); ++iv) {
+                      notify(NFY_NOTICE, "             %s", iv->c_str());
+                  }
 #endif
                 // Tell the storage manager that we're going to use this
                 // version again.
                 version.MakePermanent();
 
                 return version;
-            } else {
+             } else {
               // Tell the storage manager we don't need this one any more.
-              version.NoLongerNeeded();
-            }
+                version.NoLongerNeeded();
+             }
+          }
+          catch (...) {
+            notify(NFY_WARN, "${name}: ReuseOrMakeAndUpdate could not reuse
+                   a version." )
+          }
         }
         asset->Modify($forwardinputarg meta_, config_);
     } else {

--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -331,15 +331,15 @@ ${name}Factory::ReuseOrMakeAndUpdate(
                 version.MakePermanent();
 
                 return version;
-             } else {
-              // Tell the storage manager we don't need this one any more.
+              } else {
+                // Tell the storage manager we don't need this one any more.
                 version.NoLongerNeeded();
-             }
-          }
-          catch (...) {
-            notify(NFY_WARN, "${name}: ReuseOrMakeAndUpdate could not reuse
+              }
+           }
+           catch (...) {
+             notify(NFY_WARN, "${name}: ReuseOrMakeAndUpdate could not reuse
                    a version." )
-          }
+           }
         }
         asset->Modify($forwardinputarg meta_, config_);
     } else {

--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -312,18 +312,18 @@ ${name}Factory::ReuseOrMakeAndUpdate(
                   ::IsUpToDate(config_, version->config)) {
 
 #if 0
-                  notify(NFY_NOTICE,
-                         "${name}: ReuseOrMakeAndUpdate (reusing %s)",
-                         version->GetRef().c_str());
-                  notify(NFY_NOTICE, "         boundinputs:");
-                  for (const auto & bi : boundInputs) {
-                      notify(NFY_NOTICE, "             %s", bi.c_str());
-                  }
-                  notify(NFY_NOTICE, "         version inputs:");
-                  for (std::vector<std::string>::const_iterator iv =
-                       version->inputs.begin();
-                       iv != version->inputs.end(); ++iv) {
-                      notify(NFY_NOTICE, "             %s", iv->c_str());
+                notify(NFY_NOTICE,
+                       "${name}: ReuseOrMakeAndUpdate (reusing %s)",
+                       version->GetRef().c_str());
+                notify(NFY_NOTICE, "         boundinputs:");
+                for (const auto & bi : boundInputs) {
+                    notify(NFY_NOTICE, "             %s", bi.c_str());
+                }
+                notify(NFY_NOTICE, "         version inputs:");
+                for (std::vector<std::string>::const_iterator iv =
+                     version->inputs.begin();
+                     iv != version->inputs.end(); ++iv) {
+                     notify(NFY_NOTICE, "             %s", iv->c_str());
                   }
 #endif
                 // Tell the storage manager that we're going to use this


### PR DESCRIPTION
Add error handling to alleviate a version of the DelayedBuildChildren error.

To test:

1. Build and install OpenGEE (can reliably reproduced on Ubuntu16).
2. Run the historical and tutorial scripts.
3. Verify that the databases are correct, and that `/opt/google/log/gesystemmanager.log` shows that the error was caught for the SFinset_2-5 databases (it should be caught many times).
4. Run the gauge tests (it may be wise to reinstall and clear out the tutorial databases before this step).