### PR TITLE
manually running bash on download_tutorial.sh execution

### DIFF
--- a/earth_enterprise/integration_test/step_impl/genewimageryresource.py
+++ b/earth_enterprise/integration_test/step_impl/genewimageryresource.py
@@ -18,7 +18,7 @@ def executeCommand(sTestDir):
    sImageryFile = "Imagery/bluemarble_4km.tif"
    
    # Download the imagery, if not available.
-   sCommandToRun = "sudo " + sImageryRoot + "download_tutorial.sh >/dev/null 2>/dev/null"
+   sCommandToRun = "sudo bash " + sImageryRoot + "download_tutorial.sh >/dev/null 2>/dev/null"
    print sCommandToRun
    pHandle = subprocess.Popen(sCommandToRun, shell=True)
    assert (pHandle.wait() == 0)


### PR DESCRIPTION
permissions weren't set for download_tutorial.sh, it is easier to manually pass it to bash instead of changing permissions. the decision to do that can be decided later on