### PR TITLE
Clean and Validate KML Pasted in Cutter

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -31,6 +31,7 @@ import shutil
 import sys
 import time
 import urllib
+from lxml import etree
 
 from common import form_wrap
 from common import postgres_manager_wrap
@@ -195,7 +196,9 @@ class GlobeBuilder(object):
     """Save polygon kml to a file."""
     with open(self.polygon_file, "w") as fp:
       if polygon:
-        fp.write(polygon)
+        # Check XML validity and standardize representation
+        xml = etree.ElementTree(etree.fromstring(polygon))
+        xml.write(fp, xml_declaration=True, encoding='UTF-8')
         self.Status("Saved polygon to %s" % self.polygon_file)
       else:
         self.Status("Created empty polygon file %s" % self.polygon_file)
@@ -309,7 +312,7 @@ class GlobeBuilder(object):
               "--map_directory=\"%s\"  --default_level=%d --max_level=%d "
               "--metadata_file=\"%s\" "
               % (COMMAND_DIR, ignore_imagery_depth_str, source,
-                 self.qtnodes_file, self.globe_dir, default_level, 
+                 self.qtnodes_file, self.globe_dir, default_level,
                  max_level, self.metadata_file))
 
     common.utils.ExecuteCmdInBackground(os_cmd, self.logger)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/drawing_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/drawing_tools.js
@@ -449,7 +449,7 @@ function finishKML() {
   loadMapPolygon(myKML);
   cutterMode('complete');
   gees.dom.setClass('CutButtonBlue', 'button blue');
-  var kmlFromForm = gees.dom.get('kml_field').value;
+  gees.dom.get('kml_field').value = kmlEdit;
   gees.tools.setElementDisplay(DISPLAY_ELEMENTS_KML, 'none');
  }
 }


### PR DESCRIPTION
KML pasted into Cutter to define a region is checked in Javascript. That XML is then implicitly trusted when the process to build a globe is started. This PR adds a server-side validity check and saves the XML in a standardized form.