### PR TITLE
Fix 1211: Copy download_tutorial.sh instead of link

### DIFF
--- a/earth_enterprise/tutorial/SConstruct
+++ b/earth_enterprise/tutorial/SConstruct
@@ -92,6 +92,5 @@ if env.GetOption('clean'):
     # clean the search and getomcat install folders.
     commands.getstatusoutput("rm -rf " + tutorials_dir)
 else:
-    # makeSoftLinks(root_dir, tutorial_src_dir, ['.svn'])
     copyFiles(root_dir, tutorial_src_dir, ['.svn'])
 

--- a/earth_enterprise/tutorial/SConstruct
+++ b/earth_enterprise/tutorial/SConstruct
@@ -62,10 +62,36 @@ def makeSoftLinks(dest_dir, src_dir, excluded_list):
             commands.getstatusoutput('ln -s "' + src_filepath + '" "' +
                                     dest_filepath + '"')
 
+def copyFiles(dest_dir, src_dir, excluded_list):
+    """Make copies of all files in src_dir and place
+    them in dest_dir. Don't copy files in excluded_list.
+    Recurse through all subdirectories of src_dir.
+    """
+    # Strip trailing slashes because they cause trouble later
+    dest_dir = dest_dir.rstrip(os.sep)
+    src_dir = src_dir.rstrip(os.sep)
+    src_contents = os.listdir(src_dir)
+    # Ensure the destination directory exists at each step
+    commands.getstatusoutput("mkdir -p " + dest_dir)
+    for file in src_contents:
+        if file in excluded_list:
+            continue
+        # Use full paths to all files so `ln -s ... ` succeeds
+        dest_filepath = os.path.join(dest_dir, file)
+        src_filepath = os.path.join(src_dir, file)
+        if os.path.isdir(src_filepath):
+            # Recurse for next-lower directory
+            makeSoftLinks(dest_filepath, src_filepath, excluded_list)
+        else:
+            commands.getstatusoutput('cp "' + src_filepath + '" "' +
+                                    dest_filepath + '"')
+
 # Clean install dir (note: the current sconscripts leave stuff behind, like
 # directories).
 if env.GetOption('clean'):
     # clean the search and getomcat install folders.
     commands.getstatusoutput("rm -rf " + tutorials_dir)
 else:
-    makeSoftLinks(root_dir, tutorial_src_dir, ['.svn'])
+    # makeSoftLinks(root_dir, tutorial_src_dir, ['.svn'])
+    copyFiles(root_dir, tutorial_src_dir, ['.svn'])
+

--- a/earth_enterprise/tutorial/SConstruct
+++ b/earth_enterprise/tutorial/SConstruct
@@ -49,7 +49,7 @@ def copyFiles(dest_dir, src_dir):
     # Ensure the destination directory exists at each step
     commands.getstatusoutput("mkdir -p " + dest_dir)
     commands.getstatusoutput("cp -R " + source_dir + os.sep 
-                             + "*" + " " + dest_dir
+                             + "*" + " " + dest_dir)
 
 # Clean install dir (note: the current sconscripts leave stuff behind, like
 # directories).

--- a/earth_enterprise/tutorial/SConstruct
+++ b/earth_enterprise/tutorial/SConstruct
@@ -48,7 +48,7 @@ def copyFiles(dest_dir, src_dir):
     src_dir = src_dir.rstrip(os.sep)
     # Ensure the destination directory exists at each step
     commands.getstatusoutput("mkdir -p " + dest_dir)
-    commands.getstatusoutput("cp -R " + source_dir + os.sep 
+    commands.getstatusoutput("cp -R " + src_dir + os.sep 
                              + "*" + " " + dest_dir)
 
 # Clean install dir (note: the current sconscripts leave stuff behind, like

--- a/earth_enterprise/tutorial/SConstruct
+++ b/earth_enterprise/tutorial/SConstruct
@@ -38,53 +38,18 @@ root_dir = tutorials_dir + '/opt/google/share/tutorials/fusion/'
 #   it's using, and FusionTutorial is expected below the SConscript file.
 tutorial_src_dir = os.path.join(os.getcwd(), 'FusionTutorial')
 
-def makeSoftLinks(dest_dir, src_dir, excluded_list):
-    """Make soft links of all files in src_dir and place
-    them in dest_dir. Don't link to files in excluded_list.
-    Recurse through all subdirectories of src_dir.
-    """
-    # Strip trailing slashes because they cause trouble later
-    dest_dir = dest_dir.rstrip(os.sep)
-    src_dir = src_dir.rstrip(os.sep)
-    src_contents = os.listdir(src_dir)
-    # Ensure the destination directory exists at each step
-    commands.getstatusoutput("mkdir -p " + dest_dir)
-    for file in src_contents:
-        if file in excluded_list:
-            continue
-        # Use full paths to all files so `ln -s ... ` succeeds
-        dest_filepath = os.path.join(dest_dir, file)
-        src_filepath = os.path.join(src_dir, file)
-        if os.path.isdir(src_filepath):
-            # Recurse for next-lower directory
-            makeSoftLinks(dest_filepath, src_filepath, excluded_list)
-        else:
-            commands.getstatusoutput('ln -s "' + src_filepath + '" "' +
-                                    dest_filepath + '"')
-
-def copyFiles(dest_dir, src_dir, excluded_list):
+def copyFiles(dest_dir, src_dir):
     """Make copies of all files in src_dir and place
-    them in dest_dir. Don't copy files in excluded_list.
-    Recurse through all subdirectories of src_dir.
+    them in dest_dir. Recurse through all subdirectories 
+    of src_dir.
     """
     # Strip trailing slashes because they cause trouble later
     dest_dir = dest_dir.rstrip(os.sep)
     src_dir = src_dir.rstrip(os.sep)
-    src_contents = os.listdir(src_dir)
     # Ensure the destination directory exists at each step
     commands.getstatusoutput("mkdir -p " + dest_dir)
-    for file in src_contents:
-        if file in excluded_list:
-            continue
-        # Use full paths to all files so `ln -s ... ` succeeds
-        dest_filepath = os.path.join(dest_dir, file)
-        src_filepath = os.path.join(src_dir, file)
-        if os.path.isdir(src_filepath):
-            # Recurse for next-lower directory
-            makeSoftLinks(dest_filepath, src_filepath, excluded_list)
-        else:
-            commands.getstatusoutput('cp "' + src_filepath + '" "' +
-                                    dest_filepath + '"')
+    commands.getstatusoutput("cp -R " + source_dir + os.sep 
+                             + "*" + " " + dest_dir
 
 # Clean install dir (note: the current sconscripts leave stuff behind, like
 # directories).
@@ -92,5 +57,5 @@ if env.GetOption('clean'):
     # clean the search and getomcat install folders.
     commands.getstatusoutput("rm -rf " + tutorials_dir)
 else:
-    copyFiles(root_dir, tutorial_src_dir, ['.svn'])
+    copyFiles(root_dir, tutorial_src_dir)
 


### PR DESCRIPTION
Adjusts scons build scripts to copy the `download_tutorial.sh` script instead of linking it. Thus when it is installed it is an actual file.

To test:

1. Build OpenGEE, including the RPMs.
2. Install using the installation scripts.
3. Verify that `download_tutorial.sh` is a file, not a link.
4. Uninstall OpenGEE.
5. Install using the RPMs.
6. Verify that `download_tutorial.sh` is a file, not a link.
