### PR TITLE
Change the request to quit the portable server into a POST

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/local/quit.html
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/quit.html
@@ -50,7 +50,7 @@
 <script type="text/javascript">
 
 function Quit() {
-  jQuery.get("?cmd=quit");
+  jQuery.post("?cmd=quit");
 }
 
 // Wait to give page a chance to get all of its images.

--- a/earth_enterprise/src/fusion/portableglobe/servers/portable_web_interface.py
+++ b/earth_enterprise/src/fusion/portableglobe/servers/portable_web_interface.py
@@ -375,9 +375,7 @@ now serving</div>
         self.write("Setup from localhost only.")
         return
 
-      if cmd == "quit":
-        tornado.ioloop.IOLoop.instance().stop()
-      elif cmd == "pre-quit":
+      if cmd == "pre-quit":
         self.set_header("Content-Type", "text/html")
         self.WriteLocalFile("quit.html")
       elif cmd == "share":
@@ -453,7 +451,9 @@ now serving</div>
     cmd = self.request.arguments["cmd"][0]
     self.set_header("Content-Type", "text/html")
     print "cmd (post) : \"%s\"" % cmd
-    if cmd == "local_only":
+    if cmd == "quit":
+      tornado.ioloop.IOLoop.instance().stop()
+    elif cmd == "local_only":
       if self.verifyConfirmationId(self.request.arguments):
         tornado.web.globe_.config_.accept_all_requests_ = False
     elif cmd == "accept_all_requests":


### PR DESCRIPTION
Fixes google#1281

IE appears to perform aggressive caching, which was preventing the `GET` request to `cmd=quit` from making it to the server.

Changing the command to be a `POST` request prevents this; given that `cmd=quit` has side effects, it seems like it should be a `POST` anyhow.
