### PR TITLE
Don't run state change handlers unnecessarily

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -374,9 +374,7 @@ void StateUpdater::UpdateWaitingAssets(
   const SharedString ref = version->GetRef();
   const AssetDefs::State newState = version->state;
   waitingListeners.Update(ref, newState, oldState, waitingFor.inputs);
-  if (IsParent(version)) {
-    inProgressParents.Update(ref, newState, oldState, waitingFor.children);
-  }
+  inProgressParents.Update(ref, newState, oldState, waitingFor.children);
 }
 
 void StateUpdater::SetInProgress(AssetHandle<AssetVersionImpl> & version) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -188,7 +188,7 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
         DependentStateTreeVertexDescriptor vertex,
         AssetDefs::State newState,
         const WaitingFor & waitingFor,
-        bool sendNotification) const {
+        bool runHandlers) const {
       SharedString name = tree[vertex].name;
       AssetDefs::State oldState = tree[vertex].state;
       if (newState != oldState) {
@@ -196,7 +196,7 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
               name.toString().c_str(), ToString(oldState).c_str(), ToString(newState).c_str());
         auto version = updater.storageManager->GetMutable(name);
         if (version) {
-          updater.SetVersionStateAndRunHandlers(version, newState, waitingFor, sendNotification);
+          updater.SetVersionStateAndRunHandlers(version, newState, waitingFor, runHandlers);
 
           // Get the new state directly from the asset version since it may be
           // different from the passed-in state
@@ -257,9 +257,9 @@ class StateUpdater::SetStateVisitor : public default_dfs_visitor {
       // Set the state for assets in the dependent tree.
       if (data.inDepTree) {
         // Check if we're going to recalculate the state below. If not, we need
-        // to send the state change notification now.
-        bool sendNotification = UserActionRequired(newState);
-        SetState(vertex, newState, {0, 0}, sendNotification);
+        // to run the handlers now.
+        bool runHandlers = UserActionRequired(newState);
+        SetState(vertex, newState, {0, 0}, runHandlers);
       }
 
       // For all assets (including parents and listeners) recalculate the state

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -41,8 +41,7 @@ class StateUpdater
     void SetVersionStateAndRunHandlers(
         AssetHandle<AssetVersionImpl> & version,
         AssetDefs::State newState,
-        const WaitingFor & waitingFor = {0, 0},
-        bool sendNotification = true);
+        const WaitingFor & waitingFor = {0, 0});
     AssetDefs::State RunStateChangeHandlers(
         AssetHandle<AssetVersionImpl> & version,
         AssetDefs::State newState,


### PR DESCRIPTION
Fixes a difference between the new StateUpdater code and the legacy AssetVersionD code in which OnStateChange was called unnecessarily during the first phase of a resume.

Fixes #1556