### PR TITLE
I1469 GLC Assembly should check KML for validity

### DIFF
--- a/docs/geedocs/5.3.2/answer/releaseNotes/relNotesGEE5_3_2.html
+++ b/docs/geedocs/5.3.2/answer/releaseNotes/relNotesGEE5_3_2.html
@@ -154,6 +154,10 @@ from making it to the server. Changing the command to be a POST request prevents
 <td>Upgrade PostgreSQL and PostGIS to latest patch releases</td>
 <td>The current patch releases have been incorporated.</td>
 </tr>
+<tr class="row-odd"><td>1469</td>
+<td>GLC Assembly should check KML for validity</td>
+<td>GLC Assembly performs improved check for KML validity.</td>
+</tr>
 </tbody>
 </table>
 <p class="rubric">Known Issues</p>

--- a/docs/geedocs/5.3.2/answer/releaseNotes/relNotesGEE5_3_2.html
+++ b/docs/geedocs/5.3.2/answer/releaseNotes/relNotesGEE5_3_2.html
@@ -154,10 +154,6 @@ from making it to the server. Changing the command to be a POST request prevents
 <td>Upgrade PostgreSQL and PostGIS to latest patch releases</td>
 <td>The current patch releases have been incorporated.</td>
 </tr>
-<tr class="row-odd"><td>1469</td>
-<td>GLC Assembly should check KML for validity</td>
-<td>GLC Assembly performs improved check for KML validity.</td>
-</tr>
 </tbody>
 </table>
 <p class="rubric">Known Issues</p>

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
@@ -544,6 +544,16 @@ class GlcAssembler(object):
   #   "polygon":"-- polygon --"
   #   "is_2d":true
   # }
+
+  def WritePolygonFile(self, polygon, logger):
+    with open(self.polygon_file, "w") as fp:
+      # Check XML validity and standardize representation
+      utils.PrintAndLog("Checking polygon")
+      xml = etree.ElementTree(etree.fromstring(str(polygon)))
+      utils.PrintAndLog("Writing polygon")
+      xml.write(fp, xml_declaration=True, encoding='UTF-8')
+      utils.PrintAndLog("SUCCESS", logger, None)
+
   def AssembleGlc(self, form_):
     """Assemble a 2d or 3d glc based on given parameters."""
     utils.PrintAndLog("Assembling ...")
@@ -604,13 +614,7 @@ class GlcAssembler(object):
 
       utils.PrintAndLog("Create polygon file: %s" % self.polygon_file, logger)
 
-      with open(self.polygon_file, "w") as fp:
-        # Check XML validity and standardize representation
-        utils.PrintAndLog("Checking polygon")
-        xml = etree.ElementTree(etree.fromstring(str(spec["polygon"])))
-        utils.PrintAndLog("Writing polygon")
-        xml.write(fp, xml_declaration=True, encoding='UTF-8')
-        utils.PrintAndLog("SUCCESS", logger, None)
+      self.WritePolygonFile(spec["polygon"], logger)
 
       if spec["is_2d"]:
         utils.PrintAndLog("Building 2d glc at %s ..." % path, logger)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
@@ -29,6 +29,7 @@ import urllib
 import yaml
 from common import utils
 import common.configs
+from lxml import etree
 
 
 CONFIG_FILE = "/opt/google/gehttpd/cgi-bin/advanced_cutter.cfg"
@@ -601,8 +602,14 @@ class GlcAssembler(object):
       utils.PrintAndLog("SUCCESS", logger, None)
 
       utils.PrintAndLog("Create polygon file: %s" % self.polygon_file, logger)
-      utils.CreateFile(self.polygon_file, spec["polygon"])
-      utils.PrintAndLog("SUCCESS", logger, None)
+
+      with open(self.polygon_file, "w") as fp:
+        # Check XML validity and standardize representation
+        utils.PrintAndLog("Checking polygon")
+        xml = etree.ElementTree(etree.fromstring(str(spec["polygon"])))
+        utils.PrintAndLog("Writing polygon")
+        xml.write(fp, xml_declaration=True, encoding='UTF-8')
+        utils.PrintAndLog("SUCCESS", logger, None)
 
       if spec["is_2d"]:
         utils.PrintAndLog("Building 2d glc at %s ..." % path, logger)

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/glc_assembler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019, Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/glc_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/glc_tools.js
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2019, Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/glc_tools.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/cutter/js/glc_tools.js
@@ -603,8 +603,7 @@ function createGlcJson() {
   }
   glcJson.name = gees.dom.get('glc_name_field').value;
   glcJson.description = gees.dom.get('glc_desc_field').value;
-  var kmlString = gees.dom.get('glc_poly_field').value;
-  glcJson.polygon = validateKml(kmlString);
+  glcJson.polygon = gees.dom.get('glc_poly_field').value;
   return JSON.stringify(glcJson);
 }
 


### PR DESCRIPTION
This is a first-stab at validating the KML.  The change to the javascript file removes the KML validation done there (which is, arguably, not very good), and to add the lxml.etree validation in the python file.  A large section of the javascript file can be removed, but isn't at this time.

Issue: https://github.com/google/earthenterprise/issues/1469 