### PR TITLE
Fix invalid cast

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
+++ b/earth_enterprise/src/fusion/autoingest/AssetGenDaemonCpp.pl
@@ -425,7 +425,7 @@ ${name}AssetImplD::Load(const std::string &boundref)
 {
     // make sure the base class loader actually instantiated one of me
     // this should always happen, but there are no compile time guarantees
-    auto loaded = ${name}AssetVersionImpl::Load(boundref);
+    auto loaded = ${name}AssetImpl::Load(boundref);
     std::shared_ptr<${name}AssetImplD> result =
         std::dynamic_pointer_cast<${name}AssetImplD>(loaded);
 


### PR DESCRIPTION
Fixes an invalid cast that causes system manager to crash.

I've verified that this was introduced in 5.3.2 and is not a problem in 5.3.1.

The only way I've found to reproduce this is to run PR #1396 through the gauge tests (specifically `gauge run specs --tags=failed`). I'm not sure why it doesn't turn up more often.

Fixes #1398.