### PR TITLE
Log when cache size is exceeded

### DIFF
--- a/earth_enterprise/src/common/khCache.h
+++ b/earth_enterprise/src/common/khCache.h
@@ -18,6 +18,7 @@
 #ifndef __khCache_h
 #define __khCache_h
 
+#include <cctype>
 #include <chrono>
 #include <map>
 #include <vector>
@@ -80,6 +81,7 @@ class khCache {
   Item *head;
   Item *tail;
   const uint targetMax;
+  const std::string name;
 #ifdef SUPPORT_VERBOSE
   bool verbose;
 #endif
@@ -175,11 +177,12 @@ class khCache {
   size_type capacity(void) const { return targetMax; }
   uint64 getMemoryUse(void) const { return cacheMemoryUse; }
 
-  khCache(uint targetMax_
+  khCache(uint targetMax_, std::string name_
 #ifdef SUPPORT_VERBOSE
           , bool verbose_ = false
 #endif
           ) : head(0), tail(0), targetMax(targetMax_),
+              name(name_.replace(0, 1, 1, std::toupper(name_[0]))), // Make the first letter upper case for pretty notify statements
 #ifdef SUPPORT_VERBOSE
               verbose(verbose_),
 #endif
@@ -344,8 +347,8 @@ class khCache {
       actualSize = map.size();
       units = "items";
     }
-    notify(NFY_INFO, "Cache size exceeded. Configured size: %lu %s, Actual size: %lu %s, Prune time: %f seconds",
-           configuredSize, units.c_str(), actualSize, units.c_str(), elapsedTime.count());
+    notify(NFY_INFO, "%s cache size exceeded. Configured size: %lu %s, Actual size: %lu %s, Prune time: %f seconds",
+           name.c_str(), configuredSize, units.c_str(), actualSize, units.c_str(), elapsedTime.count());
   }
 
 };

--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -64,7 +64,7 @@ class StorageManager : public StorageManagerInterface<AssetType> {
     using PointerType = typename Base::PointerType;
 
     StorageManager(uint cacheSize, bool limitByMemory, uint64 maxMemory, const std::string & type) :
-        cache(cacheSize),
+        cache(cacheSize, type),
         assetType(type) { SetCacheMemoryLimit(limitByMemory, maxMemory); }
     ~StorageManager() = default;
 

--- a/earth_enterprise/src/fusion/gst/gstEarthStream.cpp
+++ b/earth_enterprise/src/fusion/gst/gstEarthStream.cpp
@@ -493,7 +493,7 @@ bool gstEarthStream::GetImage(const gstQuadAddress& addr, char* buffer) {
 ImageVersion gstEarthStream::GetImageVersion(const gstQuadAddress& addr) {
   std::string blist = addr.BlistAsString();
   static khCache<std::string, ImageExistanceHandle>
-    image_existance_cache(kImageExistanceCacheSize);
+    image_existance_cache(kImageExistanceCacheSize, "image existence cache");
   ImageExistanceHandle image_existance;
   if (!image_existance_cache.Find(ImageExistanceImpl::PacketName(blist),
                                    image_existance)) {

--- a/earth_enterprise/src/fusion/gst/gstSourceManager.cpp
+++ b/earth_enterprise/src/fusion/gst/gstSourceManager.cpp
@@ -36,9 +36,9 @@ void gstSourceManager::init(int sz) {
 }
 
 gstSourceManager::gstSourceManager(int cacheSize)
-    : geode_cache_(gstSourceManager::kGeodesCacheSize),
-      geometry_cache_(cacheSize),
-      record_cache_(gstSourceManager::kRecordCacheSize) {
+    : geode_cache_(gstSourceManager::kGeodesCacheSize, "GST geode"),
+      geometry_cache_(cacheSize, "GST geometry"),
+      record_cache_(gstSourceManager::kRecordCacheSize, "GST record") {
 }
 
 gstSourceManager::~gstSourceManager() {

--- a/earth_enterprise/src/fusion/gst/maprender/PreviewController.cpp
+++ b/earth_enterprise/src/fusion/gst/maprender/PreviewController.cpp
@@ -33,7 +33,7 @@ PreviewController::PreviewController(const khTilespace &tilespace_,
     oversizeFactor(oversizeFactor_),
     addrShift(tilespace.tileSizeLog2 - tilespace.pixelsAtLevel0Log2),
     config(config_),
-    cache(5 /* only cache a small number of these */),
+    cache(5 /* only cache a small number of these */, "preview controller"),
     debug(debug_)
 {
   SelectorVector dummy;

--- a/earth_enterprise/src/fusion/khraster/CachedRasterInsetReader.h
+++ b/earth_enterprise/src/fusion/khraster/CachedRasterInsetReader.h
@@ -83,7 +83,7 @@ class CachingProductTileReader_ImageryAlpha
 
   CachingProductTileReader_ImageryAlpha(uint tileCacheSize,
                                         uint readerCacheSize) :
-      tileCache(tileCacheSize),
+      tileCache(tileCacheSize, "imagery alpha tile reader"),
       readerCache(readerCacheSize)
   { }
 };
@@ -128,7 +128,7 @@ class CachingProductTileReader_Heightmap
 
   CachingProductTileReader_Heightmap(uint tileCacheSize,
                                      uint readerCacheSize) :
-      tileCache(tileCacheSize),
+      tileCache(tileCacheSize, "height map tile reader"),
       readerCache(readerCacheSize)
   { }
 };

--- a/earth_enterprise/src/fusion/khraster/ProductLevelReaderCache.h
+++ b/earth_enterprise/src/fusion/khraster/ProductLevelReaderCache.h
@@ -76,7 +76,7 @@ class ProductLevelReaderCache
   mutable khCache<const khRasterProductLevel*, CachedReader> cache;
 
  public:
-  inline ProductLevelReaderCache(uint cacheSize) : cache(cacheSize) { }
+  inline ProductLevelReaderCache(uint cacheSize) : cache(cacheSize, "product level reader") { }
 
   template <class DestTile>
   inline void

--- a/earth_enterprise/src/fusion/rasterfuse/ReaderCache.h
+++ b/earth_enterprise/src/fusion/rasterfuse/ReaderCache.h
@@ -69,7 +69,7 @@ class FFIORasterReaderCache
   mutable khCache<const RawReader*, CachedReader> cache;
 
  public:
-  inline FFIORasterReaderCache(uint cacheSize) : cache(cacheSize) { }
+  inline FFIORasterReaderCache(uint cacheSize) : cache(cacheSize, "reader") { }
 
   inline void
   ReadTile(const RawReader *reader, const khTileAddr &addr,

--- a/earth_enterprise/src/fusion/rasterfuse/TmeshPackgenTraverser.cpp
+++ b/earth_enterprise/src/fusion/rasterfuse/TmeshPackgenTraverser.cpp
@@ -155,7 +155,7 @@ TmeshPackgenTraverser::TmeshPackgenTraverser(
                         StartLowerLeft,
                         false /* isvector */),
       writer_(file_pool_, output, true /* overwrite */),
-      extra_cache_(20000 /* apx 160M */),
+      extra_cache_(20000 /* apx 160M */, "tmesh traverser"),
       not_covered_tiles_exist_(false) {
 
   if((decimation_threshold <= 0.0) || (config.decimate == false)) {


### PR DESCRIPTION
Fixes #1401 by adding a log statement when the cache size is exceeded.

To test:
1. Set the log level to 4 or more.
2. Set the cache sizes very low in misc.xml (I used 10).
3. Run a test (I used the gauge tests).
4. Look for log statements in gesystemmanager.log indicating that there are too many items in the cache(s).
5. Set the logs to be limited by memory utilization and set the memory size very low (I used 5000 bytes).
6. Run a test (I used the gauge tests again).
7. Look for log statements in gesystemmanager.log indicating that the size of the caches have exceeded the specified number of bytes.