### PR TITLE
1344 Add single layer glc packet walker

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
@@ -319,6 +319,20 @@ void GlcUnpacker::MapDataPacketWalker(const map_packet_walker& walker) const
   }
 }
 
+void GlcUnpacker::MapDataPacketWalker(int layer, const map_packet_walker& walker) const
+{
+  if (!is_gee_) {
+    std::cerr << "Not a GEE file." << std::endl;
+    return;
+  }
+  auto iter = unpacker_index_.find(layer);
+  if (iter == unpacker_index_.end()) {
+    std::cerr << "Layer " << layer << " not found." << std::endl;
+    return;
+  }
+  iter.second->MapDataPacketWalker(layer, walker);
+}
+
 /**
  * Find qtp packet and set offset and size for the packet. Qtp packets can
  * be quadtree packets or a dbroot packet.

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.cpp
@@ -330,7 +330,7 @@ void GlcUnpacker::MapDataPacketWalker(int layer, const map_packet_walker& walker
     std::cerr << "Layer " << layer << " not found." << std::endl;
     return;
   }
-  iter.second->MapDataPacketWalker(layer, walker);
+  iter->second->MapDataPacketWalker(layer, walker);
 }
 
 /**

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/glc_unpacker.h
@@ -76,7 +76,22 @@ class GlcUnpacker {
                          int layer,
                          PackageFileLoc* data_loc);
 
+  /**
+   * Call walker function on all map data packets in all layers of the file.
+   * @param walker   A function specifier taking an int layer ID and a const
+   *                 IndexItem& parameter to process.  If walker returns true after
+   *                 handling a packet, the traversal will stop.
+   */
   void MapDataPacketWalker(const map_packet_walker& walker) const;
+
+  /**
+   * Call walker function on all map data packets in the specified layer of the file.
+   * @param layer    The layer to walk
+   * @param walker   A function specifier taking an int layer ID and a const
+   *                 IndexItem& parameter to process.  If walker returns true after
+   *                 handling a packet, the traversal will stop.
+   */
+  void MapDataPacketWalker(int layer, const map_packet_walker& walker) const;
 
   /**
    * Find qtp packet and set offset and size for the packet. Qtp packets can


### PR DESCRIPTION
Fixes issue #1344.  These changes add a version of GlcUnpacker::MapDataPacketWalker that walks a single layer, complementing the existing MapDataPacketWalker that walks packets in all layers.