### PR TITLE
Issue #1342: missed shared string

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -60,7 +60,7 @@ class StorageManager
     bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<std::string> *);
     HandleType Get(const AssetHandleInterface<AssetType> *, bool, bool, bool);
   private:
-    using CacheType = khCache<std::string, HandleType>;
+    using CacheType = khCache<AssetKey, HandleType>;
 
     static const bool check_timestamps;
 

--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -57,7 +57,7 @@ class StorageManager
     inline void AddExisting(const AssetKey &, const HandleType &);
     inline void NoLongerNeeded(const AssetKey &, bool = true);
     void Abort();
-    bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<std::string> *);
+    bool SaveDirtyToDotNew(khFilesTransaction &, std::vector<SharedString> *);
     HandleType Get(const AssetHandleInterface<AssetType> *, bool, bool, bool);
   private:
     using CacheType = khCache<AssetKey, HandleType>;
@@ -177,7 +177,7 @@ void StorageManager<AssetType>::Abort() {
 template<class AssetType>
 bool StorageManager<AssetType>::SaveDirtyToDotNew(
     khFilesTransaction &savetrans,
-    std::vector<std::string> *saved) {
+    std::vector<SharedString> *saved) {
   notify(NFY_INFO, "Writing %lu %s records", dirtyMap.size(), assetType.c_str());
   typename std::map<AssetKey, HandleType>::iterator entry = dirtyMap.begin();
   while (entry != dirtyMap.end()) {

--- a/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
@@ -257,7 +257,8 @@ TEST_F(StorageManagerTest, SaveDirty) {
   getAssetsForDirtyTest(storageManager, handles);
   
   khFilesTransaction trans;
-  storageManager.SaveDirtyToDotNew(trans, nullptr);
+  bool result = storageManager.SaveDirtyToDotNew(trans, nullptr);
+  ASSERT_TRUE(result) << "SaveDirtyToDotNew should return true when there are no issues";
   ASSERT_EQ(storageManager.CacheSize(), 5) << "Unexpected number of items in cache";
   ASSERT_EQ(storageManager.DirtySize(), 0) << "Storage manager has wrong number of items in dirty map";
   ASSERT_EQ(trans.NumNew(), 2) << "Wrong number of new items in file transaction";
@@ -285,7 +286,8 @@ TEST_F(StorageManagerTest, FailedSave) {
   TestHandle item = Get<TestHandle>(storageManager, "item", false, true, true);
   item.handle->saveSucceeds = false;
   khFilesTransaction trans;
-  storageManager.SaveDirtyToDotNew(trans, nullptr);
+  bool result = storageManager.SaveDirtyToDotNew(trans, nullptr);
+  ASSERT_FALSE(result) << "SaveDirtyToDotNew should return false when a save fails";
   ASSERT_EQ(storageManager.CacheSize(), 1) << "Unexpected number of items in cache";
   ASSERT_EQ(storageManager.DirtySize(), 1) << "Storage manager has wrong number of items in dirty map";
   ASSERT_EQ(trans.NumNew(), 0) << "Transaction should be empty after failed save";

--- a/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager_unittest.cpp
@@ -274,7 +274,7 @@ TEST_F(StorageManagerTest, SaveDirtyToVector) {
   getAssetsForDirtyTest(storageManager, handles);
   
   khFilesTransaction trans;
-  vector<string> saved;
+  vector<SharedString> saved;
   storageManager.SaveDirtyToDotNew(trans, &saved);
   ASSERT_EQ(saved.size(), 2) << "Wrong number of items in saved vector";
   ASSERT_TRUE(find(saved.begin(), saved.end(), "mutable2") != saved.end()) << "Dirty item missing from saved vector";

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetHandleD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetHandleD.h
@@ -153,7 +153,7 @@ class MutableAssetHandleD_ : public virtual Base_ {
   }
 
   static bool SaveDirtyToDotNew(khFilesTransaction &savetrans,
-                                std::vector<std::string> *saveDirty) {
+                                std::vector<SharedString> *saveDirty) {
     return Base::storageManager().SaveDirtyToDotNew(savetrans, saveDirty);
   }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
@@ -101,7 +101,7 @@ khAssetManager::ApplyPending(void)
   // The actual list saved may be smaller than what's
   // in the dirty set. Some things can be in the dirty set
   // even if it really didn't change
-  std::vector<std::string> savedAssets;
+  std::vector<SharedString> savedAssets;
 
 
   QTime timer;
@@ -149,9 +149,8 @@ khAssetManager::ApplyPending(void)
 
   // build a list of AssetChanges
   AssetChanges changes;
-  for (std::vector<std::string>::const_iterator i = savedAssets.begin();
-       i != savedAssets.end(); ++i) {
-    changes.items.push_back(AssetChanges::Item(*i, "Modified"));
+  for (const auto & ref : savedAssets) {
+    changes.items.push_back(AssetChanges::Item(ref, "Modified"));
   }
   for (std::map<SharedString, AssetDefs::State>::const_iterator i
          = pendingStateChanges.begin();


### PR DESCRIPTION
Fixes #1342 by using shared strings as keys in the asset and asset version caches.