### PR TITLE
Build Apache with crypto enabled (#1564)

### DIFF
--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -128,7 +128,7 @@ env_opt = 'PORT=80 INCLUDES=-I/opt/google/include EAPI_MM=%s/%s' % (build_root,
 config_opt += (
     ' --with-program-name=gehttpd --with-port=80 --prefix=/opt/google/gehttpd '
     '--enable-mods-shared=all --with-ssl=/opt/google --enable-ssl=shared '
-    '--with-crypto --enable-session-crypto '
+    '--with-crypto  '
     '--with-expat=/opt/google --with-mpm=worker --enable-proxy '
     '--enable-proxy-ajp --disable-proxy-connect --disable-proxy-ftp '
     '--disable-proxy-http --disable-proxy-balancer --without-sqlite2 '

--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -128,6 +128,7 @@ env_opt = 'PORT=80 INCLUDES=-I/opt/google/include EAPI_MM=%s/%s' % (build_root,
 config_opt += (
     ' --with-program-name=gehttpd --with-port=80 --prefix=/opt/google/gehttpd '
     '--enable-mods-shared=all --with-ssl=/opt/google --enable-ssl=shared '
+    '--with-crypto --enable-session-crypto '
     '--with-expat=/opt/google --with-mpm=worker --enable-proxy '
     '--enable-proxy-ajp --disable-proxy-connect --disable-proxy-ftp '
     '--disable-proxy-http --disable-proxy-balancer --without-sqlite2 '


### PR DESCRIPTION
Adds crypto flags to Apache's optional build configurations to ensure Apache is building mod_session_crypto.  Fixes issue #1564 

**Verification**
1. Clone and build earthenterprise as normal.
2. Ensure the output module exists:
`earthenterprise/earth_enterprise/src/NATIVE-REL-x86_64/third_party/apache2/install/opt/google/gehttpd/modules/mod_session_crypto.so`