### PR TITLE
Accept col/row/level if x/y/z is missing in wms request when serving portable globes

### DIFF
--- a/earth_enterprise/src/server/mod_fdb/portableservice.cpp
+++ b/earth_enterprise/src/server/mod_fdb/portableservice.cpp
@@ -710,9 +710,18 @@ int PortableService::DoQuery(request_rec* r,
 
   if ((arg_map["request"] == "ImageryMaps") ||
       (arg_map["request"] == "VectorMapsRaster")) {
-    x = atoi(arg_map["x"].c_str());
-    y = atoi(arg_map["y"].c_str());
-    z = atoi(arg_map["z"].c_str());
+    if(arg_map["x"].empty())
+        x = atoi(arg_map["col"].c_str());
+    else
+        x = atoi(arg_map["x"].c_str());
+    if(arg_map["y"].empty())
+        y = atoi(arg_map["row"].c_str());
+    else
+        y = atoi(arg_map["y"].c_str());
+    if(arg_map["z"].empty())
+        z = atoi(arg_map["level"].c_str());
+    else
+        z = atoi(arg_map["z"].c_str());
     if (z > QuadtreePath::kMaxLevel) {
       ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
                     "Zoom level exceeds maximum allowed value.");


### PR DESCRIPTION
This fixes a problem where clients (such as qgis) use col/row/level instead of x/y/z tile requests.  In prior behavior zooming into a cut would throw a generic 404 error in qgis wms without a uri.  New behavior; you can enter the cut and view it cleanly in wms.