### PR TITLE
Dont load unneeded children and inputs

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.cpp
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.cpp
@@ -51,6 +51,52 @@ AssetVersionImpl::GetInputFilenames(std::vector<std::string> &out) const
 
 
 // ****************************************************************************
+// ***  LeafAssetVersionImpl
+// ****************************************************************************
+// bool LeafAssetVersionImpl::InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {
+//   bool InputStatesAffectMyState = false;
+//   if (!AssetDefs::Ready(state)) {
+//     // I'm currently not ready, so take whatever my inputs say
+//     InputStatesAffectMyState = true;
+//   } else if (stateByInputs != AssetDefs::Queued) {
+//     // My inputs have regressed
+//     // Let's see if I should regress too
+
+//     if (AssetDefs::Working(state)) {
+//       // I'm in the middle of building myself
+//       // revert my state to wait/block on my inputs
+//       // OnStateChange will pick up this revert and stop my running task
+//       InputStatesAffectMyState = true;
+//     } else {
+//       // my task has already finished
+//       if (blockedByOfflineInputs) {
+//         // If the only reason my inputs have reverted is because
+//         // some of them have gone offline, that's usually OK and
+//         // I don't need to revert my state.
+//         // Check to see if I care about my inputs going offline
+//         if (OfflineInputsBreakMe()) {
+//           // I care, revert my state too.
+//           InputStatesAffectMyState = true;
+//         } else {
+//           // I don't care, so leave my state alone.
+//         }
+//       } else {
+//         // My inputs have regresseed for some reason other than some
+//         // of them going offline.
+//         // revert my state
+//         InputStatesAffectMyState = true;
+//       }
+//     }
+//   } else {
+//     // nothing to do
+//     // my current state is correct based on what my task has told me so far
+//   }
+  
+//   return InputStatesAffectMyState;
+// }
+
+
+// ****************************************************************************
 // ***  CompositeAssetVersionImpl
 // ****************************************************************************
 void
@@ -78,6 +124,35 @@ CompositeAssetVersionImpl::GetOutputFilename(uint i) const
   }
   return std::string();
 }
+
+// bool CompositeAssetVersionImpl::InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {
+//   // Undecided composites take their state from their inputs
+//   bool InputStatesAffectMyState = false;
+//   if (children.empty()) {
+//     InputStatesAffectMyState = true;
+//   }
+
+//   // some composite assets (namely Database) care about the state of their
+//   // inputs, for all others all that matters is the state of their children
+//   if (CompositeStateCaresAboutInputsToo()) {
+//     if (stateByInputs != AssetDefs::Queued) {
+//       // something is wrong with my inputs (or they're not done yet)
+//       if (blockedByOfflineInputs) {
+//         if (OfflineInputsBreakMe()) {
+//           InputStatesAffectMyState = true;
+//         }
+//       } else {
+//         InputStatesAffectMyState = true;
+//       }
+//     }
+//   }
+
+//   return InputStatesAffectMyState;
+// }
+
+// bool CompositeAssetVersionImpl::ChildStatesAffectMyState() const {
+//   return true;
+// }
 
 namespace {
 // Construct a versioned asset path from a full gedb/mapdb path.

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.cpp
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.cpp
@@ -51,52 +51,6 @@ AssetVersionImpl::GetInputFilenames(std::vector<std::string> &out) const
 
 
 // ****************************************************************************
-// ***  LeafAssetVersionImpl
-// ****************************************************************************
-// bool LeafAssetVersionImpl::InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {
-//   bool InputStatesAffectMyState = false;
-//   if (!AssetDefs::Ready(state)) {
-//     // I'm currently not ready, so take whatever my inputs say
-//     InputStatesAffectMyState = true;
-//   } else if (stateByInputs != AssetDefs::Queued) {
-//     // My inputs have regressed
-//     // Let's see if I should regress too
-
-//     if (AssetDefs::Working(state)) {
-//       // I'm in the middle of building myself
-//       // revert my state to wait/block on my inputs
-//       // OnStateChange will pick up this revert and stop my running task
-//       InputStatesAffectMyState = true;
-//     } else {
-//       // my task has already finished
-//       if (blockedByOfflineInputs) {
-//         // If the only reason my inputs have reverted is because
-//         // some of them have gone offline, that's usually OK and
-//         // I don't need to revert my state.
-//         // Check to see if I care about my inputs going offline
-//         if (OfflineInputsBreakMe()) {
-//           // I care, revert my state too.
-//           InputStatesAffectMyState = true;
-//         } else {
-//           // I don't care, so leave my state alone.
-//         }
-//       } else {
-//         // My inputs have regresseed for some reason other than some
-//         // of them going offline.
-//         // revert my state
-//         InputStatesAffectMyState = true;
-//       }
-//     }
-//   } else {
-//     // nothing to do
-//     // my current state is correct based on what my task has told me so far
-//   }
-  
-//   return InputStatesAffectMyState;
-// }
-
-
-// ****************************************************************************
 // ***  CompositeAssetVersionImpl
 // ****************************************************************************
 void
@@ -124,35 +78,6 @@ CompositeAssetVersionImpl::GetOutputFilename(uint i) const
   }
   return std::string();
 }
-
-// bool CompositeAssetVersionImpl::InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {
-//   // Undecided composites take their state from their inputs
-//   bool InputStatesAffectMyState = false;
-//   if (children.empty()) {
-//     InputStatesAffectMyState = true;
-//   }
-
-//   // some composite assets (namely Database) care about the state of their
-//   // inputs, for all others all that matters is the state of their children
-//   if (CompositeStateCaresAboutInputsToo()) {
-//     if (stateByInputs != AssetDefs::Queued) {
-//       // something is wrong with my inputs (or they're not done yet)
-//       if (blockedByOfflineInputs) {
-//         if (OfflineInputsBreakMe()) {
-//           InputStatesAffectMyState = true;
-//         }
-//       } else {
-//         InputStatesAffectMyState = true;
-//       }
-//     }
-//   }
-
-//   return InputStatesAffectMyState;
-// }
-
-// bool CompositeAssetVersionImpl::ChildStatesAffectMyState() const {
-//   return true;
-// }
 
 namespace {
 // Construct a versioned asset path from a full gedb/mapdb path.

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -138,7 +138,6 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
   }
 
   virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {assert(false); return true;}
-  virtual bool ChildStatesAffectMyState() const {assert(false); return true;}
   const SharedString & GetRef(void) const { return name; }
   std::string GetAssetRef(void) const {
     AssetVersionRef verref(name);

--- a/earth_enterprise/src/fusion/autoingest/AssetVersion.h
+++ b/earth_enterprise/src/fusion/autoingest/AssetVersion.h
@@ -137,6 +137,8 @@ class AssetVersionImpl : public AssetVersionStorage, public StorageManaged {
     return (state == AssetDefs::Bad);
   }
 
+  virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const {assert(false); return true;}
+  virtual bool ChildStatesAffectMyState() const {assert(false); return true;}
   const SharedString & GetRef(void) const { return name; }
   std::string GetAssetRef(void) const {
     AssetVersionRef verref(name);

--- a/earth_enterprise/src/fusion/autoingest/storage/AssetDefs.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/AssetDefs.idl
@@ -41,6 +41,9 @@ class AssetDefs {
   static bool NotFinished(State state) {
     return !Finished(state);
   }
+  static bool IsBlocking(State state) {
+    return state & (AssetDefs::Blocked | AssetDefs::Canceled | AssetDefs::Failed);
+  }
   static bool CanRebuild(State state) {
     return state & (AssetDefs::Canceled | AssetDefs::Failed);
   }

--- a/earth_enterprise/src/fusion/autoingest/storage/AssetDefs.idl
+++ b/earth_enterprise/src/fusion/autoingest/storage/AssetDefs.idl
@@ -42,10 +42,10 @@ class AssetDefs {
     return !Finished(state);
   }
   static bool IsBlocking(State state) {
-    return state & (AssetDefs::Blocked | AssetDefs::Canceled | AssetDefs::Failed);
+    return state & (Blocked | Canceled | Failed | Offline | Bad);
   }
   static bool CanRebuild(State state) {
-    return state & (AssetDefs::Canceled | AssetDefs::Failed);
+    return state & (Canceled | Failed);
   }
   static bool CanOffline(State state) {
     return ((state != Offline) &&

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
@@ -129,7 +129,7 @@ void HandleTaskDone(const TaskDoneMsg & msg, MiscConfig::GraphOpsType graphOps) 
         stateUpdater->SetSucceeded(version);
       }
       else {
-        stateUpdater->SetFailed(version);
+        stateUpdater->SetStateForRefAndDependents(msg.verref, AssetDefs::Failed, AssetDefs::Finished);
       }
     }
     else if (!version) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
@@ -129,7 +129,7 @@ void HandleTaskDone(const TaskDoneMsg & msg, MiscConfig::GraphOpsType graphOps) 
         stateUpdater->SetSucceeded(version);
       }
       else {
-        stateUpdater->SetStateForRefAndDependents(msg.verref, AssetDefs::Failed, AssetDefs::Finished);
+        stateUpdater->SetFailed(version);
       }
     }
     else if (!version) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation.cpp
@@ -50,7 +50,7 @@ void RebuildVersion(const SharedString & ref, MiscConfig::GraphOpsType graphOps)
       }
     }
 
-    stateUpdater->SetStateForRefAndDependents(ref, AssetDefs::New, AssetDefs::CanRebuild);
+    stateUpdater->SetAndPropagateState(ref, AssetDefs::New, AssetDefs::CanRebuild);
   }
   else {
     MutableAssetVersionD version(ref);
@@ -80,7 +80,7 @@ void CancelVersion(const SharedString & ref, MiscConfig::GraphOpsType graphOps) 
       }
     }
 
-    stateUpdater->SetStateForRefAndDependents(ref, AssetDefs::Canceled, AssetDefs::NotFinished);
+    stateUpdater->SetAndPropagateState(ref, AssetDefs::Canceled, AssetDefs::NotFinished);
   }
   else {
     MutableAssetVersionD version(ref);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
@@ -359,8 +359,7 @@ TEST_F(AssetOperationTest, DoneFailed) {
   auto msg = TaskDoneMsg(REF, TASKID, false, BEGIN_TIME, END_TIME, OUTFILES);
   sm.GetMutableVersion()->taskid = TASKID;
   HandleTaskDone(msg, MiscConfig::ALL_GRAPH_OPS);
-  ASSERT_TRUE(sm.GetVersion()->stateSetForRefAndDependents);
-  ASSERT_EQ(sm.GetVersion()->refAndDependentsState, AssetDefs::Failed);
+  ASSERT_TRUE(sm.GetVersion()->setFailed);
   ASSERT_EQ(sm.GetVersion()->beginTime, BEGIN_TIME);
   ASSERT_EQ(sm.GetVersion()->progressTime, END_TIME);
   ASSERT_EQ(sm.GetVersion()->endTime, END_TIME);

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetOperation_unittest.cpp
@@ -359,12 +359,13 @@ TEST_F(AssetOperationTest, DoneFailed) {
   auto msg = TaskDoneMsg(REF, TASKID, false, BEGIN_TIME, END_TIME, OUTFILES);
   sm.GetMutableVersion()->taskid = TASKID;
   HandleTaskDone(msg, MiscConfig::ALL_GRAPH_OPS);
+  ASSERT_TRUE(sm.GetVersion()->stateSetForRefAndDependents);
+  ASSERT_EQ(sm.GetVersion()->refAndDependentsState, AssetDefs::Failed);
   ASSERT_EQ(sm.GetVersion()->beginTime, BEGIN_TIME);
   ASSERT_EQ(sm.GetVersion()->progressTime, END_TIME);
   ASSERT_EQ(sm.GetVersion()->endTime, END_TIME);
   ASSERT_NE(sm.GetVersion()->outfiles, OUTFILES);
   ASSERT_FALSE(sm.GetVersion()->setDone);
-  ASSERT_TRUE(sm.GetVersion()->setFailed);
 }
 
 TEST_F(AssetOperationTest, DoneBadVersion) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -1201,25 +1201,8 @@ CompositeAssetVersionImplD::CalcStateByInputsAndChildren(const InputAndChildStat
   this->numInputsWaitingFor = stateData.waitingFor.inputs;
   this->numChildrenWaitingFor = stateData.waitingFor.children;
 
-  // // Undecided composites take their state from their inputs
-  // if (children.empty()) {
-  //   return stateData.stateByInputs;
-  // }
-
-  // // some composite assets (namely Database) care about the state of their
-  // // inputs, for all others all that matters is the state of their children
-  // if (CompositeStateCaresAboutInputsToo()) {
-  //   if (stateData.stateByInputs != AssetDefs::Queued) {
-  //     // something is wrong with my inputs (or they're not done yet)
-  //     if (BlockedByOfflineInputs(stateData)) {
-  //       if (OfflineInputsBreakMe()) {
-  //         return stateData.stateByInputs;
-  //       }
-  //     } else {
-  //       return stateData.stateByInputs;
-  //     }
-  //   }
-  // }
+  if (InputStatesAffectMyState(stateData))
+    return stateData.stateByInputs;
 
   return stateData.stateByChildren;
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.cpp
@@ -1192,10 +1192,6 @@ bool CompositeAssetVersionImplD::InputStatesAffectMyState(AssetDefs::State state
   return InputStatesAffectMyState;
 }
 
-bool CompositeAssetVersionImplD::ChildStatesAffectMyState() const {
-  return true;
-}
-
 AssetDefs::State
 CompositeAssetVersionImplD::CalcStateByInputsAndChildren(const InputAndChildStateData & stateData) const {
   this->numInputsWaitingFor = stateData.waitingFor.inputs;

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -113,8 +113,6 @@ class AssetVersionImplD : public virtual AssetVersionImpl
     }
   }
 
-  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const = 0;
-  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const = 0;
   bool OkToClean(std::vector<std::string> *wouldbreak = nullptr) const;
   bool OkToCleanAsInput(void) const;
   void SetBad(void);
@@ -208,8 +206,8 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
   virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const override;
-  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const override;
-  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const override { return false; }
+  virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const override;
+  virtual bool ChildStatesAffectMyState() const override { return false; }
 };
 
 
@@ -251,8 +249,8 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
   virtual bool RecalcState(WaitingFor &) const override;
-  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const override;
-  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const override;
+  virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const override;
+  virtual bool ChildStatesAffectMyState() const override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -207,7 +207,6 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
                                          AssetDefs::State oldstate) override;
   virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const override;
   virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const override;
-  virtual bool ChildStatesAffectMyState() const override { return false; }
 };
 
 
@@ -250,7 +249,6 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
                                          AssetDefs::State oldstate) override;
   virtual bool RecalcState(WaitingFor &) const override;
   virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const override;
-  virtual bool ChildStatesAffectMyState() const override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/AssetVersionD.h
@@ -113,6 +113,8 @@ class AssetVersionImplD : public virtual AssetVersionImpl
     }
   }
 
+  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const = 0;
+  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const = 0;
   bool OkToClean(std::vector<std::string> *wouldbreak = nullptr) const;
   bool OkToCleanAsInput(void) const;
   void SetBad(void);
@@ -206,6 +208,8 @@ class LeafAssetVersionImplD : public virtual LeafAssetVersionImpl,
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
   virtual AssetDefs::State CalcStateByInputsAndChildren(const InputAndChildStateData &) const override;
+  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const override;
+  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const override { return false; }
 };
 
 
@@ -247,6 +251,8 @@ class CompositeAssetVersionImplD : public virtual CompositeAssetVersionImpl,
   virtual AssetDefs::State OnStateChange(AssetDefs::State newstate,
                                          AssetDefs::State oldstate) override;
   virtual bool RecalcState(WaitingFor &) const override;
+  virtual bool InputStatesAffectMyState(const InputAndChildStateData & stateData) const override;
+  virtual bool ChildStatesAffectMyState(const InputAndChildStateData & stateData) const override;
 };
 
 #endif /* __AssetVersionD_h */

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -168,7 +168,7 @@ void DependentStateTreeFactory::FillInVertex(
   if (vertices[name].includeConnections) {
     // In some cases, assets in the dependent tree don't need their inputs and
     // children to calculate their states.
-    if (includeDepDescendents || !tree[myVertex].inDepTree) {
+    if (includeDepDescendents) {
       for (const auto &child : version->children)
       {
         auto childVertex = AddOrUpdateVertex(child, false, false);

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -169,8 +169,8 @@ void DependentStateTreeFactory::FillInVertex(
   // state. If I don't need to recalculate my state, I don't need to add any of
   // my connections. I'm only used to calculate someone else's state.
   if (vertices[name].includeConnections) {
-    // In some cases, assets in the dependent tree don't need their inputs and
-    // children to calculate their states.
+    // In some cases, assets don't need all their inputs and children to
+    // calculate their states.
     if (includeAllChildrenAndInputs) {
       for (const auto &child : version->children)
       {

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.cpp
@@ -153,8 +153,8 @@ void DependentStateTreeFactory::FillInVertex(
     tree[myVertex].inDepTree = false;
     vertices[name].includeConnections = false;
   }
-  // If I'm in the dependency tree I need to add my dependents because they are
-  // also in the dependency tree.
+  // If I'm in the dependency tree, and if the new state propagates to dependents,
+  // then I need to add my dependents to the graph and the dependency tree.
   if (tree[myVertex].inDepTree && includeDependentChildren) {
     vector<SharedString> dependents;
     version->DependentChildren(dependents);

--- a/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/DependentStateTree.h
@@ -50,7 +50,8 @@ using DependentStateTreeVertexDescriptor = DependentStateTree::vertex_descriptor
 DependentStateTree BuildDependentStateTree(
     const SharedString & ref,
     std::function<bool(AssetDefs::State)> includePredicate,
-    bool includeDepDescencents,
+    bool includeDependentChildren,
+    bool includeAllChildrenAndInputs,
     StorageManagerInterface<AssetVersionImpl> * sm);
 
 #endif

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -351,10 +351,6 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
         // to run the handlers now.
         bool runHandlers = true;//UserActionRequired(newState);
         SetState(vertex, newState, {0, 0}, runHandlers);
-        if (hasBlockingInputs->find(data.name) != hasBlockingInputs->end())
-          hasBlockingInputs->erase(data.name);
-        if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end())
-          hasBlockingChildren->erase(data.name);
       }
       else {
         auto version = updater.storageManager->Get(data.name);
@@ -362,8 +358,7 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
             version->InputStatesAffectMyState(AssetDefs::Blocked, true)) {
           SetState(vertex, AssetDefs::Blocked, {0,0}, true );
         }
-
-        if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end() && 
+        else if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end() && 
             version->ChildStatesAffectMyState()) {
           SetState(vertex, AssetDefs::Blocked, {0,0}, true );
         }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -539,7 +539,11 @@ void StateUpdater::NotifyChildOrInputSucceeded(
 }
 
 void StateUpdater::SetFailed(AssetHandle<AssetVersionImpl> & version) {
-  version->SetAndPropagateState(AssetDefs::Failed);
+  SetStateForRefAndDependents(
+      version->GetRef(), 
+      AssetDefs::Failed, 
+      [](AssetDefs::State){return true;}
+  );
 }
 
 void StateUpdater::RecalcState(const SharedString & ref) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -331,9 +331,9 @@ class StateUpdater::SetBlockingStateVisitor : public StateUpdater::VisitorBase {
         // Set the state to blocked if needed, otherwise do nothing
         auto version = updater.storageManager->Get(data.name);
         auto inputIt = hasBlockingInputs->find(data.name);
-        if (inputIt != hasBlockingInputs->end() && 
-            version->InputStatesAffectMyState(AssetDefs::Blocked, true)) {
-          SetState(vertex, AssetDefs::Blocked, {0,0}, true);
+        if (inputIt != hasBlockingInputs->end()) {
+          if (version->InputStatesAffectMyState(AssetDefs::Blocked, true))
+            SetState(vertex, AssetDefs::Blocked, {0,0}, true);
           hasBlockingInputs->erase(inputIt);
         }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -302,7 +302,7 @@ class StateUpdater::SetBlockingStateVisitor : public StateUpdater::VisitorBase {
     const std::shared_ptr<BlockedSet> hasBlockingChildren;
 
     void MarkParentsForLaterProcessing(AssetHandle<AssetVersionImpl> & version) const override {
-      if (AssetDefs::Canceled == newState || AssetDefs::Blocked == newState || AssetDefs::Failed == newState){
+      if (AssetDefs::IsBlocking(newState)){
         hasBlockingChildren->insert(version->parents.begin(), version->parents.end());
         hasBlockingInputs->insert(version->listeners.begin(), version->listeners.end());
       }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -299,10 +299,10 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
       AssetDefs::State oldState = tree[vertex].state;
       if (newState != oldState) {
         notify(NFY_PROGRESS, "Setting state of '%s' from '%s' to '%s'",
-              name.toString().c_str(), ToString(oldState).c_str(), ToString(newState).c_str());
+            name.toString().c_str(), ToString(oldState).c_str(), ToString(newState).c_str());
         auto version = updater.storageManager->GetMutable(name);
         if (version) {
-            updater.SetVersionStateAndRunHandlers(version, newState, waitingFor);
+          updater.SetVersionStateAndRunHandlers(version, newState, waitingFor);
 
           // Get the new state directly from the asset version since it may be
           // different from the passed-in state
@@ -318,7 +318,7 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
           // This shoud never happen - we had to successfully load the asset
           // previously to get it into the tree.
           notify(NFY_WARN, "Could not load asset '%s' to set state.",
-                name.toString().c_str());
+              name.toString().c_str());
         }
       }
     }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -306,8 +306,7 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
 
           // Get the new state directly from the asset version since it may be
           // different from the passed-in state
-          auto & data = tree[vertex];
-          data.state = version->state;
+          tree[vertex].state = version->state;
 
           if (AssetDefs::Canceled == newState || AssetDefs::Blocked == newState || AssetDefs::Failed == newState){
             hasBlockingChildren->insert(version->parents.begin(), version->parents.end());

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -331,12 +331,19 @@ class StateUpdater::SetBlockingStateVisitor : public StateUpdater::VisitorBase {
       else {
         // Set the state to blocked if needed, otherwise do nothing
         auto version = updater.storageManager->Get(data.name);
-        if (hasBlockingInputs->find(data.name) != hasBlockingInputs->end() && 
+        auto inputIt = hasBlockingInputs->find(data.name);
+        if (inputIt != hasBlockingInputs->end() && 
             version->InputStatesAffectMyState(AssetDefs::Blocked, true)) {
           SetState(vertex, AssetDefs::Blocked, {0,0}, true);
+          hasBlockingInputs->erase(inputIt);
         }
-        else if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end()) {
+
+        auto childIt = hasBlockingChildren->find(data.name);
+        if (childIt != hasBlockingChildren->end()) {
+          // SetState could already have been called because of a blocking input.
+          // If that's the case, it will return immediately without doing anything.
           SetState(vertex, AssetDefs::Blocked, {0,0}, true);
+          hasBlockingChildren->erase(childIt);
         }
       }
     }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -349,8 +349,7 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
             version->InputStatesAffectMyState(AssetDefs::Blocked, true)) {
           SetState(vertex, AssetDefs::Blocked, {0,0});
         }
-        else if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end() && 
-            version->ChildStatesAffectMyState()) {
+        else if (hasBlockingChildren->find(data.name) != hasBlockingChildren->end()) {
           SetState(vertex, AssetDefs::Blocked, {0,0});
         }
       }

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -286,7 +286,6 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
     StateUpdater & updater;
     DependentStateTree & tree;
     const AssetDefs::State newState;
-    // These are intended for things not in the dependency tree. 
     // This is a shared_ptr because the visitor will be copied several times
     // during the course of the traversal.
     const std::shared_ptr<RecalcSet> hasBlockingInputs;

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.cpp
@@ -360,7 +360,7 @@ class StateUpdater::SetBlockingStateVisitor : public default_dfs_visitor {
 /**********************************************
 * StateUpdater
 **********************************************/
-void StateUpdater::SetStateForRefAndDependents(
+void StateUpdater::SetAndPropagateState(
     const SharedString & ref,
     AssetDefs::State newState,
     function<bool(AssetDefs::State)> updateStatePredicate) {
@@ -538,7 +538,7 @@ void StateUpdater::NotifyChildOrInputSucceeded(
 }
 
 void StateUpdater::SetFailed(AssetHandle<AssetVersionImpl> & version) {
-  SetStateForRefAndDependents(
+  SetAndPropagateState(
       version->GetRef(), 
       AssetDefs::Failed, 
       [](AssetDefs::State){return true;}

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -32,6 +32,7 @@ class StateUpdater
   private:
     class UnsupportedException {};
     class SetStateVisitor;
+    class SetBlockingStateVisitor;
 
     StorageManagerInterface<AssetVersionImpl> * const storageManager;
     khAssetManagerInterface * const assetManager;

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -31,6 +31,7 @@ class StateUpdater
 {
   private:
     class UnsupportedException {};
+    class VisitorBase;
     class SetStateVisitor;
     class SetBlockingStateVisitor;
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater.h
@@ -73,7 +73,7 @@ class StateUpdater
       storageManager(sm), assetManager(am),
       waitingListeners(AssetDefs::Waiting), inProgressParents(AssetDefs::InProgress) {}
     StateUpdater() : StateUpdater(&AssetVersion::storageManager(), &theAssetManager) {}
-    virtual void SetStateForRefAndDependents(
+    virtual void SetAndPropagateState(
         const SharedString & ref,
         AssetDefs::State newState,
         std::function<bool(AssetDefs::State)> updateStatePredicate);

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -1017,8 +1017,8 @@ TEST_F(StateUpdaterTest, FailedInputDontCare) {
 
   GetMutableVersion(sm, "a")->inputStatesAffectMyState = false;
 
-  // MockVersion::InputStatesAffectMyState will return true, so setting this input
-  // to a Failed state should cause the listener to become Blocked
+  // MockVersion::InputStatesAffectMyState will return false, so the listener's
+  // state should be uanffected.
   updater.SetAndPropagateState(fix("b"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
 
   assertStateNotSet(sm, "a");

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -92,6 +92,10 @@ class MockVersion : public AssetVersionImpl {
     MockVersion(const MockVersion & that) : MockVersion() {
       name = that.name; // Don't add the suffix - the other MockVersion already did
     }
+
+    virtual bool InputStatesAffectMyState(AssetDefs::State stateByInputs, bool blockedByOfflineInputs) const override {return true;}
+    virtual bool ChildStatesAffectMyState() const override {return true;}
+
     virtual void DependentChildren(vector<SharedString> & d) const override {
       for(auto dependent : dependents) {
         d.push_back(dependent);
@@ -960,6 +964,10 @@ TEST_F(StateUpdaterTest, NotifyProgressFailed) {
 // notifications.
 TEST_F(StateUpdaterTest, Cancel) {
   GetBigTree(sm);
+
+  // The STARTING_STATE defined above is Blocked. If we don't set the state of "gp"
+  // to something else, it will not be updated.
+  GetMutableVersion(sm, "gp")->state = AssetDefs::InProgress;
   updater.SetStateForRefAndDependents(fix("p1"), AssetDefs::Canceled, [](AssetDefs::State) { return true; });
   
   assertStateSet(sm, "p1", 1);

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -942,7 +942,6 @@ TEST_F(StateUpdaterTest, SetFailed) {
   SetVersions(sm, {MockVersion("a")});
   auto version = sm.GetMutable(fix("a"));
   updater.SetFailed(version);
-  ASSERT_TRUE(GetVersion(sm, "a")->setAndPropagateStateCalled);
   ASSERT_EQ(GetVersion(sm, "a")->state, AssetDefs::Failed);
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -1024,7 +1024,7 @@ TEST_F(StateUpdaterTest, FailedInputDontCare) {
   assertStateNotSet(sm, "a");
   assertStateSet(sm, "b");
   assert(AssetDefs::Waiting == GetMutableVersion(sm, "a")->state);
-  assert(AssetDefs::Failed == GetMutableVersion(sm, "b")->state );
+  assert(AssetDefs::Failed == GetMutableVersion(sm, "b")->state);
 }
 
 TEST_F(StateUpdaterTest, FailedChild) {
@@ -1044,7 +1044,7 @@ TEST_F(StateUpdaterTest, FailedChild) {
   assertStateSet(sm, "p");
   assertStateSet(sm, "c");
   assert(AssetDefs::Blocked == GetMutableVersion(sm, "p")->state);
-  assert(AssetDefs::Failed == GetMutableVersion(sm, "c")->state );
+  assert(AssetDefs::Failed == GetMutableVersion(sm, "c")->state);
 }
 
 int main(int argc, char **argv) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -990,44 +990,44 @@ TEST_F(StateUpdaterTest, Cancel) {
 
 TEST_F(StateUpdaterTest, FailedInput) {
   SetVersions(sm, {
-                    MockVersion("l"),
-                    MockVersion("i")
+                    MockVersion("a"),
+                    MockVersion("b")
                   });
-  SetListenerInput(sm, "l", "i");
+  SetListenerInput(sm, "a", "b");
 
-  GetMutableVersion(sm, "l")->state = AssetDefs::Waiting;
-  GetMutableVersion(sm, "i")->state = AssetDefs::InProgress;
+  GetMutableVersion(sm, "a")->state = AssetDefs::Waiting;
+  GetMutableVersion(sm, "b")->state = AssetDefs::InProgress;
 
   // MockVersion::InputStatesAffectMyState will return true, so setting this input
   // to a Failed state should cause the listener to become Blocked
-  updater.SetStateForRefAndDependents(fix("i"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
+  updater.SetStateForRefAndDependents(fix("b"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
 
-  assertStateSet(sm, "l");
-  assertStateSet(sm, "i");
-  assert(AssetDefs::Blocked == GetMutableVersion(sm, "l")->state);
-  assert(AssetDefs::Failed == GetMutableVersion(sm, "i")->state );
+  assertStateSet(sm, "a");
+  assertStateSet(sm, "b");
+  assert(AssetDefs::Blocked == GetMutableVersion(sm, "a")->state);
+  assert(AssetDefs::Failed == GetMutableVersion(sm, "b")->state);
 }
 
 TEST_F(StateUpdaterTest, FailedInputDontCare) {
   SetVersions(sm, {
-                    MockVersion("l"),
-                    MockVersion("i")
+                    MockVersion("a"),
+                    MockVersion("b")
                   });
-  SetListenerInput(sm, "l", "i");
+  SetListenerInput(sm, "a", "b");
 
-  GetMutableVersion(sm, "l")->state = AssetDefs::Waiting;
-  GetMutableVersion(sm, "i")->state = AssetDefs::InProgress;
+  GetMutableVersion(sm, "a")->state = AssetDefs::Waiting;
+  GetMutableVersion(sm, "b")->state = AssetDefs::InProgress;
 
-  GetMutableVersion(sm, "l")->inputStatesAffectMyState = false;
+  GetMutableVersion(sm, "a")->inputStatesAffectMyState = false;
 
   // MockVersion::InputStatesAffectMyState will return true, so setting this input
   // to a Failed state should cause the listener to become Blocked
-  updater.SetStateForRefAndDependents(fix("i"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
+  updater.SetStateForRefAndDependents(fix("b"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
 
-  assertStateNotSet(sm, "l");
-  assertStateSet(sm, "i");
-  assert(AssetDefs::Waiting == GetMutableVersion(sm, "l")->state);
-  assert(AssetDefs::Failed == GetMutableVersion(sm, "i")->state );
+  assertStateNotSet(sm, "a");
+  assertStateSet(sm, "b");
+  assert(AssetDefs::Waiting == GetMutableVersion(sm, "a")->state);
+  assert(AssetDefs::Failed == GetMutableVersion(sm, "b")->state );
 }
 
 TEST_F(StateUpdaterTest, FailedChild) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/StateUpdater_unittest.cpp
@@ -1018,7 +1018,7 @@ TEST_F(StateUpdaterTest, FailedInputDontCare) {
   GetMutableVersion(sm, "a")->inputStatesAffectMyState = false;
 
   // MockVersion::InputStatesAffectMyState will return false, so the listener's
-  // state should be uanffected.
+  // state should be unaffected.
   updater.SetAndPropagateState(fix("b"), AssetDefs::Failed, [](AssetDefs::State) { return true; });
 
   assertStateNotSet(sm, "a");


### PR DESCRIPTION
Using a new DFS visitor that avoids unnecessarily loading children and inputs into the cache when propagating Canceled and Failed states.