### PR TITLE
#1593: Resolve Assorted Python Dependency Issues

### DIFF
--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -385,6 +385,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeCommonInitScripts) {
         'OpenLDAP and ' +
         'OpenSSL and ' +
         'Skia 5.1.2'
+ 
     type = BINARY
     autoFindProvides = true
     autoFindRequires = true
@@ -397,6 +398,7 @@ task openGeeCommonRpm(type: GeeRpm, dependsOn: openGeeCommonInitScripts) {
 
     if ("${findBuildNumber()}.${rpmPlatformString}".contains('el6')) {
         requires('python27')
+        requires('python27-lxml')
     }
 
     requiresCommands(packageSharedCommands +
@@ -456,7 +458,7 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeCommonInitScripts) {
     requires('libxml2-utils')
     requires('openssl')
     requires('python-imaging')
-    requires('python27-lxml')
+    requires('python-lxml')
     requires('python-psycopg2')
     requires('python-setuptools')
     requires('python2.7')
@@ -531,7 +533,7 @@ task openGeeServerRpm(type: GeeRpm, dependsOn: openGeeServerInitScripts) {
     requires('python-unittest2')
     // The WMS Service requires PIL, which is not automatically detected:
     requires('python-imaging')
-    requires('python27-lxml')
+    requires('python-lxml')
 
     requiresCommands(
         packageSharedCommands +
@@ -631,7 +633,7 @@ task openGeeServerDeb (type: GeeDeb, dependsOn: openGeeServerInitScripts) {
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
 
     requires('python-pil')
-    requires('python27-lxml')
+    requires('python-lxml')
 
     requiresCommands(
         packageSharedCommands +

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -456,7 +456,7 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeCommonInitScripts) {
     requires('libxml2-utils')
     requires('openssl')
     requires('python-imaging')
-    requires('python-lxml')
+    requires('python27-lxml')
     requires('python-psycopg2')
     requires('python-setuptools')
     requires('python2.7')
@@ -531,7 +531,7 @@ task openGeeServerRpm(type: GeeRpm, dependsOn: openGeeServerInitScripts) {
     requires('python-unittest2')
     // The WMS Service requires PIL, which is not automatically detected:
     requires('python-imaging')
-    requires('python-lxml')
+    requires('python27-lxml')
 
     requiresCommands(
         packageSharedCommands +
@@ -631,7 +631,7 @@ task openGeeServerDeb (type: GeeDeb, dependsOn: openGeeServerInitScripts) {
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
 
     requires('python-pil')
-    requires('python-lxml')
+    requires('python27-lxml')
 
     requiresCommands(
         packageSharedCommands +

--- a/earth_enterprise/src/portableserver/build.py
+++ b/earth_enterprise/src/portableserver/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python2.7
 #-*- Python -*-
 #
 # Copyright 2017 GEE Open Source Team <github.com/google/earthenterprise>

--- a/earth_enterprise/src/third_party/pyyaml/SConscript
+++ b/earth_enterprise/src/third_party/pyyaml/SConscript
@@ -61,7 +61,7 @@ pyyaml_build = pyyaml_env.Command(
                       env_opt, python_cmd, pyyaml_target))])
 
 # [3] Create pyyaml master installer.
-install_root_lib = '%s/lib/python%s/site-packages/yaml' % (
+install_root_lib = '%s/lib/python%s/site-packages' % (
     install_root, pyyaml_env['python_major_version'])
 install_root_doc = '%s/share/doc/packages/%s' % (
     install_root_opt, pyyaml_ge_version)


### PR DESCRIPTION
Updates to fix various python dependency issues:

- Portable shebang fixed and documentation changed.
- Pyyaml now installs to the correct location.
- OpenGEE rpms now require python27-lxml (to ensure that it gets installed automatically).

To test:

- Build portable on el6 and verify that it builds with and works with python 2.7.
- Build and install on el6 and verify that glc_assembler works.
- Take built RPMs and install on a different el6 machine. Verify that cutter works.

These changes were made in conjunction with documentation changes on the [wiki](https://github.com/google/earthenterprise/wiki/Portable-Server#run-time-prerequisites).