### PR TITLE
Update z-index of error modal

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/style.css
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/css/style.css
@@ -49,7 +49,7 @@ background-color: #fff;
   color: #333;
   top: 25%;
   left: 35%;
-  z-index: 250;
+  z-index: 300;
   position: absolute;
   display: none;
   height: auto;


### PR DESCRIPTION
As outlined in #393, the "Invalid KML" pop up would appear behind the "Paste KML" dialog box. This change just updates the z-index of the "Invalid  KML" dialog box to a higher value than the "Paste KML" z-index. This should not interfere with any other elements.

Tested on the CentOS developer virtual machine.

Fixes #393