### PR TITLE
Improve handling of TaskDone messages

### DIFF
--- a/earth_enterprise/integration_test/specs/state_propagation.spec
+++ b/earth_enterprise/integration_test/specs/state_propagation.spec
@@ -216,6 +216,7 @@ Cancel Project
   |------------|
   | InProgress |
   | Queued     |
+  | Succeeded  |
 * Verify that the state of imagery project "StatePropagationTest_CleanAfterCancel" is "Canceled"
 
 Clean Project

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -34,13 +34,17 @@ class StateChangeException : public khException {
     khException(msg), location(loc) {}
 };
 
-// Helper struct for passing data about input and child states.
+// Helper structs for passing data about input and child states.
+struct WaitingFor {
+  uint32 inputs;
+  uint32 children;
+};
+
 struct InputAndChildStateData {
   AssetDefs::State stateByInputs;
   AssetDefs::State stateByChildren;
   bool blockersAreOffline;
-  uint32 numInputsWaitingFor;
-  uint32 numChildrenWaitingFor;
+  WaitingFor waitingFor;
 };
 
 /******************************************************************************
@@ -192,9 +196,12 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
   virtual void ResetOutFiles(const std::vector<std::string> &) {
     assert(false);
   }
-  virtual bool RecalcState() const {
+  virtual bool RecalcState(WaitingFor &) const {
     assert(false);
     return false;
+  }
+  virtual void SetAndPropagateState(AssetDefs::State) {
+    assert(false);
   }
 
   // static helpers

--- a/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
@@ -64,14 +64,14 @@ TEST(AssetHandleTest, Finalize) {
   ASSERT_TRUE(finalized);
 }
 
-TEST(AssetHandleTest, ConvertConstToMutable) {
+TEST(AssetHandleTest, ConvertMutableToConst) {
   AssetHandle<TestItem> mutableHandle;
   AssetHandle<const TestItem> constHandle;
   constHandle = mutableHandle;
   ASSERT_EQ(mutableHandle.operator->(), constHandle.operator->());
 }
 
-TEST(AssetHandleTest, ConvertMutableToConst) {
+TEST(AssetHandleTest, ConvertConstToMutable) {
   // We should not be able to convert a mutable handle to a const handle.
   if(std::is_assignable<AssetHandle<TestItem>, AssetHandle<const TestItem>>::value) {
     // If the above statement is wrapped in ASSERT_FALSE it will fail to compile

--- a/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
@@ -18,6 +18,7 @@
 #include "autoingest/.idl/storage/AssetDefs.h"
 
 #include <gtest/gtest.h>
+#include <type_traits>
 
 using namespace std;
 
@@ -61,6 +62,22 @@ TEST(AssetHandleTest, Finalize) {
     ASSERT_FALSE(finalized);
   }
   ASSERT_TRUE(finalized);
+}
+
+TEST(AssetHandleTest, ConvertConstToMutable) {
+  AssetHandle<TestItem> mutableHandle;
+  AssetHandle<const TestItem> constHandle;
+  constHandle = mutableHandle;
+  ASSERT_EQ(mutableHandle.operator->(), constHandle.operator->());
+}
+
+TEST(AssetHandleTest, ConvertMutableToConst) {
+  // We should not be able to convert a mutable handle to a const handle.
+  if(std::is_assignable<AssetHandle<TestItem>, AssetHandle<const TestItem>>::value) {
+    // If the above statement is wrapped in ASSERT_FALSE it will fail to compile
+    // for some reason. This is our simple workaround.
+    FAIL();
+  }
 }
 
 int main(int argc, char **argv) {

--- a/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/StorageManagerAssetHandle_unittest.cpp
@@ -72,7 +72,7 @@ TEST(AssetHandleTest, ConvertMutableToConst) {
 }
 
 TEST(AssetHandleTest, ConvertConstToMutable) {
-  // We should not be able to convert a mutable handle to a const handle.
+  // We should not be able to convert a const handle to a mutable handle.
   if(std::is_assignable<AssetHandle<TestItem>, AssetHandle<const TestItem>>::value) {
     // If the above statement is wrapped in ASSERT_FALSE it will fail to compile
     // for some reason. This is our simple workaround.

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
@@ -16,13 +16,15 @@
 
 #include "AssetOperation.h"
 #include "AssetVersionD.h"
-#include "MiscConfig.h"
 #include "StateUpdater.h"
 
-StateUpdater updater;
+#include <memory>
 
-void RebuildVersion(const SharedString & ref) {
-  if (MiscConfig::Instance().GraphOperations) {
+std::unique_ptr<StateUpdater> stateUpdater(new StateUpdater());
+StorageManagerInterface<AssetVersionImpl> * assetOpStorageManager = &AssetVersion::storageManager();
+
+void RebuildVersion(const SharedString & ref, bool graphOps) {
+  if (graphOps) {
     // Rebuilding an already succeeded asset is quite dangerous!
     // Those who depend on me may have already finished their work with me.
     // If I rebuild, they have the right to recognize that nothing has
@@ -37,17 +39,18 @@ void RebuildVersion(const SharedString & ref) {
     // The same logic could hold true for 'Offline' as well.
     {
       // Limit the scope to release the AssetVersion as quickly as possible.
-      AssetVersion version(ref);
+      auto version = assetOpStorageManager->Get(ref);
       if (version && version->state & (AssetDefs::Succeeded | AssetDefs::Offline | AssetDefs::Bad)) {
         throw khException(kh::tr("%1 marked as %2. Refusing to resume.")
                           .arg(ToQString(ref), ToQString(version->state)));
       }
       else if (!version){
         notify(NFY_WARN, "Could not load %s for rebuild", ref.toString().c_str());
+        return;
       }
     }
 
-    updater.SetStateForRefAndDependents(ref, AssetDefs::New, AssetDefs::CanRebuild);
+    stateUpdater->SetStateForRefAndDependents(ref, AssetDefs::New, AssetDefs::CanRebuild);
   }
   else {
     MutableAssetVersionD version(ref);
@@ -60,17 +63,14 @@ void RebuildVersion(const SharedString & ref) {
   }
 }
 
-void HandleTaskProgress(const TaskProgressMsg & msg) {
-  if (MiscConfig::Instance().GraphOperations) {
-    auto version = AssetVersion::storageManager().GetMutable(msg.verref);
+void HandleTaskProgress(const TaskProgressMsg & msg, bool graphOps) {
+  if (graphOps) {
+    auto version = assetOpStorageManager->GetMutable(msg.verref);
     if (version && version->taskid == msg.taskid) {
       version->beginTime = msg.beginTime;
       version->progressTime = msg.progressTime;
-      updater.SetInProgress(version);
       version->progress = msg.progress;
-      if (!AssetDefs::Finished(version->state)) {
-        theAssetManager.NotifyVersionProgress(msg.verref, msg.progress);
-      }
+      stateUpdater->SetInProgress(version);
     }
     else if (!version) {
       notify(NFY_WARN, "Could not load %s to update progress", msg.verref.c_str());
@@ -87,9 +87,57 @@ void HandleTaskProgress(const TaskProgressMsg & msg) {
   }
 }
 
-void UpdateWaitingAssets(const SharedString & ref, AssetDefs::State oldState) {
-  if (MiscConfig::Instance().GraphOperations) {
-    auto version = AssetVersion::storageManager().GetMutable(ref);
-    updater.UpdateWaitingAssets(version, oldState);
+void HandleTaskDone(const TaskDoneMsg & msg, bool graphOps) {
+  if (graphOps) {
+    auto version = assetOpStorageManager->GetMutable(msg.verref);
+    if (version && version->taskid == msg.taskid) {
+      version->beginTime = msg.beginTime;
+      version->progressTime = msg.endTime;
+      version->endTime = msg.endTime;
+      if (msg.success) {
+        version->ResetOutFiles(msg.outfiles);
+        stateUpdater->SetSucceeded(version);
+      }
+      else {
+        stateUpdater->SetFailed(version);
+      }
+    }
+    else if (!version) {
+      notify(NFY_WARN, "Could not load %s to mark done", msg.verref.c_str());
+    }
+  }
+  else {
+    AssetVersionD ver(msg.verref);
+    if (ver && ver->taskid == msg.taskid) {
+      MutableAssetVersionD(msg.verref)->HandleTaskDone(msg);
+    }
+    else if (!ver) {
+      notify(NFY_WARN, "Could not load %s to mark done", msg.verref.c_str());
+    }
+  }
+}
+
+// This function ensures that the State Updater stays in sync with any state
+// changes that happen in the legacy code.
+void HandleExternalStateChange(
+    const SharedString & ref,
+    AssetDefs::State oldState,
+    uint32 numInputsWaitingFor,
+    uint32 numChildrenWaitingFor,
+    bool graphOps) {
+  if (graphOps) {
+    auto version = assetOpStorageManager->Get(ref);
+    if (version) {
+      // Update the lists of waiting assets
+      stateUpdater->UpdateWaitingAssets(version, oldState, {numInputsWaitingFor, numChildrenWaitingFor});
+      if (version->state == AssetDefs::Succeeded) {
+        // Notify this asset's parents and listeners so that they can decrement
+        // their waiting count.
+        stateUpdater->UpdateSucceeded(version, false);
+      }
+    }
+    else {
+      notify(NFY_WARN, "Could not load %s to update waiting assets", ref.toString().c_str());
+    }
   }
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.h
@@ -19,9 +19,16 @@
 
 #include "common/SharedString.h"
 #include "fusion/autoingest/sysman/.idl/TaskStorage.h"
+#include "MiscConfig.h"
 
-void RebuildVersion(const SharedString & ref);
-void HandleTaskProgress(const TaskProgressMsg & msg);
-void UpdateWaitingAssets(const SharedString & ref, AssetDefs::State oldState);
+void RebuildVersion(const SharedString & ref, bool graphOps = MiscConfig::Instance().GraphOperations);
+void HandleTaskProgress(const TaskProgressMsg & msg, bool graphOps = MiscConfig::Instance().GraphOperations);
+void HandleTaskDone(const TaskDoneMsg & msg, bool graphOps = MiscConfig::Instance().GraphOperations);
+void HandleExternalStateChange(
+  const SharedString & ref,
+  AssetDefs::State oldState,
+  uint32 numInputsWaitingFor,
+  uint32 numChildrenWaitingFor,
+  bool graphOps = MiscConfig::Instance().GraphOperations);
 
 #endif // ASSETOPERATION_H

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2019 The Open GEE Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "AssetOperation.h"
+#include "gee_version.h"
+#include "StateUpdater.h"
+#include "StorageManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace std;
+
+// Declare the globals that AssetOperation functions use. This is cheating but
+// it lets us mock the classes that AssetOperation calls.
+extern std::unique_ptr<StateUpdater> stateUpdater;
+extern StorageManagerInterface<AssetVersionImpl> * assetOpStorageManager;
+
+const AssetKey REF = "a";
+
+class MockVersion : public AssetVersionImpl {
+  public:
+    bool stateSetForRefAndDependents;
+    AssetDefs::State refAndDependentsState;
+    std::function<bool(AssetDefs::State)> updateStateFunc;
+    bool setProgress;
+    bool setDone;
+    bool setFailed;
+    bool outFilesReset;
+    mutable bool updatedWaiting;
+    mutable AssetDefs::State oldState;
+    mutable WaitingFor waitingFor;
+    mutable bool updatedSucceeded;
+
+    MockVersion() :
+        stateSetForRefAndDependents(false),
+        refAndDependentsState(AssetDefs::Failed),
+        updateStateFunc(nullptr),
+        setProgress(false),
+        setDone(false),
+        setFailed(false),
+        outFilesReset(false),
+        updatedWaiting(false),
+        oldState(AssetDefs::New),
+        waitingFor({0, 0}),
+        updatedSucceeded(false) {
+      type = AssetDefs::Imagery; // Ensures that operator bool can return true
+      taskid = 0;
+      beginTime = 0;
+      progressTime = 0;
+      progress = 0.0;
+    }
+    MockVersion(const AssetKey & ref)
+        : MockVersion() {
+      name = ref;
+    }
+    MockVersion(const MockVersion & that) : MockVersion() {
+      name = that.name;
+    }
+    virtual void ResetOutFiles(const vector<string> & newOutfiles) override {
+      outFilesReset = true;
+      outfiles = newOutfiles;
+    }
+
+    // Not used - only included to make MockVersion non-virtual
+    string PluginName(void) const override { return string(); }
+    void GetOutputFilenames(vector<string> &) const override {}
+    string GetOutputFilename(uint) const override { return string(); }
+};
+
+class MockStorageManager : public StorageManagerInterface<AssetVersionImpl> {
+  private:
+    // This storage only holds one version
+    shared_ptr<MockVersion> version;
+    PointerType GetRef(const AssetKey & ref) {
+      assert(ref == REF);
+      return version;
+    }
+  public:
+    MockStorageManager() : version(make_shared<MockVersion>(REF)) {}
+    virtual AssetHandle<const AssetVersionImpl> Get(const AssetKey &ref) {
+      return AssetHandle<const AssetVersionImpl>(GetRef(ref), nullptr);
+    }
+    virtual AssetHandle<AssetVersionImpl> GetMutable(const AssetKey &ref) {
+      return AssetHandle<AssetVersionImpl>(GetRef(ref), nullptr);
+    }
+    // The two functions below pull the pointer out of the AssetHandle and use it
+    // directly, which is really bad. We can get away with it in test code, but we
+    // should never do this in production code. Hopefully the production code will
+    // never need to convert AssetHandles to different types, but if it does we
+    // need to come up with a better way.
+    const MockVersion * GetVersion() {
+      AssetHandle<const AssetVersionImpl> handle = Get(REF);
+      return dynamic_cast<const MockVersion *>(handle.operator->());
+    }
+    MockVersion * GetMutableVersion() {
+      AssetHandle<AssetVersionImpl> handle = GetMutable(REF);
+      return dynamic_cast<MockVersion *>(handle.operator->());
+    }
+};
+
+class MockStateUpdater : public StateUpdater {
+  private:
+    MockStorageManager * sm;
+  public:
+    MockStateUpdater(MockStorageManager * sm) : sm(sm) {}
+    virtual void SetStateForRefAndDependents(
+        const SharedString & ref,
+        AssetDefs::State newState,
+        std::function<bool(AssetDefs::State)> updateStatePredicate) {
+      assert(ref == REF);
+      auto version = sm->GetMutableVersion();
+      version->stateSetForRefAndDependents = true;
+      version->refAndDependentsState = newState;
+      version->updateStateFunc = updateStatePredicate;
+    }
+    virtual void SetInProgress(AssetHandle<AssetVersionImpl> & version) {
+      auto v = dynamic_cast<MockVersion *>(version.operator->());
+      v->setProgress = true;
+    }
+    virtual void SetSucceeded(AssetHandle<AssetVersionImpl> & version) {
+      auto v = dynamic_cast<MockVersion *>(version.operator->());
+      v->setDone = true;
+    }
+    virtual void SetFailed(AssetHandle<AssetVersionImpl> & version) {
+      auto v = dynamic_cast<MockVersion *>(version.operator->());
+      v->setFailed = true;
+    }
+    virtual void UpdateWaitingAssets(
+        AssetHandle<const AssetVersionImpl> version,
+        AssetDefs::State oldState,
+        const WaitingFor & waitingFor) {
+      auto v = dynamic_cast<const MockVersion *>(version.operator->());
+      v->updatedWaiting = true;
+      v->oldState = oldState;
+      v->waitingFor = waitingFor;
+    }
+    virtual void UpdateSucceeded(AssetHandle<const AssetVersionImpl> version, bool propagate) {
+      // AssetOperation should always set propagate to false, so we check that here
+      ASSERT_FALSE(propagate);
+      auto v = dynamic_cast<const MockVersion *>(version.operator->());
+      v->updatedSucceeded = true;
+    }
+};
+
+class AssetOperationTest : public testing::Test {
+  protected:
+    MockStorageManager sm;
+  public:
+    AssetOperationTest() {
+      assetOpStorageManager = &sm;
+      stateUpdater.reset(new MockStateUpdater(&sm));
+    }
+};
+
+TEST_F(AssetOperationTest, Rebuild) {
+  sm.GetMutableVersion()->state = AssetDefs::Canceled;
+  RebuildVersion(REF, true);
+  ASSERT_TRUE(sm.GetVersion()->stateSetForRefAndDependents);
+  ASSERT_EQ(sm.GetVersion()->refAndDependentsState, AssetDefs::New);
+
+  // Make sure the function that determines which states to update returns the
+  // correct values.
+  ASSERT_TRUE(sm.GetVersion()->updateStateFunc(AssetDefs::Canceled));
+  ASSERT_TRUE(sm.GetVersion()->updateStateFunc(AssetDefs::Failed));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::New));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Waiting));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Blocked));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Queued));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::InProgress));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Succeeded));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Offline));
+  ASSERT_FALSE(sm.GetVersion()->updateStateFunc(AssetDefs::Bad));
+}
+
+void RebuildWrongState(MockStorageManager & sm, AssetDefs::State state) {
+  sm.GetMutableVersion()->state = state;
+  ASSERT_THROW(RebuildVersion(REF, true), khException);
+}
+
+TEST_F(AssetOperationTest, RebuildWrongStateSucceeded) {
+  RebuildWrongState(sm, AssetDefs::Succeeded);
+}
+
+TEST_F(AssetOperationTest, RebuildWrongStateOffline) {
+  RebuildWrongState(sm, AssetDefs::Offline);
+}
+
+TEST_F(AssetOperationTest, RebuildWrongStateBad) {
+  RebuildWrongState(sm, AssetDefs::Bad);
+}
+
+TEST_F(AssetOperationTest, RebuildBadVersion) {
+  sm.GetMutableVersion()->type = AssetDefs::Invalid;
+  RebuildVersion(REF, true);
+  ASSERT_FALSE(sm.GetVersion()->stateSetForRefAndDependents);
+}
+
+TEST_F(AssetOperationTest, Progress) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t PROGRESS_TIME = 789;
+  const double PROGRESS = 10.1112;
+
+  auto msg = TaskProgressMsg(REF, TASKID, BEGIN_TIME, PROGRESS_TIME, PROGRESS);
+  sm.GetMutableVersion()->taskid = TASKID;
+  HandleTaskProgress(msg, true);
+  ASSERT_EQ(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_EQ(sm.GetVersion()->progressTime, PROGRESS_TIME);
+  ASSERT_EQ(sm.GetVersion()->progress, PROGRESS);
+  ASSERT_TRUE(sm.GetVersion()->setProgress);
+}
+
+TEST_F(AssetOperationTest, ProgressWrongTaskId) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t PROGRESS_TIME = 789;
+  const double PROGRESS = 10.1112;
+
+  auto msg = TaskProgressMsg(REF, TASKID, BEGIN_TIME, PROGRESS_TIME, PROGRESS);
+  sm.GetMutableVersion()->taskid = TASKID + 1;
+  HandleTaskProgress(msg, true);
+  ASSERT_NE(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_NE(sm.GetVersion()->progressTime, PROGRESS_TIME);
+  ASSERT_NE(sm.GetVersion()->progress, PROGRESS);
+  ASSERT_FALSE(sm.GetVersion()->setProgress);
+}
+
+TEST_F(AssetOperationTest, ProgressBadVersion) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t PROGRESS_TIME = 789;
+  const double PROGRESS = 10.1112;
+
+  sm.GetMutableVersion()->type = AssetDefs::Invalid;
+  auto msg = TaskProgressMsg(REF, TASKID, BEGIN_TIME, PROGRESS_TIME, PROGRESS);
+  sm.GetMutableVersion()->taskid = TASKID + 1;
+  HandleTaskProgress(msg, true);
+  ASSERT_NE(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_NE(sm.GetVersion()->progressTime, PROGRESS_TIME);
+  ASSERT_NE(sm.GetVersion()->progress, PROGRESS);
+  ASSERT_FALSE(sm.GetVersion()->setProgress);
+}
+
+TEST_F(AssetOperationTest, Done) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t END_TIME = 789;
+  const vector<string> OUTFILES = {"x", "y", "z"};
+
+  auto msg = TaskDoneMsg(REF, TASKID, true, BEGIN_TIME, END_TIME, OUTFILES);
+  sm.GetMutableVersion()->taskid = TASKID;
+  HandleTaskDone(msg, true);
+  ASSERT_EQ(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_EQ(sm.GetVersion()->progressTime, END_TIME);
+  ASSERT_EQ(sm.GetVersion()->endTime, END_TIME);
+  ASSERT_EQ(sm.GetVersion()->outfiles, OUTFILES);
+  ASSERT_TRUE(sm.GetVersion()->setDone);
+  ASSERT_FALSE(sm.GetVersion()->setFailed);
+}
+
+TEST_F(AssetOperationTest, DoneWrongTaskId) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t END_TIME = 789;
+  const vector<string> OUTFILES = {"x", "y", "z"};
+
+  auto msg = TaskDoneMsg(REF, TASKID, true, BEGIN_TIME, END_TIME, OUTFILES);
+  sm.GetMutableVersion()->taskid = TASKID + 1;
+  HandleTaskDone(msg, true);
+  ASSERT_NE(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_NE(sm.GetVersion()->progressTime, END_TIME);
+  ASSERT_NE(sm.GetVersion()->endTime, END_TIME);
+  ASSERT_NE(sm.GetVersion()->outfiles, OUTFILES);
+  ASSERT_FALSE(sm.GetVersion()->setDone);
+  ASSERT_FALSE(sm.GetVersion()->setFailed);
+}
+
+TEST_F(AssetOperationTest, DoneFailed) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t END_TIME = 789;
+  const vector<string> OUTFILES = {"x", "y", "z"};
+
+  auto msg = TaskDoneMsg(REF, TASKID, false, BEGIN_TIME, END_TIME, OUTFILES);
+  sm.GetMutableVersion()->taskid = TASKID;
+  HandleTaskDone(msg, true);
+  ASSERT_EQ(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_EQ(sm.GetVersion()->progressTime, END_TIME);
+  ASSERT_EQ(sm.GetVersion()->endTime, END_TIME);
+  ASSERT_NE(sm.GetVersion()->outfiles, OUTFILES);
+  ASSERT_FALSE(sm.GetVersion()->setDone);
+  ASSERT_TRUE(sm.GetVersion()->setFailed);
+}
+
+TEST_F(AssetOperationTest, DoneBadVersion) {
+  const uint32 TASKID = 123;
+  const time_t BEGIN_TIME = 456;
+  const time_t END_TIME = 789;
+  const vector<string> OUTFILES = {"x", "y", "z"};
+
+  sm.GetMutableVersion()->type = AssetDefs::Invalid;
+  auto msg = TaskDoneMsg(REF, TASKID, true, BEGIN_TIME, END_TIME, OUTFILES);
+  sm.GetMutableVersion()->taskid = TASKID;
+  HandleTaskDone(msg, true);
+  ASSERT_NE(sm.GetVersion()->beginTime, BEGIN_TIME);
+  ASSERT_NE(sm.GetVersion()->progressTime, END_TIME);
+  ASSERT_NE(sm.GetVersion()->endTime, END_TIME);
+  ASSERT_NE(sm.GetVersion()->outfiles, OUTFILES);
+  ASSERT_FALSE(sm.GetVersion()->setDone);
+  ASSERT_FALSE(sm.GetVersion()->setFailed);
+}
+
+TEST_F(AssetOperationTest, HandleExternalStateChangeWaiting) {
+  const AssetDefs::State OLD_STATE = AssetDefs::Failed;
+  const WaitingFor WAITING_FOR = {123, 456};
+
+  sm.GetMutableVersion()->state = AssetDefs::Queued;
+  HandleExternalStateChange(REF, OLD_STATE, WAITING_FOR.inputs, WAITING_FOR.children, true);
+  ASSERT_TRUE(sm.GetVersion()->updatedWaiting);
+  ASSERT_EQ(sm.GetVersion()->oldState, OLD_STATE);
+  ASSERT_EQ(sm.GetVersion()->waitingFor.inputs, WAITING_FOR.inputs);
+  ASSERT_EQ(sm.GetVersion()->waitingFor.children, WAITING_FOR.children);
+  ASSERT_FALSE(sm.GetVersion()->updatedSucceeded);
+}
+
+TEST_F(AssetOperationTest, HandleExternalStateChangeSucceeded) {
+  const AssetDefs::State OLD_STATE = AssetDefs::Failed;
+  const WaitingFor WAITING_FOR = {123, 456};
+
+  sm.GetMutableVersion()->state = AssetDefs::Succeeded;
+  HandleExternalStateChange(REF, OLD_STATE, WAITING_FOR.inputs, WAITING_FOR.children, true);
+  ASSERT_TRUE(sm.GetVersion()->updatedWaiting);
+  ASSERT_EQ(sm.GetVersion()->oldState, OLD_STATE);
+  ASSERT_EQ(sm.GetVersion()->waitingFor.inputs, WAITING_FOR.inputs);
+  ASSERT_EQ(sm.GetVersion()->waitingFor.children, WAITING_FOR.children);
+  ASSERT_TRUE(sm.GetVersion()->updatedSucceeded);
+}
+
+TEST_F(AssetOperationTest, HandleExternalStateChangeBadVersion) {
+  const AssetDefs::State OLD_STATE = AssetDefs::Failed;
+  const WaitingFor WAITING_FOR = {123, 456};
+
+  sm.GetMutableVersion()->state = AssetDefs::Succeeded;
+  sm.GetMutableVersion()->type = AssetDefs::Invalid;
+  HandleExternalStateChange(REF, OLD_STATE, WAITING_FOR.inputs, WAITING_FOR.children, true);
+  ASSERT_FALSE(sm.GetVersion()->updatedWaiting);
+  ASSERT_NE(sm.GetVersion()->oldState, OLD_STATE);
+  ASSERT_NE(sm.GetVersion()->waitingFor.inputs, WAITING_FOR.inputs);
+  ASSERT_NE(sm.GetVersion()->waitingFor.children, WAITING_FOR.children);
+  ASSERT_FALSE(sm.GetVersion()->updatedSucceeded);
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -269,9 +269,9 @@ void AssetVersionImplD::SetState(
   if (newstate != state) {
     AssetDefs::State oldstate = state;
     state = newstate;
+    HandleExternalStateChange(GetRef(), oldstate, numInputsWaitingFor, GetChildrenWaitingFor());
     try {
-      // NOTE: This can end up calling back here to switch us to
-      // another state (usually Failed or Succeded)
+      // OnStateChange may return a new state that we need to transition to.
       AssetDefs::State nextstate = OnStateChange(newstate, oldstate);
       if (nextstate != newstate) SetState(nextstate);
     } catch (const StateChangeException &e) {
@@ -879,7 +879,6 @@ LeafAssetVersionImplD::OnStateChange(AssetDefs::State newstate,
                                      AssetDefs::State oldstate)
 {
   AssetVersionImplD::OnStateChange(newstate, oldstate);
-  HandleExternalStateChange(GetRef(), oldstate, numInputsWaitingFor, 0);
 
   // task related members that need to be maintained
   // - taskid (may need to SubmitTask or DeleteTask)
@@ -1206,7 +1205,6 @@ CompositeAssetVersionImplD::OnStateChange(AssetDefs::State newstate,
          ToString(oldstate).c_str(),
          ToString(newstate).c_str());
   AssetVersionImplD::OnStateChange(newstate, oldstate);
-  HandleExternalStateChange(GetRef(), oldstate, numInputsWaitingFor, numChildrenWaitingFor);
 
   // certain plugins (e.g. Database, RasterProject) don't create their
   // children until after their inputs are done.

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -99,6 +99,7 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const = 0;
   inline bool BlockedByOfflineInputs(const InputAndChildStateData & stateData) const;
   virtual bool OfflineInputsBreakMe(void) const { return false; }
+  virtual uint32 GetChildrenWaitingFor() const { return 0; }
  public:
 
   bool NeedComputeState(void) const {
@@ -232,6 +233,7 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
   virtual void DelayedBuildChildren(void);
   virtual bool CompositeStateCaresAboutInputsToo(void) const { return false; }
+  virtual uint32 GetChildrenWaitingFor() const override { return numChildrenWaitingFor; }
 
   void AddChild(MutableAssetVersionD &child);
   void AddChildren(std::vector<MutableAssetVersionD> &children);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -36,9 +36,8 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   friend class MutableAssetHandleD_<DerivedAssetHandle_<AssetVersion,
                                                         AssetVersionImplD> >;
 
-  // private and unimplemented -- illegal to copy an AssetVersionImpl
-  AssetVersionImplD(const AssetVersionImplD&);
-  AssetVersionImplD& operator=(const AssetVersionImplD&);
+  AssetVersionImplD(const AssetVersionImplD&) =  delete;
+  AssetVersionImplD& operator=(const AssetVersionImplD&) = delete;
 
  protected:
   // Tracks the state of inputs and children to a given asset version that have
@@ -79,7 +78,7 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   // since AssetVersionImpl is a virtual base class
   // my derived classes will initialize it directly
   // therefore I don't need a contructor from storage
-  AssetVersionImplD(void) : AssetVersionImpl(), verholder(nullptr) { }
+  AssetVersionImplD(void) : AssetVersionImpl(), verholder(nullptr), numInputsWaitingFor(0) { }
 
   // used when being contructed from an asset
   // these are the inputs I need to bind and attach to
@@ -96,9 +95,9 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   // needs to call SetState
   void PropagateStateChange(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual void HandleTaskLost(const TaskLostMsg &msg);
-  virtual void HandleTaskDone(const TaskDoneMsg &msg);
   virtual void HandleChildStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const = 0;
+  inline bool BlockedByOfflineInputs(const InputAndChildStateData & stateData) const;
   virtual bool OfflineInputsBreakMe(void) const { return false; }
  public:
 
@@ -125,7 +124,9 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
   virtual void HandleTaskProgress(const TaskProgressMsg &msg);
-  virtual bool RecalcState() const override { return SyncState(); }
+  virtual void HandleTaskDone(const TaskDoneMsg &msg);
+  virtual void SetAndPropagateState(AssetDefs::State newstate) override
+    { SetState(newstate); }
 
   class InputVersionHolder : public khRefCounter {
    public:
@@ -158,6 +159,8 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   // accessable only through InputVersionGuard
   mutable InputVersionHolder* verholder;
 
+ protected:
+  mutable uint32 numInputsWaitingFor;
 };
 
 
@@ -169,19 +172,17 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
                               public AssetVersionImplD
 {
  protected:
-  mutable uint32 numInputsWaitingFor;
-
   // since AssetVersionImpl and LeafAssetVersionImpl are virtual base
   // classes my derived classes will initialize it directly
   // therefore I don't need a contructor from storage
   LeafAssetVersionImplD(void)
       : AssetVersionImpl(), LeafAssetVersionImpl(),
-        AssetVersionImplD(), numInputsWaitingFor(0) { }
+        AssetVersionImplD() { }
   // used when being contructed from an asset
   // these are the inputs I need to bind and attach to
   LeafAssetVersionImplD(const std::vector<SharedString> &inputs)
       : AssetVersionImpl(), LeafAssetVersionImpl(),
-        AssetVersionImplD(inputs), numInputsWaitingFor(0) { }
+        AssetVersionImplD(inputs) { }
 
   void SubmitTask(void);
   void ClearOutfiles(void);
@@ -189,14 +190,15 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
   virtual AssetDefs::State ComputeState(void) const;
   virtual bool CacheInputVersions(void) const;
   virtual void HandleTaskLost(const TaskLostMsg &msg);
-  virtual void HandleTaskDone(const TaskDoneMsg &msg);
   virtual void HandleInputStateChange(NotifyStates, const std::shared_ptr<StateChangeNotifier>) const;
   virtual void DoSubmitTask(void) = 0;
   virtual bool OfflineInputsBreakMe(void) const { return false; }
 
  public:
   virtual void HandleTaskProgress(const TaskProgressMsg &msg) override;
+  virtual void HandleTaskDone(const TaskDoneMsg &msg) override;
   virtual void ResetOutFiles(const std::vector<std::string> &) override;
+  virtual bool RecalcState(WaitingFor &) const override;
   virtual void Cancel(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual void Rebuild(const std::shared_ptr<StateChangeNotifier> = nullptr);
   virtual void DoClean(const std::shared_ptr<StateChangeNotifier> = nullptr);
@@ -242,6 +244,7 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual void DependentChildren(std::vector<SharedString> &out) const override;
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
+  virtual bool RecalcState(WaitingFor &) const override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -36,7 +36,7 @@ class AssetVersionImplD : public virtual AssetVersionImpl
   friend class MutableAssetHandleD_<DerivedAssetHandle_<AssetVersion,
                                                         AssetVersionImplD> >;
 
-  AssetVersionImplD(const AssetVersionImplD&) =  delete;
+  AssetVersionImplD(const AssetVersionImplD&) = delete;
   AssetVersionImplD& operator=(const AssetVersionImplD&) = delete;
 
  protected:

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -98,7 +98,7 @@ DependentStateTreeFactory::AddOrUpdateVertex(
     // I'm not in the graph yet, so make a new empty vertex and let the caller
     // know we need to load it with the correct information
     auto myVertex = add_vertex(tree);
-    tree[myVertex] = {ref, AssetDefs::New, inDepTree, false, index};
+    tree[myVertex] = {ref, AssetDefs::New, inDepTree, index};
     ++index;
     vertices[ref] = {myVertex, includeConnections};
     toFillInNext.insert(myVertex);

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -29,7 +29,6 @@ struct AssetVertex {
   SharedString name;
   AssetDefs::State state;
   bool inDepTree;
-  bool stateChanged;
   size_t index; // Used by the dfs function
 };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/SConscript
@@ -149,5 +149,9 @@ env.test('StateUpdater_unittest',
     LIBS=testLibs)
 
 env.test('StorageManagerAssetFactory_unittest',
-    sysmanObjs  + extraObjs + [ 'StorageManagerAssetFactory_unittest.cpp' ],
+    sysmanObjs + extraObjs + [ 'StorageManagerAssetFactory_unittest.cpp' ],
+    LIBS=testLibs)
+
+env.test('AssetOperation_unittest',
+    sysmanObjs + extraObjs + ['AssetOperation_unittest.cpp'],
     LIBS=testLibs)

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -18,7 +18,6 @@
 #define STATEUPDATER_H
 
 #include "AssetVersion.h"
-#include "DependentStateTree.h"
 #include "khAssetManager.h"
 #include "StorageManager.h"
 #include "WaitingAssets.h"
@@ -27,7 +26,7 @@
 
 // This class efficiently updates and propagates asset states. Internally, it
 // represents the asset versions as a directed acyclic graph, and state updates
-// are mostly performed as graph operations.
+// are performed as graph operations.
 class StateUpdater
 {
   private:
@@ -39,18 +38,16 @@ class StateUpdater
     WaitingAssets waitingListeners;
     WaitingAssets inProgressParents;
 
-    void SetState(
-        DependentStateTree & tree,
-        DependentStateTreeVertexDescriptor vertex,
-        AssetDefs::State newState,
-        bool finalStateChange);
     void SetVersionStateAndRunHandlers(
         AssetHandle<AssetVersionImpl> & version,
-        AssetDefs::State newState);
+        AssetDefs::State newState,
+        const WaitingFor & waitingFor = {0, 0},
+        bool sendNotification = true);
     AssetDefs::State RunStateChangeHandlers(
         AssetHandle<AssetVersionImpl> & version,
         AssetDefs::State newState,
-        AssetDefs::State oldState);
+        AssetDefs::State oldState,
+        const WaitingFor & waitingFor);
     AssetDefs::State RunVersionStateChangeHandler(
         AssetHandle<AssetVersionImpl> & version,
         AssetDefs::State newState,
@@ -62,8 +59,12 @@ class StateUpdater
     void NotifyChildOrInputInProgress(
         const WaitingAssets & waitingAssets,
         const std::vector<SharedString> & toNotify);
+    void NotifyChildOrInputSucceeded(
+        WaitingAssets & waitingAssets,
+        const std::vector<SharedString> & toNotify,
+        bool propagate);
     void RecalcState(const SharedString & ref);
-    bool IsParent(const AssetHandle<AssetVersionImpl> & version) const
+    template <class AssetType> bool IsParent(AssetHandle<AssetType> & version) const
         { return !version->children.empty(); }
   public:
     StateUpdater(
@@ -72,14 +73,18 @@ class StateUpdater
       storageManager(sm), assetManager(am),
       waitingListeners(AssetDefs::Waiting), inProgressParents(AssetDefs::InProgress) {}
     StateUpdater() : StateUpdater(&AssetVersion::storageManager(), &theAssetManager) {}
-    void SetStateForRefAndDependents(
+    virtual void SetStateForRefAndDependents(
         const SharedString & ref,
         AssetDefs::State newState,
         std::function<bool(AssetDefs::State)> updateStatePredicate);
-    void UpdateWaitingAssets(
-        const AssetHandle<AssetVersionImpl> & version,
-        AssetDefs::State oldState);
-    void SetInProgress(AssetHandle<AssetVersionImpl> & version);
+    virtual void SetInProgress(AssetHandle<AssetVersionImpl> & version);
+    virtual void SetSucceeded(AssetHandle<AssetVersionImpl> & version);
+    virtual void SetFailed(AssetHandle<AssetVersionImpl> & version);
+    virtual void UpdateWaitingAssets(
+        AssetHandle<const AssetVersionImpl> version,
+        AssetDefs::State oldState,
+        const WaitingFor & waitingFor);
+    virtual void UpdateSucceeded(AssetHandle<const AssetVersionImpl> version, bool propagate);
 };
 
 #endif

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -20,13 +20,15 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <functional>
 #include <gtest/gtest.h>
 #include <map>
 #include <string>
 
 using namespace std;
 
-// These tests cover both StateUpdater.cpp/.h and DependentStateTree.cpp/.h.
+// These tests cover StateUpdater.cpp/.h, DependentStateTree.cpp/.h, and
+// WaitingAssets.cpp/.h.
 
 // All refs must end with "?version=X" or the calls to AssetVersionRef::Bind
 // will try to load assets from disk. For simplicity, we force everything to
@@ -61,6 +63,8 @@ class MockVersion : public AssetVersionImpl {
     mutable bool fatalLogFileWritten;
     mutable InputAndChildStateData stateData;
     mutable bool stateRecalced;
+    bool setAndPropagateStateCalled;
+    double progressNotified;
     OnStateChangeBehavior stateChangeBehavior;
     bool recalcStateReturnVal;
     vector<AssetKey> dependents;
@@ -74,9 +78,11 @@ class MockVersion : public AssetVersionImpl {
           // they are never set.
           stateData({AssetDefs::New, AssetDefs::New, false, 999, 999}),
           stateRecalced(false),
+          setAndPropagateStateCalled(false),
+          progressNotified(0.0),
           stateChangeBehavior(NO_ERRORS),
           recalcStateReturnVal(true) {
-      type = AssetDefs::Imagery;
+      type = AssetDefs::Imagery; // Ensures that operator bool can return true
       state = STARTING_STATE;
     }
     MockVersion(const AssetKey & ref)
@@ -119,9 +125,15 @@ class MockVersion : public AssetVersionImpl {
     virtual void WriteFatalLogfile(const std::string &, const std::string &) const throw() override {
       fatalLogFileWritten = true;
     }
-    virtual bool RecalcState() const override {
+    virtual bool RecalcState(WaitingFor & waitingFor) const override {
       stateRecalced = true;
+      waitingFor.inputs = 2;
+      waitingFor.children = 2;
       return recalcStateReturnVal;
+    }
+    virtual void SetAndPropagateState(AssetDefs::State newstate) override {
+      state = newstate;
+      setAndPropagateStateCalled = true;
     }
 
     // Not used - only included to make MockVersion non-virtual
@@ -142,7 +154,6 @@ class MockStorageManager : public StorageManagerInterface<AssetVersionImpl> {
         return version;
       }
       cout << "Could not find asset version " << ref << endl;
-      assert(false);
       return nullptr;
     }
   public:
@@ -185,8 +196,11 @@ class MockAssetManager : public khAssetManagerInterface {
   public:
     MockAssetManager(MockStorageManager * sm) : sm(sm) {}
     virtual void NotifyVersionStateChange(const SharedString &ref,
-                                          AssetDefs::State state) {
+                                          AssetDefs::State state) override {
       ++GetMutableVersion(*sm, unfix(ref))->notificationsSent;
+    }
+    virtual void NotifyVersionProgress(const SharedString & ref, double progress) override {
+      GetMutableVersion(*sm, unfix(ref))->progressNotified = progress;
     }
 };
 
@@ -251,7 +265,12 @@ void GetBigTree(MockStorageManager & sm) {
   SetDependent(sm, "p1", "c1");
 }
 
-void assertStateSet(MockStorageManager & sm, const SharedString & ref, int stateChanges = 1) {
+// When calling SetStateForRefAndDependents, the state will change twice for assets in the
+// dependent tree - once to set it to the requested state and once after the state is
+// recalculated. For assets not in the dependent tree, or when calling functions other than
+// SetStateForRefAndDependents, the state will only be set once. In these cases we must
+// pass in the number of expected state changes.
+void assertStateSet(MockStorageManager & sm, const SharedString & ref, int stateChanges = 2) {
   ASSERT_TRUE(GetVersion(sm, ref)->loadedMutable) << ref << " was not loaded mutable";
   ASSERT_EQ(GetVersion(sm, ref)->onStateChangeCalled, stateChanges) << "OnStateChange was not called enough times for " << ref;
   ASSERT_EQ(GetVersion(sm, ref)->notificationsSent, 1) << "Wrong number of notifications sent for " << ref;
@@ -298,7 +317,7 @@ TEST_F(StateUpdaterTest, SetStateMultipleVersionsFromChild) {
   
   assertStateSet(sm, "p1");
   assertStateSet(sm, "c1");
-  assertStateSet(sm, "gp");
+  assertStateSet(sm, "gp", 1);
 
   assertStateNotSet(sm, "gpi");
   assertStateNotSet(sm, "pi1");
@@ -350,7 +369,7 @@ TEST_F(StateUpdaterTest, DontComputeStateCanceled) {
 
 TEST_F(StateUpdaterTest, ComputeState) {
   testNeedComputeState(sm, updater, AssetDefs::Queued);
-  assertStateSet(sm, "a");
+  assertStateSet(sm, "a", 1);
 }
 
 TEST_F(StateUpdaterTest, NoInputsNoChildren) {
@@ -358,8 +377,8 @@ TEST_F(StateUpdaterTest, NoInputsNoChildren) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Queued);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::Succeeded);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 0);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 void OnlineInputBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs::State inputState) {
@@ -373,8 +392,8 @@ void OnlineInputBlockerTest(MockStorageManager & sm, StateUpdater & updater, Ass
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.blockersAreOffline, false);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 0);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, BlockedInputBlocker) {
@@ -400,8 +419,8 @@ TEST_F(StateUpdaterTest, OfflineInputBlocker) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.blockersAreOffline, true);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 0);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, BlockedAndOfflineInput) {
@@ -413,8 +432,8 @@ TEST_F(StateUpdaterTest, BlockedAndOfflineInput) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Blocked);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.blockersAreOffline, false);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 0);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, WaitingOnInput) {
@@ -427,8 +446,8 @@ TEST_F(StateUpdaterTest, WaitingOnInput) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Waiting);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 2);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, SucceededInputs) {
@@ -441,8 +460,8 @@ TEST_F(StateUpdaterTest, SucceededInputs) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Queued);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 0);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 void ChildBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs::State inputState) {
@@ -455,7 +474,7 @@ void ChildBlockerTest(MockStorageManager & sm, StateUpdater & updater, AssetDefs
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::Blocked);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, FailedChildBlocker) {
@@ -488,7 +507,7 @@ TEST_F(StateUpdaterTest, ChildInProgress) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::InProgress);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 2);
 }
 
 TEST_F(StateUpdaterTest, ChildQueued) {
@@ -501,7 +520,7 @@ TEST_F(StateUpdaterTest, ChildQueued) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Queued;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::Queued);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, SucceededChildren) {
@@ -514,7 +533,7 @@ TEST_F(StateUpdaterTest, SucceededChildren) {
   GetMutableVersion(sm, "d")->state = AssetDefs::Succeeded;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::Succeeded);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 0);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 0);
 }
 
 TEST_F(StateUpdaterTest, ChildrenAndDependents) {
@@ -535,7 +554,7 @@ TEST_F(StateUpdaterTest, ChildrenAndDependents) {
     return !(state == AssetDefs::Succeeded || state == AssetDefs::Queued || state == AssetDefs::Failed);
   });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::InProgress);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 1);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 1);
 }
 
 TEST_F(StateUpdaterTest, ChildrenAndInputs) {
@@ -556,8 +575,8 @@ TEST_F(StateUpdaterTest, ChildrenAndInputs) {
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State) { return true; });
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByChildren, AssetDefs::InProgress);
   ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.stateByInputs, AssetDefs::Waiting);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numInputsWaitingFor, 2);
-  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.numChildrenWaitingFor, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.inputs, 2);
+  ASSERT_EQ(GetMutableVersion(sm, "a")->stateData.waitingFor.children, 2);
 }
 
 // This tests a tricky corner case. d and e are inputs/children of a, but they
@@ -597,8 +616,8 @@ TEST_F(StateUpdaterTest, InputIsParent) {
   assertStateSet(sm, "a");
   assertStateSet(sm, "b");
   assertStateSet(sm, "c");
-  assertStateSet(sm, "d");
-  assertStateSet(sm, "e");
+  assertStateSet(sm, "d", 1);
+  assertStateSet(sm, "e", 1);
 }
 
 // This test creates a long chain of parents and dependents and makes sure
@@ -623,8 +642,8 @@ TEST_F(StateUpdaterTest, MultipleLevelsParentsDependents) {
   });
   assertStateNotSet(sm, "a");
   assertStateNotSet(sm, "b");
-  assertStateSet(sm, "c");
-  assertStateSet(sm, "d");
+  assertStateSet(sm, "c", 1);
+  assertStateSet(sm, "d", 1);
   assertStateSet(sm, "e");
   assertStateSet(sm, "f");
   assertStateSet(sm, "g");
@@ -635,11 +654,9 @@ TEST_F(StateUpdaterTest, MultipleLevelsParentsDependents) {
 // Verify that an asset's state doesn't change if its non-child dependent's
 // state changes.
 TEST_F(StateUpdaterTest, NonChildDependent) {
-  const AssetDefs::State NO_CHANGE_STATE = AssetDefs::Waiting;
   SetVersions(sm, {MockVersion("a"), MockVersion("b")});
   SetDependent(sm, "a", "b");
-  GetMutableVersion(sm, "a")->state = NO_CHANGE_STATE;
-  updater.SetStateForRefAndDependents(fix("a"), NO_CHANGE_STATE, [](AssetDefs::State) { return true; });
+  updater.SetStateForRefAndDependents(fix("b"), AssetDefs::Waiting, [](AssetDefs::State) { return true; });
   assertStateNotSet(sm, "a");
   assertStateSet(sm, "b");
 }
@@ -648,9 +665,10 @@ void StateChangeErrorTest(MockStorageManager & sm, StateUpdater & updater, OnSta
   SetVersions(sm, {MockVersion("a")});
   GetMutableVersion(sm, "a")->stateChangeBehavior = behavior;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State state) { return true; });
-  // We will call OnStateChange twice - once after setting it to the requested
-  // state and again after setting it to Failed.
-  assertStateSet(sm, "a", 2);
+  // We will call OnStateChange four times: to set it to the requested state,
+  // which will trigger a transition to failed, and then to recalculate the
+  // state, which will trigger another transition to failed.
+  assertStateSet(sm, "a", 4);
   ASSERT_EQ(GetVersion(sm, "a")->state, AssetDefs::Failed);
 }
 
@@ -689,109 +707,261 @@ TEST_F(StateUpdaterTest, OnStateChangeReturnsNewState) {
   SetVersions(sm, {MockVersion("a")});
   GetMutableVersion(sm, "a")->stateChangeBehavior = RETURN_NEW_STATE;
   updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State state) { return true; });
-  assertStateSet(sm, "a", 3);
+  assertStateSet(sm, "a", 4);
 }
 
-void SetInProgress(MockStorageManager & sm, StateUpdater & updater, AssetKey ref) {
+TEST_F(StateUpdaterTest, ReferenceNonExistentAsset) {
+  // Test a case in which an asset references a non-existent asset. We mostly
+  // want to make sure this doesn't crash.
+  SetVersions(sm, {MockVersion("a")});
+  GetMutableVersion(sm, "a")->children.push_back(fix("b"));
+  updater.SetStateForRefAndDependents(fix("a"), AssetDefs::New, [](AssetDefs::State state) { return true; });
+}
+
+// The expected outcomes from the SetInProgress and SetSucceeded functions are
+// similar, so they are testing using the same code.
+struct SetStateTestData {
+  function<void(StateUpdater *, AssetHandle<AssetVersionImpl> &)> SetStateFunc;
+  AssetDefs::State expectedState;
+};
+
+const SetStateTestData IN_PROGRESS_TEST_DATA = {&StateUpdater::SetInProgress, AssetDefs::InProgress};
+const SetStateTestData SUCCEEDED_TEST_DATA = {&StateUpdater::SetSucceeded, AssetDefs::Succeeded};
+
+void TestSetState(
+    MockStorageManager & sm,
+    StateUpdater & updater,
+    AssetKey ref,
+    const SetStateTestData & testData) {
   auto version = sm.GetMutable(fix(ref));
-  updater.SetInProgress(version);
-  ASSERT_EQ(GetVersion(sm, ref)->state, AssetDefs::InProgress);
+  testData.SetStateFunc(&updater, version);
+  ASSERT_EQ(GetVersion(sm, ref)->state, testData.expectedState);
   if (GetVersion(sm, ref)->stateChangeBehavior != CHANGE_NUM_CHILDREN) {
-    assertStateSet(sm, ref);
+    assertStateSet(sm, ref, 1);
   }
 }
 
-TEST_F(StateUpdaterTest, BasicSetInProgress) {
+void SetInProgress(MockStorageManager & sm, StateUpdater & updater, AssetKey ref) {
+  TestSetState(sm, updater, ref, IN_PROGRESS_TEST_DATA);
+}
+
+void SetSucceeded(MockStorageManager & sm, StateUpdater & updater, AssetKey ref) {
+  TestSetState(sm, updater, ref, SUCCEEDED_TEST_DATA);
+}
+
+void RunSetStateTest(function<void(MockStorageManager &, StateUpdater &, const SetStateTestData &)> testFunc) {
+  vector<SetStateTestData> tests = {IN_PROGRESS_TEST_DATA, SUCCEEDED_TEST_DATA};
+
+  for (const auto & test : tests) {
+    MockStorageManager sm;
+    MockAssetManager am(&sm);
+    StateUpdater updater(&sm, &am);
+    testFunc(sm, updater, test);
+  }
+}
+
+TEST(SetStateTest, SetStateNoParentsListeners) {
+  RunSetStateTest([](MockStorageManager & sm, StateUpdater & updater, const SetStateTestData & test) {
+    SetVersions(sm, {MockVersion("a")});
+    TestSetState(sm, updater, "a", test);
+  });
+}
+
+TEST(SetStateTest, SetStateNoWaiting) {
+  RunSetStateTest([](MockStorageManager & sm, StateUpdater & updater, const SetStateTestData & test) {
+    SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+    SetParentChild(sm, "a", "c");
+    SetListenerInput(sm, "b", "c");
+    TestSetState(sm, updater, "c", test);
+    // Since nothing is marked waiting, both the parent and listener should have
+    // their states recalculated.
+    ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
+    ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
+  });
+}
+
+void UpdateWaiting(MockStorageManager & sm, StateUpdater & updater, AssetKey ref, AssetDefs::State oldState, uint32 numWaitingFor = 2) {
+  auto version = sm.Get(fix(ref));
+  updater.UpdateWaitingAssets(version, oldState, {numWaitingFor, numWaitingFor});
+}
+
+TEST(SetStateTest, SetStateTestWaiting) {
+  RunSetStateTest([](MockStorageManager & sm, StateUpdater & updater, const SetStateTestData & test) {
+    // Mark the parent and listener as waiting and make sure their states are
+    // not recalculated.
+    SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+    SetParentChild(sm, "a", "c");
+    SetListenerInput(sm, "b", "c");
+
+    GetMutableVersion(sm, "a")->state = AssetDefs::InProgress;
+    UpdateWaiting(sm, updater, "a", AssetDefs::Queued);
+    GetMutableVersion(sm, "b")->state = AssetDefs::Waiting;
+    UpdateWaiting(sm, updater, "b", AssetDefs::Queued);
+    TestSetState(sm, updater, "c", test);
+    ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+    ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+
+    // Now mark the parent and listener as not waiting again and make sure the
+    // updater goes back to calculating their states
+    GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
+    GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+    GetMutableVersion(sm, "c")->notificationsSent = 0;
+    GetMutableVersion(sm, "a")->state = AssetDefs::Blocked;
+    UpdateWaiting(sm, updater, "a", AssetDefs::InProgress);
+    GetMutableVersion(sm, "b")->state = AssetDefs::Blocked;
+    UpdateWaiting(sm, updater, "b", AssetDefs::Waiting);
+    TestSetState(sm, updater, "c", test);
+    ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
+    ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
+  });
+}
+
+TEST(SetStateTest, SetStateUnsupportedException) {
+  RunSetStateTest([](MockStorageManager & sm, StateUpdater & updater, const SetStateTestData & test) {
+    SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+    SetParentChild(sm, "a", "c");
+    GetMutableVersion(sm, "c")->stateChangeBehavior = CHANGE_NUM_CHILDREN;
+    TestSetState(sm, updater, "c", test);
+    // We should get partway through setting c's state
+    ASSERT_TRUE(GetVersion(sm, "c")->loadedMutable);
+    ASSERT_EQ(GetVersion(sm, "c")->onStateChangeCalled, 1);
+    ASSERT_EQ(GetVersion(sm, "c")->notificationsSent, 0);
+    // We should not recalculate a's state
+    ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+  });
+}
+
+TEST_F(StateUpdaterTest, SetStateAlreadyWaiting) {
+  RunSetStateTest([](MockStorageManager & sm, StateUpdater & updater, const SetStateTestData & test) {
+    // This tests what happens when we encounter an asset that's already waiting
+    // but is not in the waiting list.
+    SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+    SetParentChild(sm, "a", "c");
+    SetListenerInput(sm, "b", "c");
+    GetMutableVersion(sm, "a")->state = AssetDefs::InProgress;
+    GetMutableVersion(sm, "b")->state = AssetDefs::Waiting;
+    GetMutableVersion(sm, "a")->recalcStateReturnVal = false;
+    GetMutableVersion(sm, "b")->recalcStateReturnVal = false;
+
+    TestSetState(sm, updater, "c", test);
+    // Both the parent and listener should have been recalculated
+    ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
+    ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
+
+    // Now make sure the parent and listener are in the waiting list by setting
+    // the state again and making sure they aren't recalculated.
+    GetMutableVersion(sm, "a")->stateRecalced = false;
+    GetMutableVersion(sm, "b")->stateRecalced = false;
+    GetMutableVersion(sm, "c")->loadedMutable = false;
+    GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+    GetMutableVersion(sm, "c")->notificationsSent = 0;
+    GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
+
+    TestSetState(sm, updater, "c", test);
+    ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+    ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+
+    // Set the state again and make sure the waiting count has now gone down to
+    // zero and the states are recalculated. Waiting counts won't go down when
+    // we're setting in progress, so this is only done for the Succeeded test.
+    if (test.expectedState == AssetDefs::Succeeded) {
+      GetMutableVersion(sm, "a")->stateRecalced = false;
+      GetMutableVersion(sm, "b")->stateRecalced = false;
+      GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+      GetMutableVersion(sm, "c")->notificationsSent = 0;
+      GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
+      TestSetState(sm, updater, "c", test);
+      ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
+      ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
+    }
+  });
+}
+
+TEST_F(StateUpdaterTest, RecalcWhenDoneWaiting) {
+  // Make sure parent and listener states are recalculated when the waiting for
+  // count gets to 0.
+  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+  SetParentChild(sm, "a", "c");
+  SetListenerInput(sm, "b", "c");
+  GetMutableVersion(sm, "a")->state = AssetDefs::InProgress;
+  GetMutableVersion(sm, "b")->state = AssetDefs::Waiting;
+  UpdateWaiting(sm, updater, "a", AssetDefs::New, 3);
+  UpdateWaiting(sm, updater, "b", AssetDefs::New, 3);
+
+  // First completion - state should not be calculated
+  SetInProgress(sm, updater, "c");
+  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+  GetMutableVersion(sm, "c")->notificationsSent = 0;
+  SetSucceeded(sm, updater, "c");
+  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+
+  // Second completion - state should still not be calculated
+  GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
+  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+  GetMutableVersion(sm, "c")->notificationsSent = 0;
+  SetInProgress(sm, updater, "c");
+  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+  GetMutableVersion(sm, "c")->notificationsSent = 0;
+  SetSucceeded(sm, updater, "c");
+  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+
+  // Third completion - state should be recalculated after "c" succeeds
+  GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
+  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+  GetMutableVersion(sm, "c")->notificationsSent = 0;
+  SetInProgress(sm, updater, "c");
+  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
+  GetMutableVersion(sm, "c")->notificationsSent = 0;
+  SetSucceeded(sm, updater, "c");
+  ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
+  ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
+}
+
+void UpdateSucceeded(MockStorageManager & sm, StateUpdater & updater, AssetKey ref, bool propagate = true) {
+  auto version = sm.Get(fix(ref));
+  updater.UpdateSucceeded(version, propagate);
+}
+
+TEST_F(StateUpdaterTest, UpdateSucceededNoPropagate) {
+  // When we call UpdateSucceeded and disable propagation, no states should
+  // change.
+  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
+  SetParentChild(sm, "a", "c");
+  SetListenerInput(sm, "b", "c");
+  UpdateSucceeded(sm, updater, "c", false);
+  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
+  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+  ASSERT_FALSE(GetVersion(sm, "c")->stateRecalced);
+}
+
+TEST_F(StateUpdaterTest, SetFailed) {
   SetVersions(sm, {MockVersion("a")});
+  auto version = sm.GetMutable(fix("a"));
+  updater.SetFailed(version);
+  ASSERT_TRUE(GetVersion(sm, "a")->setAndPropagateStateCalled);
+  ASSERT_EQ(GetVersion(sm, "a")->state, AssetDefs::Failed);
+}
+
+TEST_F(StateUpdaterTest, NotifyProgressSuccess) {
+  const double PROGRESS = 12.3;
+  SetVersions(sm, {MockVersion("a")});
+  GetMutableVersion(sm, "a")->progress = PROGRESS;
   SetInProgress(sm, updater, "a");
+  ASSERT_EQ(GetVersion(sm, "a")->progressNotified, PROGRESS);
 }
 
-TEST_F(StateUpdaterTest, SetInProgressNoWaiting) {
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
-  SetParentChild(sm, "a", "c");
-  SetListenerInput(sm, "b", "c");
-  SetInProgress(sm, updater, "c");
-  // Since nothing is marked waiting, both the parent and listener should have
-  // their states recalculated.
-  ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
-  ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
-}
-
-void UpdateWaiting(MockStorageManager & sm, StateUpdater & updater, AssetKey ref, AssetDefs::State oldState) {
-  auto version = sm.GetMutable(fix(ref));
-  updater.UpdateWaitingAssets(version, oldState);
-}
-
-TEST_F(StateUpdaterTest, SetInProgressTestWaiting) {
-  // Mark the parent and listener as waiting and make sure their states are
-  // not recalculated.
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
-  SetParentChild(sm, "a", "c");
-  SetListenerInput(sm, "b", "c");
-
-  GetMutableVersion(sm, "a")->state = AssetDefs::InProgress;
-  UpdateWaiting(sm, updater, "a", AssetDefs::Queued);
-  GetMutableVersion(sm, "b")->state = AssetDefs::Waiting;
-  UpdateWaiting(sm, updater, "b", AssetDefs::Queued);
-  SetInProgress(sm, updater, "c");
-  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
-  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
-  
-  // Now mark the parent and listener as not waiting again and make sure the
-  // updater goes back to calculating their states
-  GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
-  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
-  GetMutableVersion(sm, "c")->notificationsSent = 0;
-  GetMutableVersion(sm, "a")->state = AssetDefs::Blocked;
-  UpdateWaiting(sm, updater, "a", AssetDefs::InProgress);
-  GetMutableVersion(sm, "b")->state = AssetDefs::Blocked;
-  UpdateWaiting(sm, updater, "b", AssetDefs::Waiting);
-  SetInProgress(sm, updater, "c");
-  ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
-  ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
-}
-
-TEST_F(StateUpdaterTest, SetInProgressUnsupportedException) {
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
-  SetParentChild(sm, "a", "c");
-  GetMutableVersion(sm, "c")->stateChangeBehavior = CHANGE_NUM_CHILDREN;
-  SetInProgress(sm, updater, "c");
-  // We should get partway through setting c's state
-  ASSERT_TRUE(GetVersion(sm, "c")->loadedMutable);
-  ASSERT_EQ(GetVersion(sm, "c")->onStateChangeCalled, 1);
-  ASSERT_EQ(GetVersion(sm, "c")->notificationsSent, 0);
-  // We should not recalculate a's state
-  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
-}
-
-TEST_F(StateUpdaterTest, SetInProgressAlreadyWaiting) {
-  // This tests what happens when we encounter an asset that's already waiting
-  // but is not in the waiting list.
-  SetVersions(sm, {MockVersion("a"), MockVersion("b"), MockVersion("c")});
-  SetParentChild(sm, "a", "c");
-  SetListenerInput(sm, "b", "c");
-  GetMutableVersion(sm, "a")->state = AssetDefs::InProgress;
-  GetMutableVersion(sm, "b")->state = AssetDefs::Waiting;
-  GetMutableVersion(sm, "a")->recalcStateReturnVal = false;
-  GetMutableVersion(sm, "b")->recalcStateReturnVal = false;
-
-  SetInProgress(sm, updater, "c");
-  // Both the parent and listener should have been recalculated
-  ASSERT_TRUE(GetVersion(sm, "a")->stateRecalced);
-  ASSERT_TRUE(GetVersion(sm, "b")->stateRecalced);
-
-  // Now make sure the parent and listener are in the waiting list by setting
-  // the state again and making sure they aren't recalculated.
-  GetMutableVersion(sm, "a")->stateRecalced = false;
-  GetMutableVersion(sm, "b")->stateRecalced = false;
-  GetMutableVersion(sm, "c")->loadedMutable = false;
-  GetMutableVersion(sm, "c")->onStateChangeCalled = 0;
-  GetMutableVersion(sm, "c")->notificationsSent = 0;
-  GetMutableVersion(sm, "c")->state = AssetDefs::Queued;
-
-  SetInProgress(sm, updater, "c");
-  ASSERT_FALSE(GetVersion(sm, "a")->stateRecalced);
-  ASSERT_FALSE(GetVersion(sm, "b")->stateRecalced);
+TEST_F(StateUpdaterTest, NotifyProgressFailed) {
+  const double PROGRESS = 12.3;
+  SetVersions(sm, {MockVersion("a")});
+  GetMutableVersion(sm, "a")->progress = PROGRESS;
+  GetMutableVersion(sm, "a")->stateChangeBehavior = STATE_CHANGE_EXCEPTION;
+  auto version = sm.GetMutable(fix("a"));
+  updater.SetInProgress(version);
+  ASSERT_NE(GetVersion(sm, "a")->progressNotified, PROGRESS);
 }
 
 int main(int argc, char **argv) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.cpp
@@ -19,15 +19,30 @@
 void WaitingAssets::Update(
     const SharedString & ref,
     AssetDefs::State newState,
-    AssetDefs::State oldState) {
-  if (newState == waitingState) {
-    waiting.insert(ref);
+    AssetDefs::State oldState,
+    uint numWaitingFor) {
+  if (newState == waitingState && numWaitingFor > 0) {
+    waiting[ref] = numWaitingFor;
   }
   else if (oldState == waitingState) {
     waiting.erase(ref);
   }
 }
 
-bool WaitingAssets::IsWaiting(const SharedString & ref) const {
-  return waiting.find(ref) != waiting.end();
+bool WaitingAssets::DecrementAndCheckWaiting(const SharedString & ref) {
+  auto asset = waiting.find(ref);
+  if (IsWaiting(asset)) {
+    --asset->second;
+    if (asset->second > 0) {
+      // Still waiting
+      return true;
+    }
+    else {
+      // This was the last one we were waiting for, so we're no longer waiting
+      waiting.erase(asset);
+      return false;
+    }
+  }
+  // We were not waiting to begin with
+  return false;
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.cpp
@@ -20,7 +20,7 @@ void WaitingAssets::Update(
     const SharedString & ref,
     AssetDefs::State newState,
     AssetDefs::State oldState,
-    uint numWaitingFor) {
+    uint32 numWaitingFor) {
   if (newState == waitingState && numWaitingFor > 0) {
     waiting[ref] = numWaitingFor;
   }

--- a/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.h
@@ -20,19 +20,26 @@
 #include "autoingest/.idl/storage/AssetDefs.h"
 #include "common/SharedString.h"
 
-#include <unordered_set>
+#include <unordered_map>
 
 class WaitingAssets {
   private:
+    using WaitingContainer = std::unordered_map<SharedString, uint>;
     const AssetDefs::State waitingState;
-    std::unordered_set<SharedString> waiting;
+    WaitingContainer waiting;
+
+    inline bool IsWaiting(WaitingContainer::const_iterator asset) const
+      { return asset != waiting.end(); }
   public:
     WaitingAssets(AssetDefs::State waitingState) : waitingState(waitingState) {}
+    inline bool IsWaiting(const SharedString & ref) const
+      { return IsWaiting(waiting.find(ref)); }
     void Update(
         const SharedString & ref,
         AssetDefs::State newState,
-        AssetDefs::State oldState);
-    bool IsWaiting(const SharedString & ref) const;
+        AssetDefs::State oldState,
+        uint numWaitingFor);
+    bool DecrementAndCheckWaiting(const SharedString & ref);
 };
 
 #endif // WAITINGASSETS_H

--- a/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/WaitingAssets.h
@@ -24,7 +24,7 @@
 
 class WaitingAssets {
   private:
-    using WaitingContainer = std::unordered_map<SharedString, uint>;
+    using WaitingContainer = std::unordered_map<SharedString, uint32>;
     const AssetDefs::State waitingState;
     WaitingContainer waiting;
 
@@ -38,7 +38,7 @@ class WaitingAssets {
         const SharedString & ref,
         AssetDefs::State newState,
         AssetDefs::State oldState,
-        uint numWaitingFor);
+        uint32 numWaitingFor);
     bool DecrementAndCheckWaiting(const SharedString & ref);
 };
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.cpp
@@ -665,10 +665,7 @@ khAssetManager::TaskDone(const TaskDoneMsg &msg)
   alwaysTaskCmds.push_back
     (TaskCmd(std::mem_fun(&khResourceManager::BumpDownBlockers)));
 
-  AssetVersionD ver(msg.verref);
-  if (ver->taskid == msg.taskid) {
-    MutableAssetVersionD(msg.verref)->HandleTaskDone(msg);
-  }
+  ::HandleTaskDone(msg);
 }
 
 void

--- a/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khAssetManager.h
@@ -67,6 +67,7 @@ class khAssetManagerInterface {
  public:
   virtual void NotifyVersionStateChange(const SharedString &ref,
                                         AssetDefs::State state) = 0;
+  virtual void NotifyVersionProgress(const SharedString &ref, double progress) = 0;
 };
 
 class khAssetManager : public khAssetManagerInterface
@@ -87,8 +88,8 @@ class khAssetManager : public khAssetManagerInterface
   // routines others can call to tell me about things that need to be done
   // once the AssetGuard has been released
   virtual void NotifyVersionStateChange(const SharedString &ref,
-                                        AssetDefs::State state);
-  void NotifyVersionProgress(const SharedString &ref,double progress);
+                                        AssetDefs::State state) override;
+  virtual void NotifyVersionProgress(const SharedString &ref, double progress) override;
   void SubmitTask(const SharedString &verref, const TaskDef &taskdef,
                   int32 priority = 0);
   void DeleteTask(const std::string &verref);


### PR DESCRIPTION
This PR improves the handling for TaskDone messages to make them faster and easier to understand. It also adds tests for the AssetOperation code (and fixes some bugs in that code found through the tests).

No release notes updates are included in this PR because it fits within the release notes updates included in PR #1509.

Fixes #1522