### PR TITLE
Don't load unnecessary assets during Resume

### DIFF
--- a/earth_enterprise/src/common/SharedString.h
+++ b/earth_enterprise/src/common/SharedString.h
@@ -71,7 +71,6 @@ protected:
     };
 
     static StringStorage strStore;
-    std::string val;
     uint32_t key;
 
     friend std::ostream & operator<<(std::ostream &out, const SharedString & ref);
@@ -83,17 +82,14 @@ protected:
     SharedString(): key(0) {}
 
     SharedString(const SharedString& str): key(str.key) {
-      val = strStore.RefFromKey(key);
     }
 
     SharedString(const std::string& str) {
         key = strStore.KeyFromRef(str);
-        val = strStore.RefFromKey(key);
     } 
 
     SharedString(const char* s) {
         key = strStore.KeyFromRef(s);
-        val = strStore.RefFromKey(key);
     }
 
     bool empty() const {
@@ -102,7 +98,6 @@ protected:
 
     SharedString & operator=(const std::string &str) {
         key = strStore.KeyFromRef(str);
-        val = strStore.RefFromKey(key);
         return *this;
     }
 

--- a/earth_enterprise/src/common/SharedString.h
+++ b/earth_enterprise/src/common/SharedString.h
@@ -71,6 +71,7 @@ protected:
     };
 
     static StringStorage strStore;
+    std::string val;
     uint32_t key;
 
     friend std::ostream & operator<<(std::ostream &out, const SharedString & ref);
@@ -82,14 +83,17 @@ protected:
     SharedString(): key(0) {}
 
     SharedString(const SharedString& str): key(str.key) {
+      val = strStore.RefFromKey(key);
     }
 
     SharedString(const std::string& str) {
         key = strStore.KeyFromRef(str);
+        val = strStore.RefFromKey(key);
     } 
 
     SharedString(const char* s) {
         key = strStore.KeyFromRef(s);
+        val = strStore.RefFromKey(key);
     }
 
     bool empty() const {
@@ -98,6 +102,7 @@ protected:
 
     SharedString & operator=(const std::string &str) {
         key = strStore.KeyFromRef(str);
+        val = strStore.RefFromKey(key);
         return *this;
     }
 

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -161,10 +161,6 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
   virtual void SetMyStateOnly(AssetDefs::State newstate, bool sendNotifications = true) {
     assert(false);  // Can only call from sub-classes
   }
-  virtual bool NeedComputeState() const {
-    assert(false);  // Can only call from sub-classes
-    return false;
-  }
 
   // static helpers
   static std::string WorkingDir(const AssetVersionRef &ref);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
@@ -44,7 +44,6 @@ void RebuildVersion(const SharedString & ref) {
 
     StateUpdater updater;
     updater.SetStateForRefAndDependents(ref, AssetDefs::New, AssetDefs::CanRebuild);
-    updater.RecalculateAndSaveStates();
   }
   else {
     MutableAssetVersionD version(ref);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -275,12 +275,27 @@ void AssetVersionImplD::SetState(
     const std::shared_ptr<StateChangeNotifier> notifier)
 {
   if (newstate != state) {
-    SetMyStateOnly(newstate, propagate);
+    AssetDefs::State oldstate = state;
+    state = newstate;
+    try {
+      // NOTE: This can end up calling back here to switch us to
+      // another state (usually Failed or Succeded)
+      OnStateChange(newstate, oldstate);
+    } catch (const std::exception &e) {
+      notify(NFY_WARN, "Exception during OnStateChange: %s", 
+             e.what());
+    } catch (...) {
+      notify(NFY_WARN, "Unknown exception during OnStateChange");
+    }
 
     // only propagate changes if the state is still what we
     // set it to above. OnStateChange can call SetState recursively. We
     // don't want to propagate an old state.
     if (propagate && (state == newstate)) {
+      notify(NFY_VERBOSE, "Calling theAssetManager.NotifyVersionStateChange(%s, %s)", 
+             GetRef().toString().c_str(), 
+             ToString(newstate).c_str());
+      theAssetManager.NotifyVersionStateChange(GetRef(), newstate);
       PropagateStateChange(notifier);
     }
   }
@@ -299,21 +314,21 @@ void AssetVersionImplD::SetMyStateOnly(AssetDefs::State newstate, bool sendNotif
          GetRef().toString().c_str());
   AssetDefs::State oldstate = state;
   state = newstate;
-  try {
-    // NOTE: This can end up calling back here to switch us to
-    // another state (usually Failed or Succeded)
-    OnStateChange(newstate, oldstate);
-  } catch (const std::exception &e) {
-    notify(NFY_WARN, "Exception during OnStateChange: %s", 
-           e.what());
-  } catch (...) {
-    notify(NFY_WARN, "Unknown exception during OnStateChange");
-  }
 
-  // only notify and propagate changes if the state is still what we
+  // only run callbacks and notify if the state is still what we
   // set it to above. OnStateChange can call SetState recursively. We
   // don't want to notify an old state.
   if (sendNotifications && (state == newstate)) {
+    try {
+      // NOTE: This can end up calling back here to switch us to
+      // another state (usually Failed or Succeded)
+      OnStateChange(newstate, oldstate);
+    } catch (const std::exception &e) {
+      notify(NFY_WARN, "Exception during OnStateChange: %s", 
+             e.what());
+    } catch (...) {
+      notify(NFY_WARN, "Unknown exception during OnStateChange");
+    }
     notify(NFY_VERBOSE, "Calling theAssetManager.NotifyVersionStateChange(%s, %s)", 
            GetRef().toString().c_str(), 
            ToString(newstate).c_str());

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -102,7 +102,7 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   virtual bool OfflineInputsBreakMe(void) const { return false; }
  public:
 
-  virtual bool NeedComputeState(void) const {
+  bool NeedComputeState(void) const {
     if (state & (AssetDefs::Bad |
                  AssetDefs::Offline |
                  AssetDefs::Canceled)) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -207,6 +207,7 @@ void StateUpdater::SetStateForRefAndDependents(
   SharedString verref = AssetVersionImpl::Key(ref);
   auto refVertex = BuildDependentTreeForStateCalculation(verref);
   SetStateForVertexAndDependents(refVertex, newState, updateStatePredicate);
+  RecalculateAndSaveStates();
 }
 
 // Sets the state for the specified ref and recursively sets the state for

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "StateUpdater.h"
+#include "AssetVersion.h"
 #include "common/notify.h"
 
 using namespace boost;
@@ -147,13 +148,6 @@ void StateUpdater::FillInVertex(
     return;
   }
   tree[myVertex].state = version->state;
-  // The ref passed in may be slightly different than the ref used in the storage
-  // manager, so fix that here.
-  if (name != version->GetRef()) {
-    name = version->GetRef();
-    tree[myVertex].name = name;
-    buildData.vertices[name] = myVertex;
-  }
   AddConnections(version, myVertex, buildData, toFillIn);
 }
 
@@ -221,7 +215,7 @@ void StateUpdater::SetStateForRefAndDependents(
     const SharedString & ref,
     AssetDefs::State newState,
     function<bool(AssetDefs::State)> updateStatePredicate) {
-  SharedString verref = AssetVersionRef::Bind(ref);
+  SharedString verref = AssetVersionImpl::Key(ref);
   auto refVertex = BuildDependentTreeForStateCalculation(verref);
   SetStateForVertexAndDependents(refVertex, newState, updateStatePredicate);
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -108,11 +108,23 @@ StateUpdater::AddOrUpdateVertex(
     return myVertex;
   }
   else {
-    // I'm already in the graph. Make sure recalcState is set correctly and
-    // return my existing vertex descriptor.
-    auto myVertex = tree[myVertexIter->second];
-    myVertex.inDepTree = myVertex.inDepTree || inDepTree;
-    myVertex.recalcState = myVertex.recalcState || recalcState;
+    // I'm already in the graph. First make sure my connections are in the tree
+    // if I need them and they haven't been added yet, and then return the
+    // existing vertex descriptor.
+    auto & myVertexData = tree[myVertexIter->second];
+    bool needConnections = false;
+    if (inDepTree && !myVertexData.inDepTree) {
+      myVertexData.inDepTree = true;
+      needConnections = true;
+    }
+    if (recalcState && !myVertexData.recalcState) {
+      myVertexData.recalcState = true;
+      needConnections = true;
+    }
+    if (needConnections) {
+      auto version = storageManager->Get(ref);
+      AddConnections(version, myVertexIter->second, buildData, toFillIn);
+    }
     return myVertexIter->second;
   }
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -62,7 +62,7 @@ StateUpdater::TreeType::vertex_descriptor
 StateUpdater::BuildDependentTreeForStateCalculation(const SharedString & ref) {
   VertexMap vertices;
   size_t index = 0;
-  list<TreeType::vertex_descriptor> toFillIn, toFillInNext;
+  set<TreeType::vertex_descriptor> toFillIn, toFillInNext;
   // First create an empty vertex for the provided asset. Then fill it in,
   // which includes adding its connections to other assets. Every time we fill
   // in a node we will get new assets to add to the tree until all assets have
@@ -92,7 +92,7 @@ StateUpdater::AddEmptyVertex(
     size_t & index,
     bool inDepTree,
     bool recalcState,
-    list<TreeType::vertex_descriptor> & toFillIn) {
+    set<TreeType::vertex_descriptor> & toFillIn) {
   auto myVertexIter = vertices.find(ref);
   if (myVertexIter == vertices.end()) {
     // I'm not in the graph yet, so make a new empty vertex and let the caller
@@ -101,7 +101,7 @@ StateUpdater::AddEmptyVertex(
     tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, index};
     ++index;
     vertices[ref] = myVertex;
-    toFillIn.push_back(myVertex);
+    toFillIn.emplace(myVertex);
     return myVertex;
   }
   else {
@@ -120,7 +120,7 @@ void StateUpdater::FillInVertex(
     TreeType::vertex_descriptor myVertex,
     VertexMap & vertices,
     size_t & index,
-    list<TreeType::vertex_descriptor> & toFillIn) {
+    set<TreeType::vertex_descriptor> & toFillIn) {
   SharedString name = tree[myVertex].name;
   notify(NFY_PROGRESS, "Loading '%s' for state update", name.toString().c_str());
   auto version = storageManager->Get(name);

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -94,13 +94,13 @@ class StateUpdater
         TreeType::vertex_descriptor vertex,
         AssetDefs::State newState,
         bool sendNotifications);
+    void RecalculateAndSaveStates();
   public:
     StateUpdater(StorageManagerInterface<AssetVersionImpl> * sm = &AssetVersion::storageManager()) : storageManager(sm) {}
     void SetStateForRefAndDependents(
         const SharedString & ref,
         AssetDefs::State newState,
         std::function<bool(AssetDefs::State)> updateStatePredicate);
-    void RecalculateAndSaveStates();
 };
 
 #endif // ASSETTREE_H

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -59,6 +59,9 @@ class StateUpdater
         AssetEdge> TreeType;
     typedef std::map<SharedString, TreeType::vertex_descriptor> VertexMap;
 
+    // Helper structs for building the tree
+    struct TreeBuildData;
+
     // Used by dfs function to update states of assets in the tree
     friend struct boost::property_map<TreeType, boost::vertex_index_t>;
     class UpdateStateVisitor;
@@ -71,15 +74,13 @@ class StateUpdater
     TreeType::vertex_descriptor BuildDependentTreeForStateCalculation(const SharedString & ref);
     TreeType::vertex_descriptor AddEmptyVertex(
         const SharedString & ref,
-        VertexMap & vertices,
-        size_t & index,
+        TreeBuildData & buildData,
         bool inDepTree,
         bool recalcState,
         std::set<TreeType::vertex_descriptor> & toFillIn);
     void FillInVertex(
         TreeType::vertex_descriptor vertex,
-        VertexMap & vertices,
-        size_t & index,
+        TreeBuildData & buildData,
         std::set<TreeType::vertex_descriptor> & toFillIn);
     void AddEdge(
         TreeType::vertex_descriptor from,

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -42,6 +42,7 @@ class StateUpdater
       AssetDefs::State state;
       bool inDepTree;
       bool recalcState;
+      bool stateChanged;
       size_t index; // Used by the dfs function
     };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -64,14 +64,14 @@ class StateUpdater
 
     // Used by dfs function to update states of assets in the tree
     friend struct boost::property_map<TreeType, boost::vertex_index_t>;
-    class UpdateStateVisitor;
+    class SetStateVisitor;
 
     StorageManagerInterface<AssetVersionImpl> * const storageManager;
     TreeType tree;
 
     inline bool IsDependent(DependencyType type) { return type == DEPENDENT || type == DEPENDENT_AND_CHILD; }
 
-    TreeType::vertex_descriptor BuildDependentTreeForStateCalculation(const SharedString & ref);
+    void BuildDependentTree(const SharedString & ref);
     TreeType::vertex_descriptor AddOrUpdateVertex(
         const SharedString & ref,
         TreeBuildData & buildData,
@@ -86,15 +86,10 @@ class StateUpdater
         TreeType::vertex_descriptor from,
         TreeType::vertex_descriptor to,
         AssetEdge data);
-    void SetStateForVertexAndDependents(
-        TreeType::vertex_descriptor vertex,
-        AssetDefs::State newState,
-        std::function<bool(AssetDefs::State)> updateStatePredicate);
     void SetState(
         TreeType::vertex_descriptor vertex,
         AssetDefs::State newState,
         bool sendNotifications);
-    void RecalculateAndSaveStates();
   public:
     StateUpdater(StorageManagerInterface<AssetVersionImpl> * sm = &AssetVersion::storageManager()) : storageManager(sm) {}
     void SetStateForRefAndDependents(

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -71,7 +71,9 @@ class StateUpdater
 
     inline bool IsDependent(DependencyType type) { return type == DEPENDENT || type == DEPENDENT_AND_CHILD; }
 
-    void BuildDependentTree(const SharedString & ref);
+    void BuildDependentTree(
+        const SharedString & ref,
+        std::function<bool(AssetDefs::State)> includePredicate);
     TreeType::vertex_descriptor AddOrUpdateVertex(
         const SharedString & ref,
         TreeBuildData & buildData,

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -59,7 +59,7 @@ class StateUpdater
         AssetEdge> TreeType;
     typedef std::map<SharedString, TreeType::vertex_descriptor> VertexMap;
 
-    // Helper structs for building the tree
+    // Helper struct for building the tree
     struct TreeBuildData;
 
     // Used by dfs function to update states of assets in the tree

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -82,11 +82,6 @@ class StateUpdater
         TreeType::vertex_descriptor myVertex,
         TreeBuildData & buildData,
         std::set<TreeType::vertex_descriptor> & toFillIn);
-    void AddConnections(
-        AssetHandle<const AssetVersionImpl> version,
-        TreeType::vertex_descriptor myVertex,
-        TreeBuildData & buildData,
-        std::set<TreeType::vertex_descriptor> & toFillIn);
     void AddEdge(
         TreeType::vertex_descriptor from,
         TreeType::vertex_descriptor to,

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -40,6 +40,7 @@ class StateUpdater
     struct AssetVertex {
       SharedString name;
       AssetDefs::State state;
+      bool recalcState;
       size_t index; // Used by the dfs function
     };
 
@@ -66,20 +67,22 @@ class StateUpdater
 
     inline bool IsDependent(DependencyType type) { return type == DEPENDENT || type == DEPENDENT_AND_CHILD; }
 
-    TreeType::vertex_descriptor BuildTree(const SharedString & ref);
+    TreeType::vertex_descriptor BuildDependentTreeForStateCalculation(const SharedString & ref);
     TreeType::vertex_descriptor AddEmptyVertex(
         const SharedString & ref,
         VertexMap & vertices,
         size_t & index,
+        bool recalcState,
         std::list<TreeType::vertex_descriptor> & toFillIn);
     void FillInVertex(
         TreeType::vertex_descriptor vertex,
         VertexMap & vertices,
         size_t & index,
         std::list<TreeType::vertex_descriptor> & toFillIn);
-    void AddEdge(TreeType::vertex_descriptor from,
-                 TreeType::vertex_descriptor to,
-                 AssetEdge data);
+    void AddEdge(
+        TreeType::vertex_descriptor from,
+        TreeType::vertex_descriptor to,
+        AssetEdge data);
     void SetStateForVertexAndDependents(
         TreeType::vertex_descriptor vertex,
         AssetDefs::State newState,

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -72,14 +72,19 @@ class StateUpdater
     inline bool IsDependent(DependencyType type) { return type == DEPENDENT || type == DEPENDENT_AND_CHILD; }
 
     TreeType::vertex_descriptor BuildDependentTreeForStateCalculation(const SharedString & ref);
-    TreeType::vertex_descriptor AddEmptyVertex(
+    TreeType::vertex_descriptor AddOrUpdateVertex(
         const SharedString & ref,
         TreeBuildData & buildData,
         bool inDepTree,
         bool recalcState,
         std::set<TreeType::vertex_descriptor> & toFillIn);
     void FillInVertex(
-        TreeType::vertex_descriptor vertex,
+        TreeType::vertex_descriptor myVertex,
+        TreeBuildData & buildData,
+        std::set<TreeType::vertex_descriptor> & toFillIn);
+    void AddConnections(
+        AssetHandle<const AssetVersionImpl> version,
+        TreeType::vertex_descriptor myVertex,
         TreeBuildData & buildData,
         std::set<TreeType::vertex_descriptor> & toFillIn);
     void AddEdge(

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -19,7 +19,7 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <functional>
-#include <list>
+#include <set>
 #include <map>
 
 #include "AssetVersion.h"
@@ -75,12 +75,12 @@ class StateUpdater
         size_t & index,
         bool inDepTree,
         bool recalcState,
-        std::list<TreeType::vertex_descriptor> & toFillIn);
+        std::set<TreeType::vertex_descriptor> & toFillIn);
     void FillInVertex(
         TreeType::vertex_descriptor vertex,
         VertexMap & vertices,
         size_t & index,
-        std::list<TreeType::vertex_descriptor> & toFillIn);
+        std::set<TreeType::vertex_descriptor> & toFillIn);
     void AddEdge(
         TreeType::vertex_descriptor from,
         TreeType::vertex_descriptor to,

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -40,6 +40,7 @@ class StateUpdater
     struct AssetVertex {
       SharedString name;
       AssetDefs::State state;
+      bool inDepTree;
       bool recalcState;
       size_t index; // Used by the dfs function
     };
@@ -72,6 +73,7 @@ class StateUpdater
         const SharedString & ref,
         VertexMap & vertices,
         size_t & index,
+        bool inDepTree,
         bool recalcState,
         std::list<TreeType::vertex_descriptor> & toFillIn);
     void FillInVertex(

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -292,7 +292,7 @@ TEST_F(StateUpdaterTest, RecalculateState_StateDoesAndDoesntChange) {
   ASSERT_FALSE(GetVersion(sm, "a")->stateSet);
   ASSERT_FALSE(GetVersion(sm, "b")->stateSet);
 
-  updater.SetStateForRefAndDependents(fix("a"), CALCULATED_STATE, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), CALCULATED_STATE, [](AssetDefs::State) { return true; });
   ASSERT_FALSE(GetVersion(sm, "a")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "b")->stateSet);
   ASSERT_FALSE(GetVersion(sm, "a")->loadedMutable);
@@ -300,7 +300,7 @@ TEST_F(StateUpdaterTest, RecalculateState_StateDoesAndDoesntChange) {
 
 TEST_F(StateUpdaterTest, NoInputsNoChildren) {
   SetVersions(sm, {MockVersion("a")});
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Queued);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Succeeded);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 0);
@@ -314,7 +314,7 @@ void OnlineInputBlockerTest(MockStorageManager & sm, StateUpdater & updater, Ass
   GetMutableVersion(sm, "b")->state = inputState;
   GetMutableVersion(sm, "c")->state = AssetDefs::InProgress;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, false);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 0);
@@ -340,7 +340,7 @@ TEST_F(StateUpdaterTest, OfflineInputBlocker) {
   SetVersions(sm, {MockVersion("a"), MockVersion("b")});
   SetListenerInput(sm, "a", "b");
   GetMutableVersion(sm, "b")->state = AssetDefs::Offline;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, true);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 0);
@@ -352,7 +352,7 @@ TEST_F(StateUpdaterTest, BlockedAndOfflineInput) {
   SetListenerInput(sm, "a", "c");
   GetMutableVersion(sm, "b")->state = AssetDefs::Offline;
   GetMutableVersion(sm, "c")->state = AssetDefs::Failed;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, false);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 0);
@@ -366,7 +366,7 @@ TEST_F(StateUpdaterTest, WaitingOnInput) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "c")->state = AssetDefs::InProgress;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Waiting);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 2);
 }
@@ -379,7 +379,7 @@ TEST_F(StateUpdaterTest, SucceededInputs) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "c")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Queued);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 0);
 }
@@ -392,7 +392,7 @@ void OnlineChildBlockerTest(MockStorageManager & sm, StateUpdater & updater, Ass
   GetMutableVersion(sm, "b")->state = inputState;
   GetMutableVersion(sm, "c")->state = AssetDefs::InProgress;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Blocked);
 }
 
@@ -424,7 +424,7 @@ TEST_F(StateUpdaterTest, ChildInProgress) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "c")->state = AssetDefs::InProgress;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
 }
 
@@ -436,7 +436,7 @@ TEST_F(StateUpdaterTest, ChildQueued) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "d")->state = AssetDefs::Queued;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Queued);
 }
 
@@ -448,7 +448,7 @@ TEST_F(StateUpdaterTest, SucceededChildren) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "c")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Succeeded);
 }
 
@@ -465,7 +465,7 @@ TEST_F(StateUpdaterTest, ChildrenAndDependents) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "d")->state = AssetDefs::Failed;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
 }
 
@@ -484,59 +484,51 @@ TEST_F(StateUpdaterTest, ChildrenAndInputs) {
   GetMutableVersion(sm, "e")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "f")->state = AssetDefs::InProgress;
   GetMutableVersion(sm, "g")->state = AssetDefs::Succeeded;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Waiting);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numWaitingForVal, 2);
 }
 
-// This tests a tricky corner case. c is the input to a, but it is also the
-// dependent of a's dependent. Thus, c doesn't seem to be in the dependent tree
-// from a's perspective, even though it actually is. This test ensures that the
-// code handles that case.
+// This tests a tricky corner case. d and e are inputs/children of a, but they
+// are also dependent's of a's dependent's. Thus, d and e don't seem to be in
+// the dependent tree from a's perspective, even though they actually are. This
+// test ensures that the code handles that case.
 TEST_F(StateUpdaterTest, ChildDepIsInput) {
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c"),
+                   MockVersion("d"), MockVersion("e")});
   SetDependent(sm, "a", "b");
   SetDependent(sm, "b", "c");
-  SetListenerInput(sm, "a", "c");
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  SetDependent(sm, "c", "d");
+  SetDependent(sm, "c", "e");
+  SetListenerInput(sm, "a", "d");
+  SetParentChild(sm, "a", "e");
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_TRUE(GetVersion(sm, "a")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "b")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "c")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "d")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "e")->stateSet);
 }
 
-// This tests another corner case where a's input is the parent of another
-// asset version in the dependency tree. Again, c needs to be updated but it
-// doesn't look that way from a's perspective.
+// This tests another corner case where a's input/child is the parent/listener
+// of another asset version in the dependency tree. d and e need to be updated
+// but it doesn't look that way from a's perspective.
 TEST_F(StateUpdaterTest, InputIsParent) {
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c"),
+                   MockVersion("d"), MockVersion("e")});
   SetDependent(sm, "a", "b");
-  SetListenerInput(sm, "a", "c");
-  SetParentChild(sm, "c", "b");
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  SetDependent(sm, "b", "c");
+  SetListenerInput(sm, "a", "d");
+  SetParentChild(sm, "a", "e");
+  SetParentChild(sm, "d", "c");
+  SetListenerInput(sm, "e", "c");
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_TRUE(GetVersion(sm, "a")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "b")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "c")->stateSet);
-}
-
-TEST_F(StateUpdaterTest, RecalculateMultipleStates) {
-  GetBigTree(sm);
-  updater.SetStateForRefAndDependents(fix("p1"), AssetDefs::New, [](AssetDefs::State) { return false; });
-  // States should be changed for parents and dependents
-  ASSERT_TRUE(GetVersion(sm, "gp")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "p1")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "c1")->stateSet);
-
-  // All other states shouldn't change (including dependents of parents)
-  ASSERT_FALSE(GetVersion(sm, "c2")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "p2")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "pi1")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "gpi")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "c3")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "c4")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "ci1")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "ci2")->stateSet);
-  ASSERT_FALSE(GetVersion(sm, "ci3")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "d")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "e")->stateSet);
 }
 
 int main(int argc, char **argv) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -560,6 +560,21 @@ TEST_F(StateUpdaterTest, ChildDepIsInput) {
   ASSERT_TRUE(GetVersion(sm, "c")->stateSet);
 }
 
+// This tests another corner case where a's input is the parent of another
+// asset version in the dependency tree. Again, c needs to be updated but it
+// doesn't look that way from a's perspective.
+TEST_F(StateUpdaterTest, InputIsParent) {
+  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+  SetDependent(sm, "a", "b");
+  SetListenerInput(sm, "a", "c");
+  SetParentChild(sm, "c", "b");
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.RecalculateAndSaveStates();
+  ASSERT_TRUE(GetVersion(sm, "a")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "b")->stateSet);
+  ASSERT_TRUE(GetVersion(sm, "c")->stateSet);
+}
+
 TEST_F(StateUpdaterTest, RecalculateMultipleStates) {
   GetBigTree(sm);
   updater.SetStateForRefAndDependents(fix("p1"), AssetDefs::New, [](AssetDefs::State) { return false; });

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -326,7 +326,7 @@ TEST_F(StateUpdaterTest, RecalculateState_StateDoesAndDoesntChange) {
   SetVersions(sm, {MockVersion("a"), MockVersion("b")});
   GetMutableVersion(sm, "a")->state = CALCULATED_STATE;
   GetMutableVersion(sm, "b")->state = STARTING_STATE;
-  SetListenerInput(sm, "a", "b");
+  SetDependent(sm, "a", "b");
   GetMutableVersion(sm, "a")->loadedMutable = false;
   updater.SetStateForRefAndDependents(fix("a"), CALCULATED_STATE, [](AssetDefs::State) { return false; });
 
@@ -546,20 +546,23 @@ TEST_F(StateUpdaterTest, ChildrenAndInputs) {
 
 TEST_F(StateUpdaterTest, RecalculateMultipleStates) {
   GetBigTree(sm);
-  updater.SetStateForRefAndDependents(fix("gp"), AssetDefs::New, [](AssetDefs::State) { return false; });
+  updater.SetStateForRefAndDependents(fix("p1"), AssetDefs::New, [](AssetDefs::State) { return false; });
   updater.RecalculateAndSaveStates();
+  // States should be changed for parents and dependents
   ASSERT_TRUE(GetVersion(sm, "gp")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "gpi")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "p1")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "pi1")->stateSet);
   ASSERT_TRUE(GetVersion(sm, "c1")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "p2")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "c2")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "c3")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "c4")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "ci1")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "ci2")->stateSet);
-  ASSERT_TRUE(GetVersion(sm, "ci3")->stateSet);
+
+  // All other states shouldn't change (including dependents of parents)
+  ASSERT_FALSE(GetVersion(sm, "c2")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "p2")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "pi1")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "gpi")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "c3")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "c4")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "ci1")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "ci2")->stateSet);
+  ASSERT_FALSE(GetVersion(sm, "ci3")->stateSet);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Updates the new resume code so that it doesn't load assets that are not needed for the resume. Conceptually it does the following:
1. Load the resumed asset, its dependents, their dependents, and so on to the bottom of the tree. These are the assets whose state will definitely change do to the resume.
1. For everything in the tree up to this point, load all the parents and listeners. These are the assets that may need to recalculate their state because another asset changed state.
1. For everything in the tree up to this point, load all the inputs and children. These are the assets required to calculate the state for everything else in the tree.
In reality, however, all 3 steps are performed simultaneously to avoid loading assets from disk multiple times. There are also some additional improvements, such as not loading assets that can't be resumed, as well as some refactoring to make the code cleaner and more performant.