### PR TITLE
1376 Use config for Cutter API calls

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/advanced_cutter.cfg
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/advanced_cutter.cfg
@@ -21,3 +21,6 @@ USE_POST f
 # Maximum number of concurrent processes to distribute cutting task over.
 MAX_PROCESSES 15
 
+# Host URL that is used for API calls
+DATABASE_HOST http://localhost:80
+

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -37,7 +37,10 @@ from common import form_wrap
 from common import postgres_manager_wrap
 import common.utils
 from core import globe_cutter
+import common.configs
 
+CONFIG_FILE = "/opt/google/gehttpd/cgi-bin/advanced_cutter.cfg"
+CONFIGS = common.configs.Configs(CONFIG_FILE)
 
 COMMAND_DIR = "/opt/google/bin"
 WEB_URL_BASE = "/cutter/globes"
@@ -477,8 +480,8 @@ class GlobeBuilder(object):
     if source:
       server, target = common.utils.GetServerAndPathFromUrl(source)
 
-    if not server:
-      server = "http://localhost/"
+    # Replace the server with advanced configuration host
+    server = CONFIGS.GetStr("DATABASE_HOST")
 
     target = common.utils.NormalizeTargetPath(target)
     base_url = "%s/cgi-bin/globe_cutter_app.py" % server
@@ -898,7 +901,7 @@ if __name__ == "__main__":
     elif cgi_cmd == "ADD_PLUGIN_FILES":
       is_2d = FORM.getvalue("is_2d")
       globe_builder.CheckArgs(["globe_name", "source"], FORM)
-      globe_builder.AddPluginFiles(FORM.getvalue_url("source"), is_2d)
+      globe_builder.AddPluginFiles(CONFIGS.GetStr("DATABASE_HOST"), is_2d)
 
     elif cgi_cmd == "PACKAGE_GLOBE":
       globe_builder.CheckArgs(["globe_name"], FORM)


### PR DESCRIPTION
Fixes issue #1376 .  Uses the advanced configuration to set a URL that will be used when cutter tries to make an openurl call. As these calls happen internally by default, this defaults to localhost.