### PR TITLE
Purge caches after writing dirty assets to disk

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/StorageManager.h
+++ b/earth_enterprise/src/fusion/autoingest/StorageManager.h
@@ -351,6 +351,7 @@ bool StorageManager<AssetType>::SaveDirtyToDotNew(
       return false;
     }
   }
+  cache.Prune();
   return true;
 }
 


### PR DESCRIPTION
Added an additional call to Prune in SaveDirtyToDotNew so that the caches won't overfill after load and think.