### PR TITLE
Optimize child state change handling

### DIFF
--- a/docs/geedocs/5.3.2/answer/7160009.html
+++ b/docs/geedocs/5.3.2/answer/7160009.html
@@ -46,8 +46,11 @@ gtag('config', 'UA-108632131-2');
   <h5>
     <p id="overview_5.3.2">New Features</p>
   </h5>
-    <p><strong>Multithreaded builds.</strong> Parts of imagery project builds can now run on <a href="../answer/176738.html#packgen_thread_configuration">multiple threads</a>.
-    This capability is experimental and is not recommended for production builds.</p>
+    <p><strong>KML validation in cutter.</strong> Basic validation is now performed on KML that is pasted into the cutter tool.</p>
+    <p><strong>Memory and performance improvements.</strong> This version of Open GEE includes several optimizations for performance and memory utilization.</p>
+    <p><strong>Multithreaded builds.</strong> Parts of imagery project builds can now run on <a href="../answer/176738.html#packgen_thread_configuration">multiple threads</a>.</p>
+    <p><strong>Improved resume operation.</strong> The resume operation has been <a href="../answer/176738.html#improving_optimization_performance">rewritten to improve performance</a>.</p>
+    <p><strong>Specify cache sizes in bytes.</strong> The sizes of the asset and asset version caches can now be <a href="../answer/176738.html#cache_configuration">specified in bytes</a>.</p>
   <h5>
     <p id="supported_5.3.2">Supported Platforms</p>
   </h5>

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -161,7 +161,7 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
     // parent asset (ex: parent is canceled, so these children
     // must also be canceled.
   }
-  virtual AssetDefs::State CalcStateByInputsAndChildren(AssetDefs::State, AssetDefs::State, bool, uint32) const {
+  virtual AssetDefs::State CalcStateByInputsAndChildren(AssetDefs::State, AssetDefs::State, bool, uint32, uint32) const {
     assert(false); // Can only call from sub-classes
     return AssetDefs::Bad;
   }

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -26,6 +26,23 @@
 #include "StorageManager.h"
 #include "CacheSizeCalculations.h"
 
+// Used by child classes of AssetVersionImpl
+class StateChangeException : public khException {
+ public:
+  const std::string location;
+  StateChangeException(const std::string & msg, const std::string & loc) :
+    khException(msg), location(loc) {}
+};
+
+// Helper struct for passing data about input and child states.
+struct InputAndChildStateData {
+  AssetDefs::State stateByInputs;
+  AssetDefs::State stateByChildren;
+  bool blockersAreOffline;
+  uint32 numInputsWaitingFor;
+  uint32 numChildrenWaitingFor;
+};
+
 /******************************************************************************
  ***  AssetVersionImpl
  ***
@@ -161,7 +178,7 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
     // parent asset (ex: parent is canceled, so these children
     // must also be canceled.
   }
-  virtual AssetDefs::State CalcStateByInputsAndChildren(AssetDefs::State, AssetDefs::State, bool, uint32, uint32) const {
+  virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const {
     assert(false); // Can only call from sub-classes
     return AssetDefs::Bad;
   }

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -303,7 +303,6 @@ AssetVersionImplD::SetProgress(double newprogress)
   progress = newprogress;
   if (!AssetDefs::Finished(state)) {
     theAssetManager.NotifyVersionProgress(GetRef(), progress);
-    PropagateProgress();
   }
 }
 
@@ -342,23 +341,6 @@ AssetVersionImplD::PropagateStateChange(const std::shared_ptr<StateChangeNotifie
 }
 
 void
-AssetVersionImplD::PropagateProgress(void)
-{
-  notify(NFY_VERBOSE, "PropagateProgress(%s): %s",
-         ToString(progress).c_str(), GetRef().toString().c_str());
-  for (auto p = parents.begin();
-       p != parents.end(); ++p) {
-    AssetVersionD parent(*p);
-    if (parent) {
-      parent->HandleChildProgress(GetRef());
-    } else {
-      notify(NFY_WARN, "'%s' has broken parent '%s'",
-             GetRef().toString().c_str(), p->toString().c_str());
-    }
-  }
-}
-
-void
 AssetVersionImplD::HandleTaskLost(const TaskLostMsg &)
 {
   // NoOp in base since composites don't need to do anything
@@ -381,12 +363,6 @@ AssetVersionImplD::HandleChildStateChange(NotifyStates, const std::shared_ptr<St
 {
   // NoOp in base since leaves don't need to do anything
   notify(NFY_VERBOSE, "AssetVersionImplD::HandleChildStateChange: %s", GetRef().toString().c_str());
-}
-
-void
-AssetVersionImplD::HandleChildProgress(const SharedString &) const
-{
-  // NoOp in base since leaves don't do anything
 }
 
 AssetDefs::State
@@ -1081,13 +1057,6 @@ CompositeAssetVersionImplD::HandleInputStateChange(NotifyStates, const std::shar
     SyncState(notifier);
   }
 }
-
-void
-CompositeAssetVersionImplD::HandleChildProgress(const SharedString &) const
-{
-  // TODO: - implement me some day
-}
-
 
 bool
 CompositeAssetVersionImplD::CacheInputVersions(void) const

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -1176,7 +1176,7 @@ CompositeAssetVersionImplD::ComputeState(void) const
     stateByChildren = AssetDefs::Queued;
   }
   
-  if (stateByChildren == AssetDefs::Queued || stateByChildren == AssetDefs::InProgress) {
+  if (stateByChildren == AssetDefs::InProgress) {
     numChildrenWaitingFor = numkids - numgood;
   }
   else {

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -1059,7 +1059,7 @@ CompositeAssetVersionImplD::HandleChildStateChange(NotifyStates newStates, const
   // I just reduce the number that I'm waiting for by the number that have
   // succeeded. However, if any of my assets have fallen out of a working state
   // without succeeding I still need to sync my state so that I can respond
-  // to the error encountered by my input.
+  // to the error encountered by my child.
   if (!children.empty() &&
       !CompositeStateCaresAboutInputsToo() &&
       state == AssetDefs::InProgress &&

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -1179,9 +1179,6 @@ CompositeAssetVersionImplD::ComputeState(void) const
   if (stateByChildren == AssetDefs::InProgress) {
     numChildrenWaitingFor = numkids - numgood;
   }
-  else {
-    numChildrenWaitingFor = 0;
-  }
 
   return stateByChildren;
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -680,7 +680,7 @@ LeafAssetVersionImplD::ComputeState(void) const
     // I'm currently not ready, so take whatever my inputs say
     newstate = statebyinputs;
   } else if (statebyinputs != AssetDefs::Queued) {
-    // My imputs have regressed
+    // My inputs have regressed
     // Let's see if I should regress too
 
     if (AssetDefs::Working(state)) {
@@ -725,7 +725,7 @@ LeafAssetVersionImplD::CalcStateByInputsAndChildren(const InputAndChildStateData
     // I'm currently not ready, so take whatever my inputs say
     newstate = stateData.stateByInputs;
   } else if (stateData.stateByInputs != AssetDefs::Queued) {
-    // My imputs have regressed
+    // My inputs have regressed
     // Let's see if I should regress too
 
     if (AssetDefs::Working(state)) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -59,8 +59,8 @@ AssetVersionImplD::StateChangeNotifier::AddToNotify(
     AssetDefs::State state,
     NotifyMap & map) {
   for (const auto & n : toNotify) {
-    // This ensures that the listener is in the list of listeners to notify
-    NotifyStates & elem = listenersToNotify[n];
+    // This ensures that n is in the list of assets to notify
+    NotifyStates & elem = map[n];
     if (state == AssetDefs::Succeeded) {
       ++elem.numSucceeded;
     }
@@ -121,8 +121,10 @@ AssetVersionImplD::StateChangeNotifier::DoNotify(
       switch(type) {
         case LISTENER:
           assetVersion->HandleInputStateChange(states, notifier);
+          break;
         case PARENT:
           assetVersion->HandleChildStateChange(states, notifier);
+          break;
       }
     } else {
       notify(NFY_WARN, "'%s' has broken %s '%s'",

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -101,13 +101,11 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   // will create a mutable handle itself if it
   // needs to call SetState
   void PropagateStateChange(const std::shared_ptr<StateChangeNotifier> = nullptr);
-  void PropagateProgress(void);
   virtual void HandleTaskLost(const TaskLostMsg &msg);
   virtual void HandleTaskProgress(const TaskProgressMsg &msg);
   virtual void HandleTaskDone(const TaskDoneMsg &msg);
   virtual void HandleChildStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const = 0;
-  virtual void HandleChildProgress(const SharedString &) const;
   virtual bool OfflineInputsBreakMe(void) const { return false; }
  public:
 
@@ -238,7 +236,6 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual bool CacheInputVersions(void) const;
   virtual void HandleChildStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
-  virtual void HandleChildProgress(const SharedString &) const;
   virtual void DelayedBuildChildren(void);
   virtual bool CompositeStateCaresAboutInputsToo(void) const { return false; }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -24,13 +24,6 @@
 #include <map>
 #include <memory>
 
-class StateChangeException : public khException {
- public:
-  const std::string location;
-  StateChangeException(const std::string & msg, const std::string & loc) :
-    khException(msg), location(loc) {}
-};
-
 // ****************************************************************************
 // ***  AssetVersionImplD
 // ****************************************************************************
@@ -205,12 +198,7 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
   virtual void DoClean(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
-  virtual AssetDefs::State CalcStateByInputsAndChildren(
-      AssetDefs::State stateByInputs,
-      AssetDefs::State stateByChildren,
-      bool blockersAreOffline,
-      uint32 numInputsWaitingFor,
-      uint32 numChildrenWaitingFor) const;
+  virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const override;
 };
 
 
@@ -246,12 +234,7 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual void Cancel(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual void Rebuild(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual void DoClean(const std::shared_ptr<StateChangeNotifier> = nullptr);
-  virtual AssetDefs::State CalcStateByInputsAndChildren(
-      AssetDefs::State stateByInputs,
-      AssetDefs::State stateByChildren,
-      bool blockersAreOffline,
-      uint32 numInputsWaitingFor,
-      uint32 numChildrenWaitingFor) const;
+  virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const override;
   virtual void DependentChildren(std::vector<SharedString> &out) const override;
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -41,8 +41,9 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   AssetVersionImplD& operator=(const AssetVersionImplD&);
 
  protected:
-  // Tracks the state of inputs to a given asset version that have changed. Each
-  // entry maps a state to the number of inputs that have changed to that state.
+  // Tracks the state of inputs and children to a given asset version that have
+  // changed. Each entry contains enough information for the asset to determine
+  // if it needs to change its state.
   struct NotifyStates {
     size_t numSucceeded;
     bool allWorkingOrSucceeded;

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -257,6 +257,7 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
       uint32 numChildrenWaitingFor) const;
   virtual void DependentChildren(std::vector<SharedString> &out) const override;
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
+                                         AssetDefs::State oldstate) override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -169,19 +169,19 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
                               public AssetVersionImplD
 {
  protected:
-  mutable uint32 numWaitingFor;
+  mutable uint32 numInputsWaitingFor;
 
   // since AssetVersionImpl and LeafAssetVersionImpl are virtual base
   // classes my derived classes will initialize it directly
   // therefore I don't need a contructor from storage
   LeafAssetVersionImplD(void)
       : AssetVersionImpl(), LeafAssetVersionImpl(),
-        AssetVersionImplD(), numWaitingFor(0) { }
+        AssetVersionImplD(), numInputsWaitingFor(0) { }
   // used when being contructed from an asset
   // these are the inputs I need to bind and attach to
   LeafAssetVersionImplD(const std::vector<SharedString> &inputs)
       : AssetVersionImpl(), LeafAssetVersionImpl(),
-        AssetVersionImplD(inputs), numWaitingFor(0) { }
+        AssetVersionImplD(inputs), numInputsWaitingFor(0) { }
 
   void SubmitTask(void);
   void ClearOutfiles(void);
@@ -205,7 +205,8 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
       AssetDefs::State stateByInputs,
       AssetDefs::State stateByChildren,
       bool blockersAreOffline,
-      uint32 numWaitingFor) const;
+      uint32 numInputsWaitingFor,
+      uint32 numChildrenWaitingFor) const;
 };
 
 
@@ -213,17 +214,19 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
                                    public AssetVersionImplD
 {
  protected:
+  mutable uint32 numChildrenWaitingFor;
+    
   // since AssetVersionImpl and CompositeAssetVersionImpl are virtual base
   // classes my derived classes will initialize it directly
   // therefore I don't need a contructor from storage
   CompositeAssetVersionImplD(void)
       : AssetVersionImpl(), CompositeAssetVersionImpl(),
-        AssetVersionImplD() { }
+        AssetVersionImplD(), numChildrenWaitingFor(0) { }
   // used when being contructed from an asset
   // these are the inputs I need to bind and attach to
   CompositeAssetVersionImplD(const std::vector<SharedString> &inputs)
       : AssetVersionImpl(), CompositeAssetVersionImpl(),
-        AssetVersionImplD(inputs) { }
+        AssetVersionImplD(inputs), numChildrenWaitingFor(0) { }
 
   virtual AssetDefs::State ComputeState(void) const;
   virtual bool CacheInputVersions(void) const;
@@ -244,10 +247,10 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
       AssetDefs::State stateByInputs,
       AssetDefs::State stateByChildren,
       bool blockersAreOffline,
-      uint32 numWaitingFor) const;
+      uint32 numInputsWaitingFor,
+      uint32 numChildrenWaitingFor) const;
   virtual void DependentChildren(std::vector<SharedString> &out) const override;
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
-                                         AssetDefs::State oldstate) override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -55,13 +55,13 @@ class AssetVersionImplD : public virtual AssetVersionImpl
     bool allWorkingOrSucceeded;
     NotifyStates() : numSucceeded(0), allWorkingOrSucceeded(true) {}
   };
-  enum NotifyType {LISTENER, PARENT};
 
   // Helper class to efficently send updates of state changes to other asset
   // versions.
   class StateChangeNotifier {
     private:
       using NotifyMap = std::map<SharedString, NotifyStates>;
+      enum NotifyType {LISTENER, PARENT};
       NotifyMap parentsToNotify;
       NotifyMap listenersToNotify;
       void AddToNotify(const std::vector<SharedString> &, AssetDefs::State, NotifyMap &);

--- a/earth_enterprise/src/fusion/autoingest/sysman/InNodeVertexIndexMap.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/InNodeVertexIndexMap.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 The Open GEE Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IN_NODE_VERTEX_INDEX_MAP_H
+#define IN_NODE_VERTEX_INDEX_MAP_H
+
+#include "DependentStateTree.h"
+
+// The depth_first_search function needs a way to map vertices to indexes. We
+// store a unique index inside each vertex; the code below provides a way for
+// boost to access them. These must be defined before including
+// depth_first_search.hpp.
+template <class Graph>
+class InNodeVertexIndexMap {
+  public:
+    typedef boost::readable_property_map_tag category;
+    typedef size_t value_type;
+    typedef value_type reference;
+    typedef typename Graph::vertex_descriptor key_type;
+
+    InNodeVertexIndexMap(const Graph & graph) : graph(graph) {};
+    const Graph & graph;
+};
+
+namespace boost {
+  template<>
+  struct property_map<DependentStateTree, vertex_index_t> {
+    typedef InNodeVertexIndexMap<DependentStateTree> const_type;
+  };
+
+  template<class Graph>
+  InNodeVertexIndexMap<Graph> get(vertex_index_t, const Graph & graph) {
+    return InNodeVertexIndexMap<Graph>(graph);
+  }
+
+  template<class Graph>
+  typename InNodeVertexIndexMap<Graph>::value_type get(
+      const InNodeVertexIndexMap<Graph> & map,
+      typename InNodeVertexIndexMap<Graph>::key_type vertex) {
+    return map.graph[vertex].index;
+  }
+}
+
+#endif

--- a/earth_enterprise/src/fusion/autoingest/sysman/LeafAssetVersion_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/LeafAssetVersion_unittest.cpp
@@ -29,7 +29,7 @@ class LeafAssetVersionImplDTest : public LeafAssetVersionImplD, public testing::
   // Handle multiple input state changes (useful for testing)
   void HandleInputStateChanges(AssetDefs::State myState, uint32 waiting, std::vector<AssetDefs::State> states) {
     state = myState;
-    numWaitingFor = waiting;
+    numInputsWaitingFor = waiting;
     InputStates inputStates;
     inputStates.numSucceeded = std::count_if(states.begin(), states.end(), [](AssetDefs::State s) {
       return s == AssetDefs::Succeeded;
@@ -50,9 +50,9 @@ class LeafAssetVersionImplDTest : public LeafAssetVersionImplD, public testing::
 };
 
 // In any case below in which stateSyncs ends up greater than zero, the value
-// of numWaitingFor at the end of the test does not matter. If stateSyncs is
+// of numInputsWaitingFor at the end of the test does not matter. If stateSyncs is
 // greater than zero, that means we called SyncState, which will set
-// numWaitingFor to the correct value in the actual code.
+// numInputsWaitingFor to the correct value in the actual code.
 
 TEST_F(LeafAssetVersionImplDTest, NewTest) {
   HandleInputStateChanges(AssetDefs::Waiting, 10, {AssetDefs::New});
@@ -71,13 +71,13 @@ TEST_F(LeafAssetVersionImplDTest, BlockedTest) {
 
 TEST_F(LeafAssetVersionImplDTest, QueuedTest) {
   HandleInputStateChanges(AssetDefs::Waiting, 10, {AssetDefs::Queued});
-  EXPECT_EQ(numWaitingFor, 10);
+  EXPECT_EQ(numInputsWaitingFor, 10);
   EXPECT_EQ(stateSyncs, 0);
 }
 
 TEST_F(LeafAssetVersionImplDTest, InProgressTest) {
   HandleInputStateChanges(AssetDefs::Waiting, 10, {AssetDefs::InProgress});
-  EXPECT_EQ(numWaitingFor, 10);
+  EXPECT_EQ(numInputsWaitingFor, 10);
   EXPECT_EQ(stateSyncs, 0);
 }
 
@@ -88,7 +88,7 @@ TEST_F(LeafAssetVersionImplDTest, FailedTest) {
 
 TEST_F(LeafAssetVersionImplDTest, SucceededTest) {
   HandleInputStateChanges(AssetDefs::Waiting, 10, {AssetDefs::Succeeded});
-  EXPECT_EQ(numWaitingFor, 9);
+  EXPECT_EQ(numInputsWaitingFor, 9);
   EXPECT_EQ(stateSyncs, 0);
 }
 
@@ -110,7 +110,7 @@ TEST_F(LeafAssetVersionImplDTest, BadTest) {
 TEST_F(LeafAssetVersionImplDTest, MultipleSucceededTest) {
   HandleInputStateChanges(AssetDefs::Waiting, 10,
       {AssetDefs::Succeeded, AssetDefs::Succeeded, AssetDefs::Succeeded});
-  EXPECT_EQ(numWaitingFor, 7);
+  EXPECT_EQ(numInputsWaitingFor, 7);
   EXPECT_EQ(stateSyncs, 0);
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/LeafAssetVersion_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/LeafAssetVersion_unittest.cpp
@@ -30,7 +30,7 @@ class LeafAssetVersionImplDTest : public LeafAssetVersionImplD, public testing::
   void HandleInputStateChanges(AssetDefs::State myState, uint32 waiting, std::vector<AssetDefs::State> states) {
     state = myState;
     numInputsWaitingFor = waiting;
-    InputStates inputStates;
+    NotifyStates inputStates;
     inputStates.numSucceeded = std::count_if(states.begin(), states.end(), [](AssetDefs::State s) {
       return s == AssetDefs::Succeeded;
     });

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -159,7 +159,7 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
             stateByChildren = AssetDefs::Queued;
           }
           
-          if (stateByChildren == AssetDefs::Queued || stateByChildren == AssetDefs::InProgress) {
+          if (stateByChildren == AssetDefs::InProgress) {
             numChildrenWaitingFor = numkids - numgood;
           }
           else {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -35,7 +35,7 @@
 class StateUpdater
 {
   private:
-    class UnsupportedException;
+    class UnsupportedException {};
     class SetStateVisitor;
 
     StorageManagerInterface<AssetVersionImpl> * const storageManager;

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -122,10 +122,9 @@ class MockVersion : public AssetVersionImpl {
     string GetOutputFilename(uint) const override { return string(); }
 };
 
-using VersionMap = map<AssetKey, shared_ptr<MockVersion>>;
-
 class MockStorageManager : public StorageManagerInterface<AssetVersionImpl> {
   private:
+    using VersionMap = map<AssetKey, shared_ptr<MockVersion>>;
     VersionMap versions;
     PointerType GetFromMap(const AssetKey & ref) {
       auto versionIter = versions.find(ref);

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -509,7 +509,7 @@ TEST_F(StateUpdaterTest, ChildQueued) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Queued;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Queued);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 3);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, SucceededChildren) {
@@ -538,7 +538,10 @@ TEST_F(StateUpdaterTest, ChildrenAndDependents) {
   GetMutableVersion(sm, "b")->state = AssetDefs::Succeeded;
   GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
   GetMutableVersion(sm, "d")->state = AssetDefs::Failed;
-  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State state) {
+    // Don't change the state of any children, just recalculate the parent's state
+    return !(state == AssetDefs::Succeeded || state == AssetDefs::Queued || state == AssetDefs::Failed);
+  });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 1);
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -68,7 +68,9 @@ class MockVersion : public AssetVersionImpl {
           onStateChangeCalled(0),
           notificationsSent(0),
           fatalLogFileWritten(false),
-          stateData({AssetDefs::New, AssetDefs::New, false, 0, 0}),
+          // Default the num*WaitingFor values to 999 instead of 0 to catch bugs where
+          // they are never set.
+          stateData({AssetDefs::New, AssetDefs::New, false, 999, 999}),
           stateChangeBehavior(NO_ERRORS) {
       type = AssetDefs::Imagery;
       state = STARTING_STATE;

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -367,6 +367,7 @@ TEST_F(StateUpdaterTest, NoInputsNoChildren) {
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Queued);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Succeeded);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 void OnlineInputBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs::State inputState) {
@@ -381,6 +382,7 @@ void OnlineInputBlockerTest(MockStorageManager & sm, StateUpdater & updater, Ass
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, false);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, BlockedInputBlocker) {
@@ -407,6 +409,7 @@ TEST_F(StateUpdaterTest, OfflineInputBlocker) {
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, true);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, BlockedAndOfflineInput) {
@@ -419,6 +422,7 @@ TEST_F(StateUpdaterTest, BlockedAndOfflineInput) {
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->blockersAreOfflineVal, false);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, WaitingOnInput) {
@@ -432,6 +436,7 @@ TEST_F(StateUpdaterTest, WaitingOnInput) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Waiting);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, SucceededInputs) {
@@ -445,6 +450,7 @@ TEST_F(StateUpdaterTest, SucceededInputs) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Queued);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 void ChildBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs::State inputState) {
@@ -457,6 +463,7 @@ void ChildBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Blocked);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, FailedChildBlocker) {
@@ -489,6 +496,7 @@ TEST_F(StateUpdaterTest, ChildInProgress) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 2);
 }
 
 TEST_F(StateUpdaterTest, ChildQueued) {
@@ -501,6 +509,7 @@ TEST_F(StateUpdaterTest, ChildQueued) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Queued;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Queued);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 3);
 }
 
 TEST_F(StateUpdaterTest, SucceededChildren) {
@@ -513,6 +522,7 @@ TEST_F(StateUpdaterTest, SucceededChildren) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::Succeeded);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 0);
 }
 
 TEST_F(StateUpdaterTest, ChildrenAndDependents) {
@@ -530,6 +540,7 @@ TEST_F(StateUpdaterTest, ChildrenAndDependents) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Failed;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 1);
 }
 
 TEST_F(StateUpdaterTest, ChildrenAndInputs) {
@@ -551,6 +562,7 @@ TEST_F(StateUpdaterTest, ChildrenAndInputs) {
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByChildrenVal, AssetDefs::InProgress);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateByInputsVal, AssetDefs::Waiting);
   ASSERT_EQ(GetMutableVersion(sm, "a")->numInputsWaitingForVal, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->numChildrenWaitingForVal, 2);
 }
 
 // This tests a tricky corner case. d and e are inputs/children of a, but they


### PR DESCRIPTION
Parents are notified whenever their child's state changes. When this happens, they check the states of all of their children to calculate their own state. However, in many cases the parent's state will not change: for example, if a parent is waiting on 100 children and one of them transitions to Succeeded, the parent's state will not change because it is still waiting on 99 other children. Thus, the constant re-checking of child states every time a parent receives a notification is unnecessary.

There is a similar issue when listeners are notified that their input state changed, but their are optimizations in HandleInputStateChange that reduce the extra work. Listeners keep track of the number of inputs they are waiting for and don't recalculate their state until that number goes to 0. This PR implements the same kind of optimization in HandleChildStateChange.

I also removed the PropagateProgress handling that loaded all the parents just so it could call an empty function on them.

This PR also updates the release notes for other work done in 5.3.2 that has not yet been included in release notes.

And, of course, I did some minor clean up and refactoring. The code related to `InNodeVertexIndexMap` is unchanged; it's only moved to a different file to make things cleaner.

Fixes #1418.