### PR TITLE
Escaped all supplemental search fields from the server for HTML compatibility

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/earth/search_supplemental_ui.html
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/earth/search_supplemental_ui.html
@@ -113,7 +113,7 @@ function createSearchList() {
           '<h1  onclick="showHideDiv(\'' + divId + '\')"' +
           ' id="div_' + divId +'">' +
           '<span id="arrow_' + divId + '" class="right_arrow">' +
-          '<label>' + label + '</label></span>' + '</h1>' +
+          '<label>' + escapeHTML(label) + '</label></span>' + '</h1>' +
           '<span id="span_' + divId + '" style="display:none;"></span>';
     } else {
       targetDiv.innerHTML +=
@@ -123,7 +123,7 @@ function createSearchList() {
     // Fill the span with the foundation of the form.
     var targetSpan = document.getElementById('span_' + divId);
     targetSpan.innerHTML =
-        '<form id="SearchForm' + i + '" action="' + formAction + '" accept-charset="UTF-8">' +
+        '<form id="SearchForm' + i + '" action="' + escapeHTML(formAction) + '" accept-charset="UTF-8">' +
         '<div id="fields_' + divId + '">' +
         '</div>' +
         '<input type="submit" value="Search">' +
@@ -140,8 +140,8 @@ function createSearchList() {
       var suggestion = field.suggestion;
       var key = field.key;
       fieldsDiv.innerHTML +=
-          fieldLabel + '<input type="text" name="' + key + '">' +
-          '<label class="fieldLabel">' + suggestion + '</label>';
+          fieldLabel + '<input type="text" name="' + escapeHTML(key) + '">' +
+          '<label class="fieldLabel">' + escapeHTML(suggestion) + '</label>';
     }
 
     // Add additional parameters as form hidden parameters.
@@ -153,8 +153,8 @@ function createSearchList() {
       for (var j = 0; j < additionalParamList.length; j++) {
         var keyValue = additionalParamList[j].split('=');
         fieldsDiv.innerHTML +=
-           '<input type="hidden" name="' + keyValue[0] + '" ' +
-           'value="' + keyValue[1] + '">';
+           '<input type="hidden" name="' + escapeHTML(keyValue[0]) + '" ' +
+           'value="' + escapeHTML(keyValue[1]) + '">';
       }
     }
 
@@ -186,6 +186,13 @@ function makeGETRequest(url) {
   return retrieveDatabases.responseText;
 }
 
+// Escapes HTML characters so that the given string can be used within HTML
+function escapeHTML(str) {
+  var regex = /[&<>"']/g
+  return str.replace(regex, function onReplace(match) {
+                              return '&#' + match.charCodeAt(0) + ';';
+                            });
+}
 </script>
 
 <style type="text/css">


### PR DESCRIPTION
Adds HTML escaping to fields used on the supplemental search page in Google Earth client.

To test:
1) Modify the search_def_table to use a search suggestion with added HTML tags.
    i.e.
`set search_def_content = '{"additional_config_param": null, "label": "Coordinates", "additional_query_param": "flyToFirstElement=true&displayKeys=location", "service_url": "/gesearch/CoordinateSearch", "result_type": "KML", "html_transform_url": "about:blank", "kml_transform_url":  "about:blank", "suggest_server": "about:blank", "fields": [{"key": "q", "suggestion": "<h1>Injected HTML</h1><h2>Latitude, longitude (e.g., 23.47, -132.67)</h2>", "label": null}]}' where search_def_id = 3`
2) Publish a globe database selecting the Search Tab and Supplemental Search Tab for the search type that was modified in step 1) (i.e. Coordinate). Both tabs have to be added because the Supplemental Search page only appears if the corresponding Search exists.
3) Open the published globe in EC. The main search suggestion appears rendered in HTML (This is believed to happen in EC which we can't change), but after clicking on the label (button) for the supplemental search page, the suggestion appears as plain text showing the HTML tags. This is the result of escaping the HTML characters on the supplemental search page.

Tested on CentOS7 with Win 10 client.
Fixes #1532 