### PR TITLE
Remove unused field from query (#1498)

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -617,14 +617,13 @@ class PublishManagerHelper(stream_manager.StreamManager):
 
     target_details = {}
     query_string = ("""SELECT db_table.host_name, db_table.db_name,
-              virtual_host_table.virtual_host_name, target_table.serve_wms, publish_context_table.ec_default_db
-              FROM target_table, target_db_table, db_table, virtual_host_table, publish_context_table
+              virtual_host_table.virtual_host_name, target_table.serve_wms
+              FROM target_table, target_db_table, db_table, virtual_host_table
               WHERE target_table.target_path = %s AND
               target_table.target_id = target_db_table.target_id AND
               target_db_table.db_id = db_table.db_id AND
               target_db_table.virtual_host_id =
-              virtual_host_table.virtual_host_id AND
-              publish_context_table.publish_context_id = target_db_table.publish_context_id""")
+              virtual_host_table.virtual_host_id""")
 
     result = self.DbQuery(query_string, (target_path,))
 

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -618,12 +618,13 @@ class PublishManagerHelper(stream_manager.StreamManager):
     target_details = {}
     query_string = ("""SELECT db_table.host_name, db_table.db_name,
               virtual_host_table.virtual_host_name, target_table.serve_wms
-              FROM target_table, target_db_table, db_table, virtual_host_table
+              FROM target_table, target_db_table, db_table, virtual_host_table, publish_context_table
               WHERE target_table.target_path = %s AND
               target_table.target_id = target_db_table.target_id AND
               target_db_table.db_id = db_table.db_id AND
               target_db_table.virtual_host_id =
-              virtual_host_table.virtual_host_id""")
+              virtual_host_table.virtual_host_id AND
+              publish_context_table.publish_context_id = target_db_table.publish_context_id""")
 
     result = self.DbQuery(query_string, (target_path,))
 


### PR DESCRIPTION
The default_db values are missing from the preceding result check. However, they're primarily unused and should simply be removed from the overall SELECT query.