### PR TITLE
1241 geglxinfo will process all meshes in a terrain packet

### DIFF
--- a/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_3.rst
+++ b/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_3.rst
@@ -68,6 +68,9 @@ Release notes: Open GEE 5.3.3
          * - 1517
            - geglxinfo should parse vector packets
            - geglxinfo will parse vector packets
+         * - 1241
+           - geglxinfo should parse all meshes in terrain packets
+           - geglxinfo will parse all meshes in terrain packets
 
       .. rubric:: Known Issues
 


### PR DESCRIPTION
#1241 These changes update geglxinfo to process all meshes in a terrain packet.  Prior to this PR only the first mesh in a terrain packet would be processed.

Testing:
1. Build and run geglxinfo against a portable globe that contains terrain data with the --extract_packets parameter.  The terrain packets will be written under the directory globetiles/1/.
2. Verify that the terrain files written contain all the mesh entries for each packet.