### PR TITLE
Short circuit state calculation

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -93,7 +93,7 @@ DependentStateTreeFactory::AddOrUpdateVertex(
     // I'm not in the graph yet, so make a new empty vertex and let the caller
     // know we need to load it with the correct information
     auto myVertex = add_vertex(tree);
-    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, false, index};
+    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, false, false, index};
     ++index;
     vertices[ref] = myVertex;
     toFillInNext.insert(myVertex);
@@ -134,6 +134,7 @@ void DependentStateTreeFactory::FillInVertex(
     return;
   }
   tree[myVertex].state = version->state;
+  tree[myVertex].hasInputs = !version->inputs.empty();
   tree[myVertex].hasChildren = !version->children.empty();
   // If this vertex is in the dependent tree but doesn't need to be included,
   // act as though it's not in the dependency tree. We'll leave it in the tree

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -93,7 +93,7 @@ DependentStateTreeFactory::AddOrUpdateVertex(
     // I'm not in the graph yet, so make a new empty vertex and let the caller
     // know we need to load it with the correct information
     auto myVertex = add_vertex(tree);
-    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, index};
+    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, false, index};
     ++index;
     vertices[ref] = myVertex;
     toFillInNext.insert(myVertex);
@@ -134,6 +134,7 @@ void DependentStateTreeFactory::FillInVertex(
     return;
   }
   tree[myVertex].state = version->state;
+  tree[myVertex].hasChildren = !version->children.empty();
   // If this vertex is in the dependent tree but doesn't need to be included,
   // act as though it's not in the dependency tree. We'll leave it in the tree
   // to avoid messing up the index numbering and in case it is needed as an

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -93,7 +93,7 @@ DependentStateTreeFactory::AddOrUpdateVertex(
     // I'm not in the graph yet, so make a new empty vertex and let the caller
     // know we need to load it with the correct information
     auto myVertex = add_vertex(tree);
-    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, false, false, index};
+    tree[myVertex] = {ref, AssetDefs::New, inDepTree, recalcState, false, index};
     ++index;
     vertices[ref] = myVertex;
     toFillInNext.insert(myVertex);
@@ -134,8 +134,6 @@ void DependentStateTreeFactory::FillInVertex(
     return;
   }
   tree[myVertex].state = version->state;
-  tree[myVertex].hasInputs = !version->inputs.empty();
-  tree[myVertex].hasChildren = !version->children.empty();
   // If this vertex is in the dependent tree but doesn't need to be included,
   // act as though it's not in the dependency tree. We'll leave it in the tree
   // to avoid messing up the index numbering and in case it is needed as an

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -29,7 +29,6 @@ struct AssetVertex {
   SharedString name;
   AssetDefs::State state;
   bool inDepTree;
-  bool recalcState;
   bool stateChanged;
   size_t index; // Used by the dfs function
 };

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -31,6 +31,7 @@ struct AssetVertex {
   bool inDepTree;
   bool recalcState;
   bool stateChanged;
+  bool hasInputs;
   bool hasChildren;
   size_t index; // Used by the dfs function
 };

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -31,6 +31,7 @@ struct AssetVertex {
   bool inDepTree;
   bool recalcState;
   bool stateChanged;
+  bool hasChildren;
   size_t index; // Used by the dfs function
 };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -31,8 +31,6 @@ struct AssetVertex {
   bool inDepTree;
   bool recalcState;
   bool stateChanged;
-  bool hasInputs;
-  bool hasChildren;
   size_t index; // Used by the dfs function
 };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -109,6 +109,9 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
             numWaitingFor = 0;
           }
         }
+        bool Decided() {
+          return false;
+        }
     };
     // Helper class for calculating state from children
     class ChildStates {
@@ -142,6 +145,9 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
           } else {
             stateByChildren = AssetDefs::Queued;
           }
+        }
+        bool Decided() {
+          return false;
         }
     };
 
@@ -182,6 +188,11 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
             // Dependents that are not also children are not considered when
             // calculating state.
             break;
+        }
+        // If we already know what the value of all of the parameters will be
+        // we can exit the loop early.
+        if (inputStates.Decided() && childStates.Decided() && childOrInputStateChanged) {
+          break;
         }
       }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -147,7 +147,12 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
           }
         }
         bool Decided() {
-          return false;
+          // If either of the below conditions is true we already know what
+          // the output from GetOutputs will be and there is no need to check
+          // the state of more children.
+          bool isBlocked = numblocking;
+          bool isInProgress = numkids != numgood && (numgood || numinprog);
+          return isBlocked || isInProgress;
         }
     };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -110,7 +110,10 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
           }
         }
         bool Decided() {
-          return false;
+          // If this function returns true then we alreay know what all the
+          // outputs from GetOutputs will be and we don't need to check the
+          // state of any more inputs.
+          return numblocking > 0 && numblocking != numoffline;
         }
     };
     // Helper class for calculating state from children
@@ -150,9 +153,9 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
           }
         }
         bool Decided() {
-          // If any of the below conditions is true we already know what the
-          // output from GetOutputs will be and there is no need to check the
-          // state of more children.
+          // If this function returns true we already know what the output from
+          // GetOutputs will be and there is no need to check the state of more
+          // children.
           return !hasKids || numblocking > 0;
         }
     };

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -73,14 +73,12 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
     // Helper class for calculating state from inputs
     class InputStates {
       private:
-        bool decided;
-        uint numinputs;
-        uint numgood;
-        uint numblocking;
-        uint numoffline;
+        bool decided = false;
+        uint numinputs = 0;
+        uint numgood = 0;
+        uint numblocking = 0;
+        uint numoffline = 0;
       public:
-        InputStates(bool hasInputs) :
-          decided(!hasInputs), numinputs(0), numgood(0), numblocking(0), numoffline(0) {}
         void Add(AssetDefs::State inputState) {
           ++numinputs;
           if (inputState == AssetDefs::Succeeded) {
@@ -122,14 +120,12 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
     // Helper class for calculating state from children
     class ChildStates {
       private:
-        bool decided;
-        uint numkids;
-        uint numgood;
-        uint numblocking;
-        uint numinprog;
+        bool decided = false;
+        uint numkids = 0;
+        uint numgood = 0;
+        uint numblocking = 0;
+        uint numinprog = 0;
       public:
-        ChildStates(bool hasKids) :
-          decided(!hasKids), numkids(0), numgood(0), numblocking(0), numinprog(0) {}
         void Add(AssetDefs::State childState) {
           ++numkids;
           if (childState == AssetDefs::Succeeded) {
@@ -175,8 +171,8 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
         bool & blockersAreOffline,
         uint32 & numWaitingFor,
         bool & needRecalcState) const {
-      InputStates inputStates(tree[vertex].hasInputs);
-      ChildStates childStates(tree[vertex].hasChildren);
+      InputStates inputStates;
+      ChildStates childStates;
 
       needRecalcState = tree[vertex].stateChanged;
       auto edgeIters = out_edges(vertex, tree);

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -73,11 +73,14 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
     // Helper class for calculating state from inputs
     class InputStates {
       private:
-        uint numinputs = 0;
-        uint numgood = 0;
-        uint numblocking = 0;
-        uint numoffline = 0;
+        bool hasInputs;
+        uint numinputs;
+        uint numgood;
+        uint numblocking;
+        uint numoffline;
       public:
+        InputStates(bool hasInputs) :
+          hasInputs(hasInputs), numinputs(0), numgood(0), numblocking(0), numoffline(0) {}
         void Add(AssetDefs::State inputState) {
           ++numinputs;
           if (inputState == AssetDefs::Succeeded) {
@@ -113,7 +116,7 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
           // If this function returns true then we alreay know what all the
           // outputs from GetOutputs will be and we don't need to check the
           // state of any more inputs.
-          return numblocking > 0 && numblocking != numoffline;
+          return !hasInputs || (numblocking > 0 && numblocking != numoffline);
         }
     };
     // Helper class for calculating state from children
@@ -172,7 +175,7 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
         bool & blockersAreOffline,
         uint32 & numWaitingFor,
         bool & childOrInputStateChanged) const {
-      InputStates inputStates;
+      InputStates inputStates(tree[vertex].hasInputs);
       ChildStates childStates(tree[vertex].hasChildren);
 
       childOrInputStateChanged = false;

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -219,7 +219,6 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
     virtual void finish_vertex(
         DependentStateTreeVertexDescriptor vertex,
         const DependentStateTree & tree) const {
-      if (!tree[vertex].recalcState) return;
       SharedString name = tree[vertex].name;
       notify(NFY_PROGRESS, "Calculating state for '%s'", name.toString().c_str());
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -204,15 +204,15 @@ void GetBigTree(MockStorageManager & sm) {
 }
 
 void assertStateSet(MockStorageManager & sm, const SharedString & ref) {
-  ASSERT_TRUE(GetVersion(sm, ref)->stateSet);
-  ASSERT_TRUE(GetVersion(sm, ref)->loadedMutable);
-  ASSERT_EQ(GetVersion(sm, ref)->notificationsSent, 1);
+  ASSERT_TRUE(GetVersion(sm, ref)->stateSet) << "State not set for " << ref;
+  ASSERT_TRUE(GetVersion(sm, ref)->loadedMutable) << ref << " was not loaded mutable";
+  ASSERT_EQ(GetVersion(sm, ref)->notificationsSent, 1) << "Wrong number of notifications sent for " << ref;
 }
 
 void assertStateNotSet(MockStorageManager & sm, const SharedString & ref) {
-  ASSERT_FALSE(GetVersion(sm, ref)->stateSet);
-  ASSERT_FALSE(GetVersion(sm, ref)->loadedMutable);
-  ASSERT_EQ(GetVersion(sm, ref)->notificationsSent, 0);
+  ASSERT_FALSE(GetVersion(sm, ref)->stateSet) << "State set for " << ref;
+  ASSERT_FALSE(GetVersion(sm, ref)->loadedMutable) << ref << " was loaded mutable";
+  ASSERT_EQ(GetVersion(sm, ref)->notificationsSent, 0) << "Notifications sent for " << ref;
 }
 
 TEST_F(StateUpdaterTest, SetStateSingleVersion) {


### PR DESCRIPTION
Exits the state calculation loop early where possible.

This PR also removes one of the fields stored in vertices and instead stores it temporarily to reduce the memory utilization of the state updater.

Unit tests have passed and I'm currently running integration tests.