### PR TITLE
installGEE initial upload

### DIFF
--- a/docs/geedocs/5.3.2/answer/installGEE/beforeYouInstallGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/beforeYouInstallGEE.rst
@@ -1,0 +1,309 @@
+|Google logo|
+
+==========================================
+Before you install Google Earth Enterprise
+==========================================
+
+.. container::
+
+   .. container:: content
+
+      -  :ref:`Overview <Overview_Before_Install_GEE>`
+      -  :ref:`Configuring Your Host Volumes <Configuring_Host_Volumes>`
+      -  :ref:`Configuring Multiple Storage Devices <Configuring_Multiple_Storage_Devices_GEE>`
+      -  :ref:`Planning the Location of Your Asset
+         Root <Planning_Location_Asset_Root_GEE>`
+      -  :ref:`Planning the Location of Your Publish Root <Planning_Location_Publish_Root_GEE>`
+      -  :ref:`Setting Up Google Earth Enterprise Users <Setting_Up_GEE_Users>`
+      -  :ref:`Deciding Which Products To Install <Deciding_Which_Products_Install>`
+
+      --------------
+
+      .. _Overview_Before_Install_GEE:
+      .. rubric:: Overview
+
+      Before you install the Google Earth Enterprise software, you must
+      configure your hardware, network, and Google Earth Enterprise
+      users. You must also think about where you want to store
+      Google Earth Enterprise Fusion data and where you want to publish
+      Google Earth Enterprise Fusion databases. You will need to
+      provide this information during installation, but you should
+      consider these decisions in advance before you begin the
+      installation procedure.
+
+      The following sections provide information about what the Google
+      Earth Enterprise software requires in each of these areas.
+
+      .. container:: alert
+
+         Be sure to complete all of the tasks described in these
+         sections before installing the Google Earth Enterprise
+         software.
+
+      --------------
+
+      .. _Configuring_Host_Volumes:
+      .. rubric:: Configuring The Host Volumes
+
+      Google Earth Enterprise Fusion data (resources, projects, and
+      databases) require a local name and network path to resolve the
+      locations of both source files and related Google Earth Enterprise
+      Fusion data. For that reason, you cannot change the network naming
+      convention you adopt for host volumes without invalidating Google
+      Earth Enterprise Fusion data.
+
+      On a single workstation setup (non-network based), the network
+      path and local path for Google Earth Enterprise Fusion data are
+      identical. However, because migration to a network-based
+      configuration is inevitable, we recommend that you use a network
+      naming convention for any new volume hosting Google Earth
+      Enterprise Fusion data or source data, whether it is part of a
+      network initially or not.
+
+      Because Linux systems frequently use either ``/vol(*)`` or
+      ``/``\ ``data(*)`` as the local volume definition on a new system,
+      using this convention for the initial Google Earth Enterprise
+      Fusion data location can cause name conflicts if you later switch
+      from a single workstation to a network-based configuration. For
+      example, if you initially define ``/vol1/assets`` as the network
+      location for a Google Earth Enterprise Fusion *asset root*, and
+      you later add another workstation that has a local volume called
+      ``/vol1``, that workstation cannot reference
+      ``/vol1/assets``\ through the network because of the name conflict
+      with its local volume definition. (See :ref:`Planning the Location of
+      Your Asset Root <Planning_Location_Asset_Root_GEE>` for more
+      information about the asset root.)
+
+      You can work around this problem by adopting a unique naming
+      convention for all volumes on your network (such as ``/vol1`` ...
+      ``/voln``). However, we suggest that you use ``/gevol`` as an
+      alternative volume naming convention because it is unlikely to
+      conflict with standard Linux volume definitions. The following
+      diagram illustrates this point.
+
+      .. note::
+
+         **Note:** On a single workstation that does not mount
+         ``/gevol`` on a network, ``/gevol`` is also required as a local
+         volume definition.
+
+      --------------
+
+      .. _Configuring_Multiple_Storage_Devices_GEE:
+      .. rubric:: Configuring Multiple Storage Devices
+
+      Google Earth Enterprise Server and the Google Earth Enterprise
+      Fusion asset root, source volumes, and publish root require large
+      amounts of disk storage space. Google Earth Enterprise Fusion
+      requires about three times as much storage space as Google Earth
+      Enterprise Server. The storage space can be either in the form of
+      internal disks, directly attached storage devices,
+      network-attached storage (NAS) devices, or storage area network
+      (SAN) devices. Typically, these devices are configured into
+      redundant arrays of independent disks (RAIDs) and presented to the
+      operating system as volumes. Volumes can be several hundred
+      gigabytes up to tens of terabytes.
+
+      The difference between configuring a workstation with a single
+      hard disk and a workstation with multiple volumes relates to the
+      mount point definitions for the source and asset volumes.When
+      configuring a Linux workstation, we strongly recommend that you
+      use the following mount point naming conventions:
+
+      -  **Single volume**
+
+         Mount the single drive to slash (/). All data
+         (``/gevol/assets``, ``/gevol/src``, and
+         ``/gevol/published_dbs``) resides on that drive with the local
+         path defined using the ``/gevol`` naming convention.
+
+      -  **Two volumes - a small system volume and a larger data
+         volume**
+
+         Mount the small system drive to slash (``/``). Mount the larger
+         data drive to ``/gevol``. Source and asset data volumes can
+         then be defined as ``/gevol/assets`` and ``/gevol/src``.
+
+      -  **Three volumes - a small system volume and two larger data
+         volumes**
+
+         Mount the small system drive to slash (``/``). Mount the first
+         large data drive to ``/gevol/assets``. Mount the second large
+         data drive to ``/gevol/src``.
+
+      -  **More than three volumes**
+
+         There are several strategies for storing very large data sets.
+         Google Earth Enterprise Fusion can read from and write to
+         multiple volumes. For more information, you can request help on
+         our `Slack channel <http://slack.opengee.org/>`_.
+
+      It is also important to keep internal and external storage devices
+      separated so that if your internal server goes down, it does not
+      affect your ability to serve published data to external clients.
+      Likewise, if your external server goes down, you can replace it
+      and publish from the internal storage device. In addition (and
+      perhaps more important), keeping your internal and external
+      storage devices separate reduces the possibility of performance
+      problems that could occur if you are building a large data set or
+      a client requests a time-consuming search.
+
+      --------------
+
+      .. _Planning_Location_Asset_Root_GEE:
+      .. rubric:: Planning the Location of Your Asset Root
+
+      During the Google Earth Enterprise Fusion installation procedure,
+      you must specify a location for your *asset root*. The asset root
+      is the main location where all of the assets (resources, map
+      layers, projects, and databases) are stored that are created with
+      Google Earth Enterprise Fusion.
+
+      The asset root must be located on a single volume. It cannot be
+      split across multiple volumes. Therefore, it is important to think
+      ahead and allocate as much storage space as possible for the asset
+      root.
+
+      Unless you have an established partitioning scheme for all of your
+      storage devices, we recommend that you accept the default
+      partitioning scheme presented to you while installing Linux. That
+      scheme gives you a reasonable amount of space in ``/opt`` for
+      Google Earth Enterprise and other system software, a small amount
+      of space for ``/home``, and the remaining space on your storage
+      device for the asset root.
+
+      We also recommend that you accept the default volume designation
+      for your asset root during installation (``/gevol/assets``),
+      unless that name conflicts with your established naming
+      conventions.
+
+      .. note::
+
+         **Note:** we recommend that you dedicate a network-attached
+         storage device (NAS) for your asset root.
+
+      .. _Planning_Location_Publish_Root_GEE:
+      .. rubric:: Planning the Location of Your Publish Root
+
+      During the Google Earth Enterprise Server installation procedure,
+      you must specify a volume for the *publish root*. The publish root
+      is the directory in which all of your published databases are
+      stored.
+
+      If you specify the same volume as the asset root, when you publish
+      a database, Google Earth Enterprise Fusion registers the database
+      on the specified volume and sets symbolic links to the database
+      files. If you specify a different volume than the asset root, when
+      you publish a database, Google Earth Enterprise Fusion registers
+      the database on the specified volume and then copies all of the
+      database files to the designated volume.
+
+      For example, if you specify ``/gevol/assets`` for your asset root
+      and ``/gevol/published_dbs`` for your publish root, when you
+      publish a database, Google Earth Enterprise Fusion registers the
+      database on ``gevol`` and sets hard links to the database files;
+      no copying is necessary.
+
+      However, if you specify ``/gevol/assets`` for your asset root and
+      ``/data1/published_dbs`` for your publish root, when you publish a
+      database, Google Earth Enterprise Fusion copies all of the
+      database files from ``/gevol/assets`` to ``/data1/published_dbs``
+      (unless you allow symbolic links during installation). Copying
+      takes more time as well as extra disk space.
+
+      --------------
+
+      .. _Setting_Up_GEE_Users:
+      .. rubric:: Setting Up Google Earth Enterprise Users
+
+      The Google Earth Enterprise installer automatically configures
+      certain system users to perform background tasks at the system
+      level. If you accept the default user names and allow the
+      installer to create those users on your local workstation, you are
+      implementing local authentication only. Local authentication is
+      designed for standalone workstations only.
+
+      If you are using Google Earth Enterprise over a network with at
+      least two workstations, storage devices, and/or servers, we
+      strongly recommend that you use a centralized network
+      authentication system, such as LDAP, NIS, or one of the many
+      commercially available systems.
+
+      If you use a centralized network authentication system, you must
+      add the following users to your authentication system’s user list:
+
+      -  **gefusionuser**
+      -  **geapacheuser**
+      -  **gepguser**
+
+      The primary group for all of these users is **gegroup**.
+
+      If you are in a multi-user environment in which multiple
+      workstations share a common asset root on a NAS/SAN, **these users
+      must have the same UID on all devices, so you must assign them
+      explicitly in both your network authentication system and in
+      GEE**.
+
+      Be sure to configure each GEE workstation, storage device, and GEE
+      Server to use your network authentication system. For more
+      information, see your network authentication system documentation.
+
+      .. rubric:: Customizing Google Earth Enterprise User Names
+
+      You can use customized user names and group names. Specify the
+      custom user and group names when running the installers.
+
+      .. _Deciding_Which_Products_Install:
+      .. rubric:: Deciding Which Products To Install
+
+      You do not need to install all products on all devices. To
+      determine which products to install, follow these general
+      guidelines:
+
+      -  Install Google Earth Enterprise Fusion and Google Earth
+         Enterprise Server on the server machine selected to import your
+         source GIS data and create flyable 3D and 2D databases. A
+         system in this configuration is typically called the
+         "development machine" since its primary task is to build
+         flyable databases and only a small number of users will view
+         the flyable data for quality assurance testing.
+      -  Install the Google Earth Enterprise Fusion tutorial files on
+         the "development machine" for users who are new to Google Earth
+         Enterprise Fusion.
+      -  Install only the Google Earth Enterprise Server software on the
+         server machine selected to only host flyable 3D and 2D
+         databases only. All authorized end users will connect to this
+         system -- typically referred to as the "production machine" --
+         to view the flyable databases. This machine must be accessible
+         through the network from the development machine in order for
+         database publishes. Users who will not have direct network
+         access to their production machines, or users who plan to
+         update remote systems with external hard drives, must also
+         install the "Disconnected Publishing Add-on" for additional
+         tools.
+
+      The following diagram shows a sample system configuration.
+
+      |Networking diagram|
+
+      In this example, there are two server-class machines assigned to
+      data building and data hosting tasks, plus one workstation to be
+      used for data management.
+
+      A GIS specialist uses the workstation to remotely log in to the
+      development machine with Google Earth Enterprise Fusion Pro
+      installed to import source GIS data and output a flyable globe to
+      publish for end users. Google Earth Enterprise Server software is
+      also installed on the development machine so the GIS specialist
+      may perform quality assurance tests on the data before publishing
+      to the production machine.
+
+      Only Google Earth Enterprise Server is installed on the production
+      machine which authorized end users in the network may access with
+      Google Earth Enterprise Client (EC) for 3D databases, or a
+      compatible web browser for 2D databases.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px
+.. |Networking diagram| image:: ../../art/fusion/install/entnetwork.jpg

--- a/docs/geedocs/5.3.2/answer/installGEE/beforeYouInstallGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/beforeYouInstallGEEServer.rst
@@ -1,0 +1,219 @@
+|Google logo|
+
+=============================
+Before you install GEE Server
+=============================
+
+.. container::
+
+   .. container:: content
+
+      Before installing Google Earth Enterprise (GEE) Server, you must
+      configure your hardware, network, and GEE users. You should also
+      carefully decide in advance where you want to store Fusion
+      data and where you want to publish Fusion databases. You must
+      provide this information during installation. The following
+      sections provide information about GEE requirements,
+      considerations, and best practices. Be sure to complete all of the
+      tasks described in these sections before installing GEE Server.
+
+      .. rubric:: Upgrading
+
+      To prevent compatibility issues, you must run the same version of
+      GEE Server and Fusion. If you upgrade Fusion without upgrading GEE
+      Server, you will not be able to publish to the GEE Server database.
+
+      .. rubric:: Configuring Your Host Volumes
+
+      The best practices for naming your host volumes are:
+
+      -  **Network naming convention**. You should use a network naming
+         convention for any new volume that hosts Fusion or source data,
+         whether it is initially part of a network or not, because you
+         will almost certainly migrate to a network-based configuration
+         eventually. Fusion requires both a network path and local name
+         to resolve the locations of source files and related Fusion
+         data, so changing the host volume name or path invalidates
+         Fusion data. On a single workstation setup, the local and
+         network paths are identical, but on a network-based
+         configuration they are not.
+      -  **/gevol**. You should use /``gevol`` as your volume naming
+         convention because it is unlikely to conflict with standard
+         Linux volume definitions. Linux systems frequently use either
+         ``/vol(*)`` or ``/``\ ``data(*)`` as the local volume
+         definition on a new system, so using this convention for Fusion
+         can cause name conflicts if you later switch from a single
+         workstation to a network-based configuration. For example, if
+         you initially define ``/vol1/assets`` as the network location
+         for a Fusion *asset root*, and you later add another
+         workstation that has a local volume called ``/vol1``, that
+         workstation cannot reference ``/vol1/assets``\ through the
+         network because of the name conflict with its local volume
+         definition. (See :ref:`Planning the Location of Your Asset Root <Planning_Location_Asset_Root_GEE>` for
+         more information about the asset root.) You can avoid this
+         conflict by using a unique naming convention for all volumes
+         on your network (such as /``vol1``... /``vol``\ *n*), but
+         /``gevol`` is a good choice because it is descriptive.
+
+      .. rubric:: Configuring Multiple Storage Devices
+
+      GEE Server and the Fusion asset root, source volumes, and publish
+      root require large amounts of disk storage space. Fusion requires
+      about three times as much storage space as GEE Server. The storage
+      space can be either in the form of internal disks, directly
+      attached storage devices, network-attached storage (NAS) devices,
+      or storage area network (SAN) devices. Typically, these devices
+      are configured into redundant arrays of independent disks (RAIDs)
+      and presented to the operating system as volumes. Volumes can
+      range in size from several hundred gigabytes to tens of
+      terabytes.
+
+      The difference between configuring a workstation with one, two, or
+      three volumes is how you define the mount point for the source and
+      asset volumes.
+
+      When configuring a Linux workstation, it is best practice to use
+      the following mount point naming conventions:
+
+      -  **Single volume**
+
+         Mount the single drive to slash (/). All data
+         (``/gevol/assets``, ``/gevol/src``, and
+         ``/gevol/published_dbs``) resides on that drive with the local
+         path defined using the /``gevol`` naming convention.
+
+      -  **Two volumes - a small system volume and a larger data
+         volume**
+
+         Mount the small system drive to slash (``/``). Mount the larger
+         data drive to ``/gevol/``. Source and asset data volumes can
+         then be defined as ``/gevol/assets`` and ``/gevol/src``.
+
+      -  **Three volumes - a small system volume and two larger data
+         volumes**
+
+         Mount the small system drive to slash (``/``). Mount the first
+         large data drive to ``/gevol/assets``. Mount the second large
+         data drive to ``/gevol/src``.
+
+      -  **More than three volumes**
+
+         There are several strategies for storing very large data sets.
+         Fusion can read from and write to multiple volumes. For more
+         information, you can request help on our `Slack
+         channel <http://slack.opengee.org/>`_.
+
+      It is also important to keep internal and external storage devices
+      separated so that if your internal server goes down, it does not
+      affect your ability to serve published data to external clients.
+      Likewise, if your external server goes down, you can replace it
+      and publish from the internal storage device. Perhaps more
+      importantly, keeping your internal and external storage devices
+      separate reduces the possibility of performance problems that
+      could occur if you are building a large data set or if a client
+      requests a time-consuming search.
+
+      .. rubric:: Planning the Location of Your Publish Root
+
+      During GEE Server installation, you must specify a volume for the
+      *publish root*. The publish root is the directory in which all of
+      your published databases are stored.
+
+      **If you specify a different volume than the asset root**:
+
+      Whenever you publish a database, Fusion registers the database on
+      the specified volume and then copies all of the database files to
+      the designated volume.
+
+      For example, if you specify ``/gevol/assets`` for your asset root
+      and ``/data1/published_dbs`` for your publish root, whenever you
+      publish a database, Fusion copies all of the database files from
+      ``/gevol/assets`` to ``/data1/published_dbs`` (unless you allow
+      symbolic links during installation). Copying takes more time as
+      well as extra disk space.
+
+      **If you specify the same volume as the asset root**:
+
+      Whenever you publish a database, Fusion registers the database on
+      the specified volume and sets symbolic links to the database
+      files.
+
+      For example, if you specify ``/gevol/assets`` for your asset root
+      and ``/gevol/published_dbs`` for your publish root, whenever you
+      publish a database, Fusion registers the database on ``gevol`` and
+      sets hard links to the database files. No copying is necessary.
+
+      .. rubric:: Setting Up GEE Users
+
+      The GEE installer automatically configures certain system users to
+      perform background tasks at the system level. If you accept the
+      default user names and allow the installer to create those users
+      on your local workstation, you are implementing local
+      authentication only. Local authentication is designed for
+      standalone workstations only.
+
+      If you are using GEE over a network with at least two
+      workstations, storage devices, or servers, the best practice is to
+      use a centralized network authentication system such as LDAP, NIS,
+      or one of the many commercially available systems.
+
+      If you use a centralized network authentication system, you must
+      add the following users to your authentication system’s user list:
+
+      -  **gefusionuser**
+      -  **geapacheuser**
+      -  **gepguser**
+
+      The primary group for all of these users is **gegroup**.
+
+      If you are in a multi-user environment in which multiple
+      workstations share a common asset root on a NAS/SAN, **these users
+      must have the same UID on all devices, so you must assign them
+      explicitly in both your network authentication system and in
+      GEE**.
+
+      Be sure to configure each GEE workstation, storage device, and GEE
+      Server to use your network authentication system. For more
+      information, see your network authentication system documentation.
+
+      .. rubric:: Customizing GEE User Names
+
+      You can use customized user and group names when installing
+      Fusion. Specify the custom user and group names via the ``-u`` and
+      ``-g`` options when running the installer. The GEE Server
+      installer does not currently provide the option to customize user
+      and group names.
+
+      .. rubric:: Deciding Which Products To Install
+
+      You do not need to install all products on all devices. Follow the
+      guidelines below.
+
+      **Development machine**:
+
+      -  Install both Fusion and GEE Server on the server machine that
+         you want to use to import your source GIS data and create
+         flyable 3D and 2D databases. A system in this configuration is
+         typically called the "development machine" since its primary
+         task is to build flyable databases and only a small number of
+         users will view the flyable data for quality assurance testing.
+      -  Install the Fusion tutorial files on the "development machine"
+         for users who are new to Fusion or to this version of Fusion.
+         You can also use the Fusion tutorial files to test publishing.
+
+      **Production machine**:
+
+      -  Install only the GEE Server on the server machine that hosts
+         flyable 3D and 2D databases. All authorized end-users will
+         connect to this system -- typically referred to as the
+         "production machine" -- to view the flyable databases. This
+         machine must be accessible through the network from the
+         development machine in order to publish databases.
+      -  Users who will not have direct network access to their
+         production machines, or users who plan to update remote systems
+         with external hard drives, must also install the "Disconnected
+         Publishing Add-on" for additional tools.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/buildInstallGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/buildInstallGEE.rst
@@ -1,0 +1,33 @@
+|Google logo|
+
+=========================
+Build and install GEE 5.x
+=========================
+
+.. container::
+
+   .. container:: content
+
+      Currently, Google Earth Enterprise must be built from source
+      before it can be installed. Refer to the `EarthEnterprise
+      Wiki <https://github.com/google/earthenterprise/wiki/Build-Instructions>`__
+      for instructions. Once you have built Google Earth Enterprise you
+      can proceed to the :doc:`install
+      instructions <4492598>`.
+
+      The **GEE Server** software package contains:
+
+      -  GEE Server software
+      -  GEE documentation
+
+      The **Fusion** software package contains:
+
+      -  Fusion software
+      -  Fusion tutorial files
+      -  GEE documentation
+      -  Example data files
+      -  Configuration files
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/hostnameFQDNConfig.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/hostnameFQDNConfig.rst
@@ -1,0 +1,73 @@
+|Google logo|
+
+======================================================
+Hostname and Fully Qualified Domain Name Configuration
+======================================================
+
+.. container::
+
+   .. container:: content
+
+      .. rubric:: Hostname and Fully Qualified Domain Name Configuration
+
+      In order to make sure that the Apache server correctly determines
+      the Fully Qualified Domain Name (FQDN) of the server and that the
+      virtual hosts use the correct server URL, the hostname should be
+      configured correctly. This is preferred instead of modifying the
+      Apache server name configuration so that all the software looks to
+      the same source for determining FQDNs. If the command
+      ``hostname -f`` returns the correct FQDN hostname then the system
+      is correctly configured to run Open GEE. If not the following
+      instructions may help.
+
+      Ideally the network where GEE is installed has a DNS set up to
+      resolve hostnames so that IP traffic can be routed appropriately.
+      However in cases where there is no DNS, static hostnames can be
+      used as well. With static hostnames the ``hostname`` or
+      ``hostnamectl`` command should be used to set the hostname to its
+      FQDN. The ``/etc/hostname`` file should be updated to match as
+      well so the name stays after reboots. If setting the hostname to
+      the FQDN is not possible, then setting the FQDN in the
+      ``/etc/hosts`` file is necessary. When using a static hostname,
+      some operating systems may still give a warning on Apache startup
+      even if it correctly determined the FQDN. Adding the FQDN to
+      ``/etc/hosts`` would fix this as well. If adding the FQDN to
+      ``/etc/hosts`` is needed, then the FQDN followed by just the host
+      portion should be added to the line that contains the IP address
+      the server will be listening on. This should be the first line of
+      the file:
+
+      ``127.0.0.1  myserver.mydomainname.com myserver localhost``
+
+      If GEE is not using DNS other clients that connect to the server
+      non-locally would need to have the same static mapping set up in
+      their hosts files since the server hostname would not be resolved
+      dynamically.
+
+      When determining where to look for the correct FQDN Apache calls
+      ``hostname`` which will use a resolver. The system configuration
+      determines what the order is for resolving the FQDN. If the
+      ``/etc/nsswitch.conf`` file is being used there is a line like
+      this that defines the order:
+
+      ``hosts:      dns myhostname files``
+
+      This example shows that the DNS on the network would be queried
+      first. If that does not define the FQDN then the hostname would be
+      queried. If the FQDN is still not defined then configuration files
+      would be queried, mainly ``/etc/hosts``.
+
+      If the ``/etc/host.conf`` file is being used to resolve the
+      hostname, then there is a line like this that defines the order:
+
+      ``order hosts,bind``
+
+      In this example hosts refers to the ``/etc/hosts`` file and is
+      checked first, and bind refers to the DNS.
+
+      Here is :doc:`another note <172794>` on the server
+      hostname.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/installGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/installGEE.rst
@@ -1,0 +1,17 @@
+|Google logo|
+
+==================================
+Installing Google Earth Enterprise
+==================================
+
+.. container::
+
+   .. container:: content
+
+      You can install OpenGEE via the command line. For instructions,
+      see the GEE wiki at
+      `https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server <https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server>`_.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/installGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/installGEEServer.rst
@@ -1,0 +1,17 @@
+|Google logo|
+
+=====================
+Installing GEE Server
+=====================
+
+.. container::
+
+   .. container:: content
+
+      You can install GEE Server via the command line. For
+      instructions, see the GEE wiki at
+      `https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server <https://github.com/google/earthenterprise/wiki/Install-Fusion-or-Earth-Server>`_.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/installOverviewGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/installOverviewGEE.rst
@@ -1,0 +1,39 @@
+|Google logo|
+
+=============================
+Installation overview for GEE
+=============================
+
+.. container::
+
+   .. container:: content
+
+      This installation guide describes the system requirements for
+      Google Earth Enterprise Server and Google Earth Enterprise Fusion
+      Pro and provides the preparation steps and installation
+      instructions for those two products.
+
+      Google Earth Enterprise software is available at
+      `https://github.com/google/earthenterprise <https://github.com/google/earthenterprise>`_. GEE Fusion Pro and
+      Server can be installed separately.
+
+      **Google Earth Enterprise Fusion Pro** includes:
+
+      -  Google Earth Enterprise Fusion software
+      -  Google Earth Enterprise Fusion tutorial files
+      -  Google Earth Enterprise documentation
+      -  Example data files
+      -  Configuration files
+
+      **Google Earth Enterprise Server** includes:
+
+      -  Google Earth Enterprise Server software
+      -  Google Earth Enterprise documentation
+
+      .. rubric:: Learn more
+
+      -  :doc:`3499934`
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/introGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/introGEEServer.rst
@@ -1,0 +1,17 @@
+|Google logo|
+
+==========================
+Introduction to GEE Server
+==========================
+
+.. container::
+
+   .. container:: content
+
+      This documentation includes instruction for installing GEE Server.
+      For additional information, see the GEE wiki at
+      `https://github.com/google/earthenterprise/wiki <https://github.com/google/earthenterprise/wiki>`_.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/sysReqFusionGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/sysReqFusionGEEServer.rst
@@ -1,0 +1,161 @@
+|Google logo|
+
+=============================================
+System requirements for Fusion and GEE Server
+=============================================
+
+.. container::
+
+   .. container:: content
+
+      .. rubric:: Hardware Requirements
+
+         -  Minimum 2 dual-core Intel or AMD CPUs; 2.0 GHz or higher
+            recommended.
+         -  Minimum 4 GB RAM (8 GB RAM for Red Hat Enterprise Linux);
+            8 GB RAM (or more) per core recommended for Fusion.
+         -  Minimum 500 GB of total hard disk storage.
+         -  A graphics card with at least 64 MB video RAM (NVIDIA
+            GeForce4 or higher preferred for Fusion GUI). You can
+            install this graphics card in a separate workstation that
+            accesses Fusion.
+
+         **Note:** If you plan on cutting globes, this processing can
+         be CPU-intensive and you may also need to plan on providing
+         more storage depending on the size of the globes.
+
+         **Note on virtual machines**: Fusion can be both CPU and I/O
+         intensive. For optimal, stable performance, you should
+         install it only on physical (non-virtual) machines. You can
+         run GEE Server on a virtualized platform, provided the guest
+         OS is one of our supported 64-bit distributions and you
+         allocate sufficient resources to the VM.
+
+      .. rubric:: Software Requirements
+
+         **Operating Systems**
+
+         Google Earth Enterprise is supported only on the 64-bit
+         versions of the operating systems listed below.
+
+            -  Red Hat Enterprise Linux 6.x and 7.x, including the most
+               recent security patches
+            -  CentOS 6.x and 7.x
+            -  Ubuntu 14.04 LTS and 16.04 LTS
+
+         **Browsers**
+
+         Google Earth Enterprise is supported on the following
+         browsers on all operating systems:
+
+            -  The latest version of Google Chrome
+            -  The latest version of Mozilla Firefox
+
+         However, Google Earth Enterprise should work with any modern
+         browser.
+
+         **Google Earth Enterprise Client (EC)**
+
+         The following versions of Google Earth Enterprise Client
+         (EC) are recommended for use with Google Earth
+         Enterprise:
+
+            -  Version 5.x, use Google Earth EC version 7.0 or later
+            -  Version 4.4, use Google Earth EC version 6.1 or later
+
+          .. note::
+
+         **Note:** Although older versions of Google Earth EC,
+         i.e., 6.0 and earlier, *may* still connect to Google
+         Earth Enterprise or Portable 3D databases, not all
+         features will be available. Also, as Google Earth
+         Enterprise has not been tested or certified against older
+         versions of Google Earth EC, there may be unknown
+         operational problems.
+
+         Google Earth Enterprise Client (EC) is supported on the
+         following platforms:
+
+         -  Windows
+         -  Mac
+         -  Linux
+
+         **Unsupported Versions and Environments**
+
+         There are many variations of operating systems and related
+         software; point ("x.x") releases can sometimes contain
+         changes that can impact your GEE installation. Although an
+         unsupported version of these software packages may appear to
+         function correctly, their use in a production environment is
+         not recommended. Unexpected results may occur.
+
+         Where possible, you should adhere to the hardware and
+         software specifications listed in this document. If a
+         problem arises in an unsupported configuration, we may not
+         be able to help you resolve it.
+
+      .. rubric:: Network Requirements
+
+         Each destination server must meet the requirements below
+         before you install GEE, and you must not change these
+         settings after deploying GEE. The hostname must be the FQDN
+         (Fully Qualified Domain Name) of your destination server, e.g.,
+         ``myserver.mydomainname.com``. Refer to :doc:`Hostname FQDN
+         Configuration <HostnameFqdnConfiguration>`
+         for additional details.
+
+         You can verify the hostname of your workstation by entering
+         ``hostname`` at a shell prompt, and you can verify the
+         network connection by using the ``ping`` command to reach
+         other hosts in the same network. The requests should resolve
+         using both and IP address and the FQDN.
+
+            -  Hostname registered in DNS
+            -  Hosts file is acceptable for small-scale systems
+            -  Allocated IP addresses
+            -  Correct network routing paths
+            -  Network connectivity (Ports 80 and 22; Port 443 for
+               HTTPS)
+            -  Default installation of a Supported OS
+            -  Java Development Kit or Runtime Environment (must
+               download from Sun; use version 1.6.0_12 or newer)
+            -  OpenSSL 0.9.8y (on OS media)
+            -  Python 2.7.5 (on OS media)
+            -  Storage for all source data and asset tree
+            -  May be local storage (i.e., RAID 5 array)
+            -  NAS storage via NFS acceptable
+            -  SAN storage acceptable
+            -  USB drive not recommended
+
+      .. rubric:: Supported Configurations
+
+         Google Earth Enterprise products are developed per the
+         hardware and software requirements listed above. The
+         products are intended to be installed according to the
+         processes described in this documentation. When installing
+         Google Earth Enterprise in an unsupported environment, there
+         are risks that the products may not operate as intended.
+
+         Some factors that could affect your installation and
+         deployment are:
+
+         -  Installations on unsupported operating systems.
+         -  Improperly configured DNS.
+         -  Third party or non-default permissions or security measures
+            (no root access, sudo blockers, etc.).
+         -  Complex proxy configurations that prevent the network
+            communications from operating as intended.
+
+      .. rubric:: Important System Security Information
+
+         We strongly recommend that users who wish to host 3D and 2D
+         globes online with Google Earth Enterprise follow
+         industry standard security practices and review their
+         systems and networks before enabling access. Although we
+         takes every precaution to secure the information, there is
+         always the risk of unauthorized access outside of a closed
+         or protected network.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/sysReqGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/sysReqGEEServer.rst
@@ -1,0 +1,157 @@
+|Google logo|
+
+==================================
+System Requirements for GEE Server
+==================================
+
+.. container::
+
+   .. container:: content
+
+      Hardware Requirements
+
+         -  Minimum 2 dual-core Intel or AMD CPUs; 2.0 GHz or higher
+            recommended.
+         -  Minimum 4 GB RAM (8 GB RAM for Red Hat Enterprise Linux);
+            8 GB RAM (or more) per core recommended for Fusion.
+         -  Minimum 500 GB of total hard disk storage.
+         -  A graphics card with at least 64 MB video RAM (NVIDIA
+            GeForce4 or higher preferred for Fusion GUI). You can
+            install this graphics card in a separate workstation that
+            accesses Fusion.
+
+         **Note:** If you plan on cutting globes, this processing can
+         be CPU-intensive and you may also need to plan on providing
+         more storage depending on the size of the globes.
+
+         **Note on virtual machines**: Fusion can be both CPU and I/O
+         intensive. For optimal, stable performance, you should
+         install it only on physical (non-virtual) machines. You can
+         run GEE Server on a virtualized platform, provided the guest
+         OS is one of our supported 64-bit distributions and you
+         allocate sufficient resources to the VM.
+
+      Software Requirements
+
+         **Operating Systems**
+
+         OpenGEE is supported only on the 64-bit versions of the
+         operating systems listed below.
+
+         -  Red Hat Enterprise Linux 6.x and 7.x, including the most
+            recent security patches
+         -  CentOS 6.x and 7.x
+         -  Ubuntu 14.04 LTS and 16.04 LTS
+
+         **Browsers**
+
+         Google Earth Enterprise is supported on the following
+         browsers on all operating systems:
+
+         -  The latest version of Google Chrome
+         -  The latest version of Mozilla Firefox
+
+         However, Google Earth Enterprise should work with any modern
+         browser.
+
+         **Google Earth Enterprise Client (EC)**
+
+         The following versions of Google Earth Enterprise Client
+         (EC) are recommended for use with Google Earth Enterprise:
+
+         -  For GEE 5.x, use Google Earth EC version 7.0 or later
+         -  For GEE 4.4, use Google Earth EC version 6.1 or later
+
+         **Note:** Although older versions of Google Earth EC,
+         i.e., 6.0 and earlier, *may* still connect to Google
+         Earth Enterprise or Portable 3D databases, not all
+         features will be available. Also, as Google Earth
+         Enterprise has not been tested or certified against older
+         versions of Google Earth EC, there may be unknown
+         operational problems.
+
+         Google Earth Enterprise Client (EC) is supported on the
+         following platforms:
+
+         -  Windows
+         -  Mac
+         -  Linux
+
+           **Unsupported Versions and Environments**
+
+         There are many variations of operating systems and related
+         software; point ("x.x") releases can sometimes contain
+         changes that can impact your GEE installation. Although an
+         unsupported version of these software packages may appear to
+         function correctly, their use in a production environment is
+         not recommended. Unexpected results may occur.
+
+         Where possible, you should adhere to the hardware and
+         software specifications listed in this document. If a
+         problem arises in an unsupported configuration, we may not
+         be able to help you resolve it.
+
+
+      Network Requirements
+
+         Each destination server must meet the requirements below
+         before you install GEE, and you must not change these
+         settings after deploying GEE. The hostname must be the FQDN
+         (Fully Qualified Domain Name) of your destination server, e.g.,
+         ``myserver.mydomainname.com``.
+
+         You can verify the hostname of your workstation by entering
+         ``hostname`` at a shell prompt, and you can verify the
+         network connection by using the ``ping`` command to reach
+         other hosts in the same network. The requests should resolve
+          using both an IP address and the FQDN.
+
+         -  Hostname registered in DNS
+         -  Hosts file is acceptable for small-scale systems
+         -  Allocated IP addresses
+         -  Correct network routing paths
+         -  Network connectivity (Ports 80 and 22; Port 443 for
+            HTTPS)
+         -  Default installation of a Supported OS
+         -  Java Development Kit or Runtime Environment (must
+            download from Sun; use version 1.6.0_12 or newer)
+         -  OpenSSL 0.9.8y (on OS media)
+         -  Python 2.7.5 (on OS media)
+         -  Storage for all source data and asset tree
+         -  May be local storage (i.e., RAID 5 array)
+         -  NAS storage via NFS acceptable
+         -  SAN storage acceptable
+         -  USB drive not recommended
+
+
+      Supported Configurations
+
+         Google Earth Enterprise products are developed per the
+         hardware and software requirements listed above. The
+         products are intended to be installed according to the
+         processes described in this documentation. When installing            Google Earth Enterprise in an unsupported environment, there
+         are risks that the products may not operate as intended.
+
+         Some factors that could affect your installation and
+         deployment are:
+
+         -  Installations on unsupported operating systems.
+         -  Improperly configured DNS.
+         -  Third party or non-default permissions or security measures
+            (no root access, sudo blockers, etc.).
+         -  Complex proxy configurations that prevent the network
+            communications from operating as intended.
+
+      Important System Security Information
+
+         We strongly recommend users who wish to host 3D and 2D
+         globes online with Google Earth Enterprise follow
+         industry standard security practices and review for their
+         systems and networks before enabling access. Although we
+         takes every precaution to secure the information, there is
+         always the risk of unauthorized access outside of a closed
+         or protected network.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/uninstallGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/uninstallGEE.rst
@@ -1,0 +1,29 @@
+|Google logo|
+
+====================================
+Uninstalling Google Earth Enterprise
+====================================
+
+.. container::
+
+   .. container:: content
+
+      OpenGEE provides command line uninstall scripts. To uninstall
+      Google Earth Enterprise Fusion and Server:
+
+      #. Open a terminal window on your Linux workstation.
+      #. Log in as ``root``.
+      #. Stop Google Earth Enterprise processes, if you have a previous
+         version installed and it is running:
+
+         | ``/etc/init.d/gefusion stop``
+         | ``/etc/init.d/geserver stop``
+
+      #. Navigate to the installation location
+         (``/opt/google/install``).
+      #. Run the scripts ``uninstall_server.sh`` and
+         ``uninstall_fusion.sh``.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/uninstallGEEServer.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/uninstallGEEServer.rst
@@ -1,0 +1,27 @@
+|Google logo|
+
+=======================
+Uninstalling GEE Server
+=======================
+
+.. container::
+
+   .. container:: content
+
+      GEE Server provides a command line uninstall script. To uninstall Google
+      Earth Enterprise Server:
+
+      #. Open a terminal window on your Linux workstation.
+      #. Log in as ``root``.
+      #. Stop the Google Earth Enterprise Server, if you have a previous
+         version installed and it is running:
+
+         ``/etc/init.d/geserver stop``
+
+      #. Navigate to the installation location
+         (``/opt/google/install``).
+      #. Run the script ``uninstall_server.sh``.
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px

--- a/docs/geedocs/5.3.2/answer/installGEE/verifyTroubleshootGEE.rst
+++ b/docs/geedocs/5.3.2/answer/installGEE/verifyTroubleshootGEE.rst
@@ -1,0 +1,103 @@
+|Google logo|
+
+=============================
+Verifying and troubleshooting
+=============================
+
+.. container::
+
+   .. container:: content
+
+      -  :ref:`Verifying that the System Manager is Running <Verifying_System_Manager_Running>`
+      -  :ref:`Troubleshooting a Failed System
+         Manager <Troubleshooting_Failed_System_Manager>`
+      -  :ref:`Restarting the Server <Restarting_System_Manager>`
+
+      --------------
+
+      .. _Verifying_System_Manager_Running:
+      .. rubric:: Verifying That the System Manager Is Running
+
+      Because a properly running system manager is critical to using
+      Google Earth Enterprise Fusion, as well as for converting your
+      source data to Google Earth Enterprise Fusion assets, verify that
+      the system manager is running after the initial installation of
+      Google Earth Enterprise Fusion and whenever you encounter problems
+      building assets.
+
+      To verify that the system manager is running, enter the following
+      command at a shell prompt:
+
+      ``getop``
+      A list of running processes appears. Two processes appear on the
+      list:
+
+      -  ``gesystemmanager``
+
+         This process is necessary to configure or build resources,
+         projects, and databases with Google Earth Enterprise Fusion. If
+         this process appears on the list, Google Earth Enterprise
+         Fusion is running properly.
+
+         If you do not see this process on the list, follow the
+         troubleshooting suggestions in the
+         :ref:`Troubleshooting <Troubleshooting_Failed_System_Manager>` section to
+         correct it.
+
+      -  ``geresourceprovider``
+
+         This process manages the workstation resources on the behalf of
+         the system manager. It also monitors free disk space on the
+         volumes for any connected workstations.
+
+         If you see a ``connection refused`` message, see the
+         :ref:`Troubleshooting <Troubleshooting_Failed_System_Manager>` section.
+
+      --------------
+
+      .. _Troubleshooting_Failed_System_Manager:
+      .. rubric:: Troubleshooting a Failed System Manager
+
+      If the Google Earth Enterprise Fusion system manager fails to run,
+      you can try stopping and restarting the it, which resolves most
+      minor problems.
+
+      .. _Restarting_System_Manager:
+      .. rubric:: Restarting the system manager
+
+      #. Log in as root.
+      #. Stop the system manager:
+         ``/etc/init.d/gefusion stop``
+      #. Start the system manager:
+         ``/etc/init.d/gefusion start``
+
+      If you are still having problems starting the system manager after
+      stopping and restarting the system manager, you can view the log
+      file for the system manager to see what errors have been reported.
+      The log file is located in:
+
+      ``/var/opt/google/log/gesystemmanager.log``
+      Any errors are listed after the **Started** notice, which appears
+      in the log for each time you started the system manager.
+
+      .. note::
+
+         **Note:** If you see a ``Connection Refused`` message when
+         running the ``getop`` command, but do not see any error
+         messages in the log file, ensure that the log directory is
+         writable by Google Earth Enterprise Fusion users.
+
+      Likewise, if Google Earth Enterprise Server fails to run, you can
+      try stopping and restarting it, which resolves most problems.
+
+      --------------
+
+      .. rubric:: Restarting the Server
+
+      #. Log in as root.
+      #. Stop and restart the server.
+      \ ``/etc/init.d/geserver restart``
+
+.. |Google logo| image:: ../../art/common/googlelogo_color_260x88dp.png
+   :width: 130px
+   :height: 44px


### PR DESCRIPTION
installGEE initial upload. Note that there appear to be more files than there were previously because not all files were in the main index - clicking a server installation link took you out to a new section with its own index that replicated the GEE installation index. 
I'd suggest having someone knowledgeable review and compare the server install and GEE install docs to see if they're duplicative - the install, uninstall, and system requirements pages are at minimum very similar, if not identical.