### PR TITLE
Delete methods

### DIFF
--- a/earth_enterprise/src/common/compressor.cpp
+++ b/earth_enterprise/src/common/compressor.cpp
@@ -64,7 +64,7 @@ uint32 MinifyCompressor::decompress(char* inbuf, int inbufSize, char* outbuf) {
 //------------------------------------------------------------------------------
 
 static void errorExit(j_common_ptr cinfo) {
-  ErrorMgr* err = (ErrorMgr*)cinfo->err;
+  ErrorMgr* err = static_cast<ErrorMgr*>(cinfo->err);//(ErrorMgr*)cinfo->err;
 
   // Format the warning message.
   char buffer[JMSG_LENGTH_MAX];
@@ -157,7 +157,7 @@ JPEGCompressor::JPEGCompressor(uint32 w, uint32 h,
 
   jpeg_set_defaults(&cinfo_);
 
-  jpeg_set_quality(&cinfo_, quality_, TRUE);
+  jpeg_set_quality(&cinfo_, quality_, true);
 }
 
 JPEGCompressor::~JPEGCompressor() {
@@ -167,7 +167,7 @@ JPEGCompressor::~JPEGCompressor() {
 
 uint32 JPEGCompressor::compress(const char *inbuf) {
   // Initialize internal state of jpeg compressor.
-  jpeg_start_compress(&cinfo_, TRUE);
+  jpeg_start_compress(&cinfo_, true);
 
   // Add JPEG comment tag, if available.
   if (!comment_string_.empty()) {

--- a/earth_enterprise/src/common/compressor.cpp
+++ b/earth_enterprise/src/common/compressor.cpp
@@ -261,6 +261,10 @@ class LZCompressor : public Compressor {
  public:
   LZCompressor(int l, uint32 sz);
   virtual ~LZCompressor();
+  LZCompressor(const LZCompressor&) = delete;
+  LZCompressor(LZCompressor&&) = delete;
+  LZCompressor& operator=(const LZCompressor&) = delete;
+  LZCompressor& operator=(LZCompressor&&) = delete;
 
   virtual char *data() { return buf; }
   virtual uint32 dataLen() { return bufLen; }

--- a/earth_enterprise/src/common/compressor.cpp
+++ b/earth_enterprise/src/common/compressor.cpp
@@ -64,7 +64,7 @@ uint32 MinifyCompressor::decompress(char* inbuf, int inbufSize, char* outbuf) {
 //------------------------------------------------------------------------------
 
 static void errorExit(j_common_ptr cinfo) {
-  ErrorMgr* err = static_cast<ErrorMgr*>(cinfo->err);//(ErrorMgr*)cinfo->err;
+  ErrorMgr* err = static_cast<ErrorMgr*>(cinfo->err);
 
   // Format the warning message.
   char buffer[JMSG_LENGTH_MAX];
@@ -157,7 +157,7 @@ JPEGCompressor::JPEGCompressor(uint32 w, uint32 h,
 
   jpeg_set_defaults(&cinfo_);
 
-  jpeg_set_quality(&cinfo_, quality_, true);
+  jpeg_set_quality(&cinfo_, quality_, TRUE);
 }
 
 JPEGCompressor::~JPEGCompressor() {
@@ -167,7 +167,7 @@ JPEGCompressor::~JPEGCompressor() {
 
 uint32 JPEGCompressor::compress(const char *inbuf) {
   // Initialize internal state of jpeg compressor.
-  jpeg_start_compress(&cinfo_, true);
+  jpeg_start_compress(&cinfo_, TRUE);
 
   // Add JPEG comment tag, if available.
   if (!comment_string_.empty()) {

--- a/earth_enterprise/src/common/compressor.h
+++ b/earth_enterprise/src/common/compressor.h
@@ -187,7 +187,7 @@ struct ReadBuffer : public jpeg_source_mgr {
     ReadBuffer* src = static_cast<ReadBuffer*>(cinfo->src);
     src->next_input_byte = &src->buf[0];
     src->bytes_in_buffer = src->bufSize;
-    return true;
+    return TRUE;
   }
 
   static void skipInputData(j_decompress_ptr cinfo, long nBytes) { ; }

--- a/earth_enterprise/src/common/compressor.h
+++ b/earth_enterprise/src/common/compressor.h
@@ -55,15 +55,15 @@ enum CompressMode {
 inline std::string CompressModeName(CompressMode t) {
   switch (t) {
     case CompressNone:
-      return "None";
+      return std::string("None");
     case CompressLZ:
-      return "LZ";
+      return std::string("LZ");
     case CompressJPEG:
-      return "JPEG";
+      return std::string("JPEG");
     case CompressDXT1:
-      return "DXT1";
+      return std::string("DXT1");
     case CompressPNG:
-      return "PNG";
+      return std::string("PNG");
   }
   return std::string(); // unreached but silences warnings
 }
@@ -125,12 +125,12 @@ struct WriteBuffer : public jpeg_destination_mgr {
   size_t bufSize;
   static const size_t reserve_size = kCRC32Size;
 
-  WriteBuffer(size_t bsz, char *pakbuf = NULL) : bufSize(bsz) {
+  WriteBuffer(size_t bsz, char *pakbuf = nullptr) : bufSize(bsz) {
     init_destination = initDestination;
     empty_output_buffer = emptyOutputBuffer;
     term_destination = termDestination;
 
-    if (pakbuf == NULL) {
+    if (pakbuf == nullptr) {
       buf = new char[bufSize + reserve_size];
       track_buf_mem_ = true;
     } else {
@@ -175,7 +175,7 @@ struct ReadBuffer : public jpeg_source_mgr {
     resync_to_restart = jpeg_resync_to_restart;
     term_source = termSource;
     bytes_in_buffer = 0;
-    next_input_byte = NULL;
+    next_input_byte = nullptr;
     buf = (JOCTET*)data;
   }
 
@@ -187,7 +187,7 @@ struct ReadBuffer : public jpeg_source_mgr {
     ReadBuffer* src = (ReadBuffer*)cinfo->src;
     src->next_input_byte = &src->buf[0];
     src->bytes_in_buffer = src->bufSize;
-    return TRUE;
+    return true;
   }
 
   static void skipInputData(j_decompress_ptr cinfo, long nBytes) { ; }

--- a/earth_enterprise/src/common/compressor.h
+++ b/earth_enterprise/src/common/compressor.h
@@ -184,7 +184,7 @@ struct ReadBuffer : public jpeg_source_mgr {
   static void initSource(j_decompress_ptr cinfo) { ; }
 
   static boolean fillInputBuffer(j_decompress_ptr cinfo) {
-    ReadBuffer* src = (ReadBuffer*)cinfo->src;
+    ReadBuffer* src = static_cast<ReadBuffer*>(cinfo->src);
     src->next_input_byte = &src->buf[0];
     src->bytes_in_buffer = src->bufSize;
     return true;

--- a/earth_enterprise/src/common/compressor.h
+++ b/earth_enterprise/src/common/compressor.h
@@ -202,6 +202,12 @@ class JPEGCompressor : public Compressor {
   JPEGCompressor(uint32 w, uint32 h, uint c, int quality);
   virtual ~JPEGCompressor();
 
+  // do not allow copying/moving
+  JPEGCompressor(const JPEGCompressor&) = delete;
+  JPEGCompressor(JPEGCompressor&&) = delete;
+  JPEGCompressor& operator=(const JPEGCompressor&) = delete;
+  JPEGCompressor& operator=(JPEGCompressor&&) = delete;
+
   virtual char* data() { return writer_->buf; }
 
   virtual uint32 dataLen() { return writer_->bufSize - writer_->free_in_buffer; }
@@ -254,6 +260,11 @@ class MinifyCompressor : public Compressor {
  public:
   MinifyCompressor(Compressor* c, uint32 width, uint32 height, uint comp);
   virtual ~MinifyCompressor();
+
+  MinifyCompressor(const MinifyCompressor&) = delete;
+  MinifyCompressor(MinifyCompressor&&) = delete;
+  MinifyCompressor& operator=(const MinifyCompressor&) = delete;
+  MinifyCompressor& operator=(MinifyCompressor&&) = delete;
 
   virtual char* data() { return compressor_->data(); }
 

--- a/earth_enterprise/src/common/qtpacket/tree_utils.h
+++ b/earth_enterprise/src/common/qtpacket/tree_utils.h
@@ -94,6 +94,10 @@ class TreeNumbering {
  public:
   TreeNumbering(int branching_factor, int depth, bool mangle_second_row);
   virtual ~TreeNumbering();
+  TreeNumbering(const TreeNumbering&) = delete;
+  TreeNumbering(TreeNumbering&&) = delete;
+  TreeNumbering& operator=(const TreeNumbering&) = delete;
+  TreeNumbering& operator=(TreeNumbering&&) = delete;
 
   // Return the total number of nodes in the tree
   int num_nodes() const {
@@ -199,8 +203,6 @@ class TreeNumbering {
 
   // Store the number of nodes in the tree at levels <= the given level
   int *nodes_at_levels_;
-
-  DISALLOW_COPY_AND_ASSIGN(TreeNumbering);
 };
 
 }  // namespace qtpacket

--- a/earth_enterprise/src/fusion/gst/gstFileUtils.h
+++ b/earth_enterprise/src/fusion/gst/gstFileUtils.h
@@ -70,7 +70,7 @@ class gstFileInfo {
 
 class gstFileIO {
  public:
-  gstFileIO(int, ssize_t sz, char* buf = NULL);
+  gstFileIO(int, ssize_t sz, char* buf = nullptr);
   ~gstFileIO();
 
   gstFileIO(const gstFileIO&) = delete;

--- a/earth_enterprise/src/fusion/gst/gstFileUtils.h
+++ b/earth_enterprise/src/fusion/gst/gstFileUtils.h
@@ -73,6 +73,11 @@ class gstFileIO {
   gstFileIO(int, ssize_t sz, char* buf = NULL);
   ~gstFileIO();
 
+  gstFileIO(const gstFileIO&) = delete;
+  gstFileIO(gstFileIO&&) = delete;
+  gstFileIO& operator=(const gstFileIO&) = delete;
+  gstFileIO& operator=(gstFileIO&&) = delete;
+
   gstStatus write(int64 pos);
   gstStatus read(int64 pos);
 

--- a/earth_enterprise/src/fusion/gst/gstHistogram.h
+++ b/earth_enterprise/src/fusion/gst/gstHistogram.h
@@ -30,6 +30,8 @@ class gstHistogram {
   ~gstHistogram() {
     delete [] bins_;
   }
+  gstHistogram(const gstHistogram&) = delete;
+  gstHistogram(gstHistogram&&) = delete;
 
   uint hash(uint id) const { return id & hash_mask_; }
 

--- a/earth_enterprise/src/fusion/gst/gstJobStats.cpp
+++ b/earth_enterprise/src/fusion/gst/gstJobStats.cpp
@@ -19,7 +19,7 @@
 
 #include <notify.h>
 
-std::vector<gstJobStats*>* gstJobStats::stat_objects = NULL;
+std::vector<gstJobStats*>* gstJobStats::stat_objects = nullptr;
 
 gstJobStats::gstJobStats(const std::string& group_name,
                          const JobName* names, int job_count)
@@ -27,7 +27,7 @@ gstJobStats::gstJobStats(const std::string& group_name,
       job_names_(names),
       job_count_(job_count),
       jobs_(new JobUnit[job_count]) {
-  if (stat_objects == NULL) {
+  if (stat_objects == nullptr) {
     stat_objects = new std::vector<gstJobStats*>;
   }
   stat_objects->push_back(this);
@@ -63,7 +63,7 @@ void gstJobStats::End(int job_id) {
 }
 
 void gstJobStats::DumpAllStats() {
-  if (stat_objects != NULL) {
+  if (stat_objects != nullptr) {
     for (std::vector<gstJobStats*>::iterator it = stat_objects->begin();
          it != stat_objects->end(); ++it) {
       (*it)->DumpStats();
@@ -72,7 +72,7 @@ void gstJobStats::DumpAllStats() {
 }
 
 void gstJobStats::ResetAll() {
-  if (stat_objects != NULL) {
+  if (stat_objects != nullptr) {
     for (std::vector<gstJobStats*>::iterator it = stat_objects->begin();
          it != stat_objects->end(); ++it) {
       (*it)->Reset();

--- a/earth_enterprise/src/fusion/gst/gstKVPFile.cpp
+++ b/earth_enterprise/src/fusion/gst/gstKVPFile.cpp
@@ -315,7 +315,7 @@ gstStatus gstKVPFile::AddGeode(gstGeodeHandle geode) {
   // ensure our raw buffer is big enough
   rawBuf.reserve(rpos.size);
 
-  if (geode->ToRaw(&rawBuf[0]) == NULL) {
+  if (geode->ToRaw(&rawBuf[0]) == nullptr) {
     notify(NFY_WARN, "Failed to convert geode to raw buffer");
     return GST_UNKNOWN;
   }
@@ -372,7 +372,7 @@ gstStatus gstKVGeomFormat::OpenFile() {
                                  gstHeaderImpl::Create());
     ldef.SetBoundingBox(kvp_file_->BoundingBox());
     delete kvp_table_;
-    kvp_table_ = NULL;
+    kvp_table_ = nullptr;
   }
 
   return GST_OKAY;

--- a/earth_enterprise/src/fusion/gst/gstKVPFile.h
+++ b/earth_enterprise/src/fusion/gst/gstKVPFile.h
@@ -117,6 +117,10 @@ class gstKVGeomFormat : public gstFormat {
  public:
   gstKVGeomFormat(const char* n);
   virtual ~gstKVGeomFormat();
+  gstKVGeomFormat(const gstKVGeomFormat&) = delete;
+  gstKVGeomFormat(gstKVGeomFormat&&) = delete;
+  gstKVGeomFormat& operator=(const gstKVGeomFormat&) = delete;
+  gstKVGeomFormat& operator=(gstKVGeomFormat&&) = delete;
 
   // gstFormat
   virtual gstStatus OpenFile();

--- a/earth_enterprise/src/fusion/gst/gstRegistry.h
+++ b/earth_enterprise/src/fusion/gst/gstRegistry.h
@@ -129,17 +129,17 @@ class gstRegistry {
   };
 
   gstRegistry(const char* n = NULL);
-  ~gstRegistry() ;
+  ~gstRegistry();
+  gstRegistry(const gstRegistry&) = delete;
+  gstRegistry(gstRegistry&&) = delete;
+  gstRegistry& operator=(const gstRegistry&) = delete;
+  gstRegistry& operator=(gstRegistry&&) = delete;
 
   gstStatus load();
-  //gstStatus load(const char* buf, int buflen);
-  //gstStatus save();
-  //gstStatus save(char** buf, int &buflen);
 
   Group* findGroup(const char* g) { return _root->findGroup(g); }
 
   void setVal(const char*, const char*, uint32 type = gstTagString);
-  //const char* getVal(const char*, ...);
 
   gstValue* locateTag(const char* tag, int create = 0, uint32 type = gstTagString);
   Group* locateGroup(const char* tag, int create = 0);
@@ -160,8 +160,6 @@ class gstRegistry {
   QString fullPath(Group* g);
 
  private:
-  //gstStatus saveGroup(Group* group, uint depth);
-  //int putLine();
 
   gstStatus parse();
   char* nextLine();

--- a/earth_enterprise/src/fusion/gst/gstRegistry.h
+++ b/earth_enterprise/src/fusion/gst/gstRegistry.h
@@ -76,7 +76,7 @@ class gstRegistry {
           return _tags.removeIndex(ii);
         }
       }
-      return NULL;
+      return nullptr;
     }
 
     khArray<gstValue*>* tags() { return &_tags; }
@@ -88,7 +88,7 @@ class gstRegistry {
           return *t;
         }
       }
-      return NULL;
+      return nullptr;
     }
 
     Group* findGroup(const char* n) const {
@@ -98,7 +98,7 @@ class gstRegistry {
           return *g;
         }
       }
-      return NULL;
+      return nullptr;
     }
 
     Group* removeGroup(Group* grp) {
@@ -128,7 +128,7 @@ class gstRegistry {
     bool _altered;
   };
 
-  gstRegistry(const char* n = NULL);
+  gstRegistry(const char* n = nullptr);
   ~gstRegistry();
   gstRegistry(const gstRegistry&) = delete;
   gstRegistry(gstRegistry&&) = delete;

--- a/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
+++ b/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
@@ -425,8 +425,6 @@ void gstTextureManager::GetOverlayList(
                  khTilespace::Denormalize(tilebox.n));
   }
 
-  //for (std::map<uint, gstTextureGuard>::iterator it = texture_map_.begin();
-  //     it != texture_map_.end(); ++it) {
     for (const auto& it : texture_map_) {
       gstTextureGuard tex = it.second;
       if (tex && tex->enabled() && tex != base_texture_) {

--- a/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
+++ b/earth_enterprise/src/fusion/gst/gstTextureManager.cpp
@@ -48,7 +48,7 @@ void ReadThread::run(void) {
   texman->readThreadFunc();
 }
 
-gstTextureManager *theTextureManager = NULL;
+gstTextureManager *theTextureManager = nullptr;
 
 gstTextureManager::gstTextureManager(int memoryCacheSize, int textureCacheSize)
     : base_texture_(),
@@ -375,7 +375,7 @@ int gstTextureManager::prepareBaseTexture(TexTile& tile) {
   tile.src = 0;
 
   TileExistance* te = tile_existance_cache_->fetch(tile.addr());
-  assert(te != NULL);
+  assert(te != nullptr);
 
   // reset address (if necessary)
   requested_level_ = LEVFROMADDR(te->bestAvailable);
@@ -425,12 +425,13 @@ void gstTextureManager::GetOverlayList(
                  khTilespace::Denormalize(tilebox.n));
   }
 
-  for (std::map<uint, gstTextureGuard>::iterator it = texture_map_.begin();
-       it != texture_map_.end(); ++it) {
-    gstTextureGuard tex = it->second;
-    if (tex && tex->enabled() && tex != base_texture_) {
-      if (tilebox.Intersect(tex->bbox()))
-        draw_list.push_back(tex);
+  //for (std::map<uint, gstTextureGuard>::iterator it = texture_map_.begin();
+  //     it != texture_map_.end(); ++it) {
+    for (const auto& it : texture_map_) {
+      gstTextureGuard tex = it.second;
+      if (tex && tex->enabled() && tex != base_texture_) {
+        if (tilebox.Intersect(tex->bbox()))
+          draw_list.push_back(tex);
     }
   }
 }
@@ -451,7 +452,7 @@ int gstTextureManager::prepareTexture(TexTile& tile,
   // determine what is the best tile that exists in our db
   TileExistance* te = tile_existance_cache_->fetch(tile.addr());
 
-  assert(te != NULL);
+  assert(te != nullptr);
 
   // no texture available
   if (te->bestAvailable == 0)
@@ -505,7 +506,7 @@ bool gstTextureManager::bindTile(uint& reuseID, const uint64& addr) {
   uchar* buf = memory_cache_->fetchAndPin(addr);
 
   // Nope, queue it up to be loaded
-  if (buf == NULL) {
+  if (buf == nullptr) {
     if (requested_level_ == LEVFROMADDR(addr)) {
       readQueue.push(addr);
       render_unfinished_++;
@@ -586,7 +587,7 @@ bool gstTextureManager::bindTile(uint& reuseID, const uint64& addr) {
 void gstTextureManager::readThreadFunc() {
   int idx = 0;
   int qsz = 0;
-  uchar* next_buffer = NULL;
+  uchar* next_buffer = nullptr;
   uint64 addr;
 
   while (true) {
@@ -600,7 +601,7 @@ void gstTextureManager::readThreadFunc() {
       gstTextureGuard tex = FindTexture(SRCFROMADDR(addr));
       assert(tex);
 
-      if (next_buffer == NULL) {
+      if (next_buffer == nullptr) {
         next_buffer = new uchar[tex->cellSize()];
         notify(NFY_VERBOSE,
                "(%d) New tex buffer [%d] sz=%d c:%d r:%d l:%d s:%d",

--- a/earth_enterprise/src/fusion/gst/gstTextureManager.h
+++ b/earth_enterprise/src/fusion/gst/gstTextureManager.h
@@ -77,9 +77,6 @@ class gstTextureManager {
   // Initialize the texture manager from a valid graphics context
   void glinit();
 
-  // Open new texture given it's pathname
-  // returns texture object on success, NULL on failure
-  //gstTextureGuard openFile(const char *path, bool base = false);
   gstTextureGuard NewTextureFromPath(const std::string& path,
                                      bool* is_mercator_imagery);
   bool AddBaseTexture(gstTextureGuard texture);

--- a/earth_enterprise/src/fusion/gst/gstTextureManager.h
+++ b/earth_enterprise/src/fusion/gst/gstTextureManager.h
@@ -66,6 +66,10 @@ class gstTextureManager {
  public:
   gstTextureManager(int memoryCacheSize, int textureCacheSize);
   ~gstTextureManager();
+  gstTextureManager(const gstTextureManager&) = delete;
+  gstTextureManager(gstTextureManager&&) = delete;
+  gstTextureManager& operator=(const gstTextureManager&) = delete;
+  gstTextureManager& operator=(gstTextureManager&&) = delete;
 
   // flush all caches
   void flush();

--- a/earth_enterprise/src/fusion/mtjtools/scroll/zoom.h
+++ b/earth_enterprise/src/fusion/mtjtools/scroll/zoom.h
@@ -445,6 +445,11 @@ class Image
 #endif
   }
 
+  Image(const Image&) = delete;
+  Image(Image&&) = delete;
+  Image& operator=(const Image&) = delete;
+  Image& operator=(Image&&) = delete;
+
   //#define QUICK 1
 
   Pixel getPixel(int x, int y)

--- a/earth_enterprise/src/fusion/mtjtools/scroll/zoom.h
+++ b/earth_enterprise/src/fusion/mtjtools/scroll/zoom.h
@@ -43,7 +43,7 @@
   artifacting occurs.
 
   - All memory allocations checked for failure; zoom() returns
-  error code. new_image() returns NULL if unable to allocate
+  error code. new_image() returns nullptr if unable to allocate
   pixel storage, even if Image struct can be allocated.
   Some assertions added.
 */
@@ -57,15 +57,10 @@
 #define M_PI     3.14159265359
 #endif
 
-//#define POINT_SAMPLE
-
-// LUT_TYPE=short and LUT_GUARD_BITS=3 [0..7] (allows floor((2^(16-1-8-LUT_GUARD_BITS) - 1)/2) support)
 #define USE_LUT
 #define LUT_TYPE short
 #define LUT_GUARD_BITS 3
 #define LUT_BINARY_POINT (8+LUT_GUARD_BITS)
-
-//#define REFLECT
 
 struct CONTRIB
 {
@@ -151,7 +146,7 @@ class CLIST
   }
 
  public:
-  int             n;              // number of contributors
+  int n;                  // number of contributors
   CONTRIB *p;             // pointer to list of coverages
 };
 
@@ -440,7 +435,7 @@ class Image
       free(data);
 
 #ifdef MALLOG
-    if (log != NULL)
+    if (log != nullptr)
       fclose(log);
 #endif
   }
@@ -450,12 +445,10 @@ class Image
   Image& operator=(const Image&) = delete;
   Image& operator=(Image&&) = delete;
 
-  //#define QUICK 1
-
   Pixel getPixel(int x, int y)
   {
     static int yy = -1;
-    static Pixel *p = NULL;
+    static Pixel *p = nullptr;
 #ifdef QUICK
     return ((Pixel *)(((char *)data) + y*span))[x]; // not quicker of compiler can't detect constant y
 #endif
@@ -477,7 +470,7 @@ class Image
   Pixel putPixel(int x, int y, Pixel d)
   {
     static int yy = -1;
-    static Pixel *p = NULL;
+    static Pixel *p = nullptr;
 #ifdef QUICK
     return ((Pixel *)(((char *)data) + y*span))[x] = d;
 #endif
@@ -551,7 +544,7 @@ class Image
   {
     void *item = ::malloc(size);
 
-    if (log != NULL)
+    if (log != nullptr)
       fprintf(log, "A 0x%08x %8d\n", item, size);
 
     return item;
@@ -560,14 +553,14 @@ class Image
   {
     void *item = ::calloc(size, count);
 
-    if (log != NULL)
+    if (log != nullptr)
       fprintf(log, "C 0x%08x %8d (%8d * %8d)\n", item, size*count, size, count);
 
     return item;
   }
   void free(void *item)
   {
-    if (log != NULL)
+    if (log != nullptr)
       fprintf(log, "F 0x%08x\n", item);
 
     ::free(item);
@@ -744,7 +737,7 @@ class Resize
 
     clist[0].n = 0;
     clist[0].p = (CONTRIB *)calloc(sizeof(CONTRIB), samples*dstSize); // single large allocation
-    if (clist[0].p == NULL)
+    if (clist[0].p == nullptr)
       return -1;
 
     for (int index = 1; index < dstSize; index++)

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
@@ -35,15 +35,20 @@ class GlcReader;
  * Class for unpacking files from a single package file.
  */
 class FileUnpacker {
+  /**
+   * TODO: portable uses swig2, which does not handle c++11 syntax.
+   * In the migration to c++11, updating to swig3+ was missed. For the
+   * moment, copy constructor and assignment constructor are made private
+   * and the move constructors are commented out. When swig is updated,
+   * these will be deleted (as well as moves) and made public
+   */
+  FileUnpacker(const FileUnpacker&);
+  FileUnpacker& operator=(const FileUnpacker&);
+
  public:
   FileUnpacker(const GlcReader& glc_reader, uint64 offset, uint64 size);
   ~FileUnpacker();
- private:
-  FileUnpacker(const FileUnpacker&);// = delete;
-  //FileUnpacker(FileUnpacker&&) = delete;
-  FileUnpacker& operator=(const FileUnpacker&);// = delete;
-  //FileUnpacker& operator=(FileUnpacker&&) = delete;
-public:
+
   /**
    * Find data packet and set offset and size for the packet. Data packets can
    * be imagery, terrain or vectors.

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
@@ -38,11 +38,12 @@ class FileUnpacker {
  public:
   FileUnpacker(const GlcReader& glc_reader, uint64 offset, uint64 size);
   ~FileUnpacker();
-  FileUnpacker(const FileUnpacker&) = delete;
-  FileUnpacker(FileUnpacker&&) = delete;
-  FileUnpacker& operator=(const FileUnpacker&) = delete;
-  FileUnpacker& operator=(FileUnpacker&&) = delete;
-
+ private:
+  FileUnpacker(const FileUnpacker&);// = delete;
+  //FileUnpacker(FileUnpacker&&) = delete;
+  FileUnpacker& operator=(const FileUnpacker&);// = delete;
+  //FileUnpacker& operator=(FileUnpacker&&) = delete;
+public:
   /**
    * Find data packet and set offset and size for the packet. Data packets can
    * be imagery, terrain or vectors.

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
@@ -38,6 +38,10 @@ class FileUnpacker {
  public:
   FileUnpacker(const GlcReader& glc_reader, uint64 offset, uint64 size);
   ~FileUnpacker();
+  FileUnpacker(const FileUnpacker&) = delete;
+  FileUnpacker(FileUnpacker&&) = delete;
+  FileUnpacker& operator=(const FileUnpacker&) = delete;
+  FileUnpacker& operator=(FileUnpacker&&) = delete;
 
   /**
    * Find data packet and set offset and size for the packet. Data packets can


### PR DESCRIPTION
Running cppcheck on the codebase has shown a list of errors and/or vulnerabilities, one of which is to address a lack of copy/move constructors and assignments. It was determined by deleting the methods, that they aren't strictly necessary.