### PR TITLE
Skip Internal Certificate Verification

### DIFF
--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Utilities for getting config parameters."""
+
+
+class Configs(object):
+  """Class for loading and provide configuration parameters."""
+
+  def __init__(self, config_file, default_values=None):
+    """Load config key/value pairs from the config file."""
+    if default_values:
+      self._config_values = default_values
+    else:
+      self._config_values = {}
+    try:
+      fp = open(config_file)
+      for line in fp:
+        line = line.strip()
+        if line and line[0] != "#":
+          (key, value) = line.split(" ")
+          self._config_values[key] = value
+      fp.close()
+    except IOError:
+      pass
+    except:
+      pass
+
+  def GetStr(self, key):
+    """Returns the value for the given key from the config file."""
+    try:
+      return self._config_values[key]
+    except KeyError:
+      return ""
+
+  def GetInt(self, key):
+    """Returns the integer value for the given key from the config file."""
+    try:
+      return int(self._config_values[key])
+    except KeyError:
+      return 0
+
+  def GetBool(self, key):
+    """Returns the boolean value for the given key from the config file."""
+    try:
+      return "t" == self._config_values[key].lower()[0]
+    except KeyError:
+      return False
+    except IndexError:
+      return False

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2019 Google Inc.
+# Copyright 2017 Google Inc.
 # Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/configs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
+# Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
@@ -286,8 +286,6 @@ def _SetTransPixelToBgcolor(tile, bgcolor):
 
   return tile
 
-key_file = '/opt/google/gehttpd/conf/privkey.pem'
-cert_file = '/opt/google/gehttpd/conf/fullchain.pem'
 
 def _FetchMapTile(url):
   """Fetches and returns a tile, given an url.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/tiles.py
@@ -21,7 +21,7 @@ import logging
 import os
 import StringIO
 import tempfile
-import urllib
+import wms_connection
 
 import geom
 import images
@@ -286,6 +286,8 @@ def _SetTransPixelToBgcolor(tile, bgcolor):
 
   return tile
 
+key_file = '/opt/google/gehttpd/conf/privkey.pem'
+cert_file = '/opt/google/gehttpd/conf/fullchain.pem'
 
 def _FetchMapTile(url):
   """Fetches and returns a tile, given an url.
@@ -297,16 +299,12 @@ def _FetchMapTile(url):
       The tile bitmap.
   """
   try:
-    fp = urllib.urlopen(url)
-    f = StringIO.StringIO(fp.read())
+    f = StringIO.StringIO(wms_connection.HandleConnection(url))
     im_tile = Image.open(f)
     im_tile.load()
   except IOError, e:
     im_tile = None
     logger.error("Failed to fetch tile:%s", e)
-  finally:
-    if fp:
-      fp.close()
 
   return im_tile
 

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handle connections to WMS API"""
+
+import ssl
+import urllib2
+import urlparse
+import logging
+import configs
+
+CONFIG_FILE = "/opt/google/gehttpd/wsgi-bin/wms/ogc/wms.cfg"
+CONFIGS = configs.Configs(CONFIG_FILE)
+
+logger = logging.getLogger("wms_maps")
+
+def HandleConnection(url):
+  logger.debug("Opening url: [%s]", url)
+
+  if CONFIGS.GetStr("DATABASE_HOST") != "":
+    url = CONFIGS.GetStr("DATABASE_HOST") + urlparse.urlsplit(url)[2:]
+
+  try:
+    # Set the context based on cert requirements
+    if CONFIGS.GetBool("VALIDATE_CERTIFICATE"):
+      cert_file = CONFIGS.GetStr("CERTIFICATE_CHAIN_PATH")
+      key_file = CONFIGS.GetStr("CERTIFICATE_KEY_PATH")
+      context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+      context.load_cert_chain(cert_file, keyfile=key_file)
+    else:
+      context = ssl.create_default_context()
+      context.check_hostname = False
+      context.verify_mode = ssl.CERT_NONE
+
+    fp = urllib2.urlopen(url, context=context)
+    response = fp.read()
+  except urllib2.HTTPError, e:
+    logger.warning("Server definitions didn't return any results %s.", e)
+    return {}
+  finally:
+    if fp:
+      fp.close()
+
+  return response

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2019 Google Inc.
+# Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2017 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/wms_connection.py
@@ -33,6 +33,7 @@ def HandleConnection(url):
   if CONFIGS.GetStr("DATABASE_HOST") != "":
     url = CONFIGS.GetStr("DATABASE_HOST") + urlparse.urlsplit(url)[2:]
 
+  fp = None
   try:
     # Set the context based on cert requirements
     if CONFIGS.GetBool("VALIDATE_CERTIFICATE"):

--- a/earth_enterprise/src/server/wsgi/wms/ogc/gee/maps_server_handler.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/gee/maps_server_handler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -194,8 +195,6 @@ class WmsLayer(object):
 
     return tile_args
 
-key_file = '/opt/google/gehttpd/conf/privkey.pem'
-cert_file = '/opt/google/gehttpd/conf/fullchain.pem'
 
 def _GetServerVars(target_url):
   """Fetches the server definitions from the Maps server.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/gee/maps_server_handler.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/gee/maps_server_handler.py
@@ -19,10 +19,11 @@
 import json
 import logging
 import re
+import ssl
 from socket import gethostname
-import urllib2
 import urlparse
 
+import wms.ogc.common.wms_connection as wms_connection
 import wms.ogc.common.projections as projections
 
 # Example 'serverDefs' from Maps/Portable. The parts we use are the same
@@ -193,6 +194,8 @@ class WmsLayer(object):
 
     return tile_args
 
+key_file = '/opt/google/gehttpd/conf/privkey.pem'
+cert_file = '/opt/google/gehttpd/conf/fullchain.pem'
 
 def _GetServerVars(target_url):
   """Fetches the server definitions from the Maps server.
@@ -210,16 +213,7 @@ def _GetServerVars(target_url):
 
   target_url = urlparse.urljoin(target_url, _SERVER_DEF_URL)
 
-  logger.debug("Opening url: [%s]", target_url)
-
-  try:
-    fp = urllib2.urlopen(target_url)
-    result = fp.read()
-  except urllib2.HTTPError, e:
-    logger.warning("Server definitions didn't return any results %s.", e)
-    return {}
-
-  fp.close()
+  result = wms_connection.HandleConnection(target_url)
 
   logger.debug("Server definitions data read, start regex")
   logger.debug("JSON vars: %s", result)

--- a/earth_enterprise/src/server/wsgi/wms/ogc/wms.cfg
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/wms.cfg
@@ -1,0 +1,9 @@
+# Toggle to enable and disable certificate validation
+VALIDATE_CERTIFICATE False
+
+# Certificate chain and key location are needed for validation
+# CERTIFICATE_CHAIN_PATH /opt/google/gehttpd/conf/server.crt
+# CERTIFICATE_KEY_PATH /opt/google/gehttpd/conf/server.key
+
+# Set a custom hostname for database connections
+# DATABASE_HOST https://localhost:443


### PR DESCRIPTION
Fixes #1404. Allows Python to bypass the internal certificate verification by default. Extra security configurations are also added to allow users to redirect the host and verify against specific certificates.

Verification Steps:
1. Install open gee.
2. Obtain an SSL certificate (preferably third party) and set up GEE Server for SSL.
3. Set a virtual host as an SSL server.
4. Publish a database over your SSL virtual host and enable WMS.
5. Ensure you can connect to your database over https with a WMS client. (QGIS is a free, open source tool https://qgis.org/en/site/)