### PR TITLE
Fixed url for release notes in blog posts

### DIFF
--- a/docs/_posts/2017-09-12-520-release.md
+++ b/docs/_posts/2017-09-12-520-release.md
@@ -26,7 +26,7 @@ I’m excited to bring you the news of Open GEE’s 5.2.0 Release! We’ve been 
 * CentOS 7.x
 * Ubuntu 14.04 LTS and 16.04 LTS
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.0-3.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160000.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.0-3.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/5.2.0/answer/7160000.html).
 
 A big thank you to all of the contributors who helped make this release possible! We now return you to your regularly scheduled 5.2.1 development, already in progress.
 

--- a/docs/_posts/2018-03-20-521-release.md
+++ b/docs/_posts/2018-03-20-521-release.md
@@ -27,7 +27,7 @@ and updates to third-party libraries. Some of the new features include:
 
 **Continuous Integration**: Travis CI is used for continuous integration. On every new commit to Open GEE a build is executed to validate the committed changes.
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.1-6.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160001.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.1-6.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/5.2.1/answer/7160001.html).
 
 A big thank you to all of the contributors who helped make this release possible! The next release, Open GEE 5.2.2, development is already in progress.
 Would you like to be part of the project ? Please join us at <a href="http://slack.opengee.org"> Slack</a> and visit the project's <a href="https://github.com/google/earthenterprise">Github repository</a>. We would love to see you there.

--- a/docs/_posts/2018-05-26-522-release.md
+++ b/docs/_posts/2018-05-26-522-release.md
@@ -21,7 +21,7 @@ Enhancements include:
 **Detailed profiling data for terrain processing.** The <code>gecombineterrain</code> command now produces performance details if profiling is enabled. To turn on profiling, use <code>log_performance=1</code> when building Open GEE, e.g. <code>scons -j8 release=1 log_performance=1 build</code> 
 
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.2-2.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160002.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.2-2.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/5.2.2/answer/7160002.html).
  
 A big thank you goes out to all of the contributors who helped make this release possible! The next release, Open GEE 5.2.3, is already in progress!
  

--- a/docs/_posts/2018-07-18-523-release.md
+++ b/docs/_posts/2018-07-18-523-release.md
@@ -29,7 +29,7 @@ Enhancements include:
 **Maps API Javascript Files.** Maps API JavaScript files are now available and installed at <code>/opt/google/gehttpd/htdocs/maps/mapfiles</code>.
 
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.3-4.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160003.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.3-4.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/5.2.3/answer/7160003.html).
  
 A big thank you goes out to all of the contributors who helped make this release possible! The next release, Open GEE 5.2.4, is already in progress!
  

--- a/docs/_posts/2018-10-11-524-release.md
+++ b/docs/_posts/2018-10-11-524-release.md
@@ -24,7 +24,7 @@ Enhancements include:
 
 **New experimental build cache folder parameter to the build**. This is an experimental option to potentially speed up builds. More work remains to be done before using this option in production builds. Use of this option is not recommended except for giving feedback and/or helping to address issues with Open GEE's build process using scons cache. See earth_enterprise/BUILD.md in source code for more details.
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.4-4.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/answer/7160004.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.4-4.final). The full release notes can also be found [here](http://www.opengee.org/geedocs/5.2.4/answer/7160004.html).
  
 Our thanks go out to all of the contributors who helped make this release possible! The next release, Open GEE 5.2.5, is already underway!
  

--- a/docs/_posts/2019-01-23-525-release.md
+++ b/docs/_posts/2019-01-23-525-release.md
@@ -24,7 +24,7 @@ Enhancements include:
 
 **Installation scripts can no longer be run when the GEE packages are installed.** The install and uninstall scripts will now check if Open GEE has been installed with a package manager before continuing, and will not make any changes if the packages are already installed.
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.5-714.41). The full release notes can also be found [here](https://www.opengee.org/geedocs/answer/7160006.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.2.5-714.41). The full release notes can also be found [here](https://www.opengee.org/geedocs/5.2.5/answer/7160006.html).
  
 Our thanks go out to all of the contributors who helped make this release possible! The next release, Open GEE 5.3.0, is already underway!
  

--- a/docs/_posts/2019-05-22-530-release.md
+++ b/docs/_posts/2019-05-22-530-release.md
@@ -30,7 +30,7 @@ We are happy to announce the official release of Open GEE 5.3.0!  This release u
 
 **- Upgraded OpenJPEG 2000 library to latest version: 2.3.1.** This upgrade brings multiple bugs fixes and improvements.
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.3.0-891.12). The full release notes can also be found [here](https://www.opengee.org/geedocs/answer/7160007.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.3.0-891.12). The full release notes can also be found [here](https://www.opengee.org/geedocs/5.3.0/answer/7160007.html).
  
 Our thanks go out to all of the contributors who helped make this release possible! The next release, Open GEE 5.3.1, is already in progress!
  

--- a/docs/_posts/2019-08-05-531-release.md
+++ b/docs/_posts/2019-08-05-531-release.md
@@ -28,7 +28,7 @@ We are excited to announce the official release of Open GEE 5.3.1!  This release
 
 **- Starting with Open GEE 5.3.2 Ubuntu 14.04 will no longer be supported.** Open GEE 5.3.1 will be the last version to support Ubuntu 14.04 due to its recent end of life.
 
-To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.3.1-1013.12). The full release notes can also be found [here](https://www.opengee.org/geedocs/answer/7160008.html).
+To download this release see the [release page](https://github.com/google/earthenterprise/releases/tag/5.3.1-1013.12). The full release notes can also be found [here](https://www.opengee.org/geedocs/5.3.1/answer/7160008.html).
  
 Our thanks go out to all of the contributors who helped make this release possible! The next release, Open GEE 5.3.2, is already in progress!
  


### PR DESCRIPTION
This address #1465 

For verifying the changes, see also: https://tst-nfarah.github.io/earthenterprise/blog.html and verify that all blog posts about version releases has the correct linked page for release notes.