### PR TITLE
1604: Fix WMS to work with reverse proxies

### DIFF
--- a/docs/geedocs/5.3.4/answer/releaseNotes/relNotesGEE5_3_4.html
+++ b/docs/geedocs/5.3.4/answer/releaseNotes/relNotesGEE5_3_4.html
@@ -108,10 +108,6 @@ correctly to the new PostgreSQL version used by Open GEE 5.3.4.</p>
 <td>Issue Description</td>
 <td>Issue Resolution</td>
 </tr>
-<tr class="row-odd"><td>1604</td>
-<td>WMS capability doesn't work with reverse proxies</td>
-<td>It now works, as long as the protocol (http vs https) matches</td>
-</tr>
 </tbody>
 </table>
 <p class="rubric">Known Issues</p>

--- a/docs/geedocs/5.3.4/answer/releaseNotes/relNotesGEE5_3_4.html
+++ b/docs/geedocs/5.3.4/answer/releaseNotes/relNotesGEE5_3_4.html
@@ -108,6 +108,10 @@ correctly to the new PostgreSQL version used by Open GEE 5.3.4.</p>
 <td>Issue Description</td>
 <td>Issue Resolution</td>
 </tr>
+<tr class="row-odd"><td>1604</td>
+<td>WMS capability doesn't work with reverse proxies</td>
+<td>It now works, as long as the protocol (http vs https) matches</td>
+</tr>
 </tbody>
 </table>
 <p class="rubric">Known Issues</p>

--- a/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_4.rst
+++ b/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_4.rst
@@ -42,9 +42,9 @@ Release notes: Open GEE 5.3.4
          * - Number
            - Description
            - Resolution
-         * - Issue number
-           - Issue Description
-           - Issue Resolution
+         * - 1604
+           - WMS capability doesn't work with reverse proxies
+           - It now works, as long as the protocol (http vs https) matches
 
       .. rubric:: Known Issues
 

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
@@ -104,7 +104,11 @@ def GetParameters(environ):
   # Examples for "this-endpoint" would be 'http://localhost/<target_path>/wms'
   # or 'http://servername/<target_path>/wms'
   (parameters["server-url"],
-   parameters["this-endpoint"]) = GetServerURL(environ)
+   parameters["this-endpoint"],
+   parameters["proxy-endpoint"]) = GetServerURL(environ)
+
+  if parameters["proxy-endpoint"] is None:
+    del parameters["proxy-endpoint"]
 
   return parameters
 
@@ -137,7 +141,14 @@ def GetServerURL(environ):
   complete_url += urllib.quote(environ.get("REDIRECT_URL", ""))
   complete_url += urllib.quote(environ.get("PATH_INFO", ""))
 
-  return server_url, complete_url
+  if environ.get("HTTP_X_FORWARDED_HOST"):
+    proxy_url = environ["wsgi.url_scheme"] + "://" + environ["HTTP_X_FORWARDED_HOST"]
+    proxy_url += urllib.quote(environ.get("REDIRECT_URL", ""))
+    proxy_url += urllib.quote(environ.get("PATH_INFO", ""))
+  else:
+    proxy_url = None
+
+  return server_url, complete_url, proxy_url
 
 
 def main():

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
@@ -115,6 +115,8 @@ class GetCapabilitiesRequest(object):
         xlink_href=url)
 
   def GetOnlineResource(self):
+    if "proxy-endpoint" in self.parameters:
+      return self._MakeOnlineResourceXml(self.parameters["proxy-endpoint"])
     return self._MakeOnlineResourceXml(self.parameters["this-endpoint"])
 
   def GetExceptionInfo(self):

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
@@ -113,6 +113,8 @@ class GetCapabilitiesRequest(object):
     return (limits.x0, limits.y0, limits.x1, limits.y1)
 
   def GetOnlineResource(self):
+    if "proxy-endpoint" in self.parameters:
+      return self._MakeOnlineResourceXml(self.parameters["proxy-endpoint"])
     return self._MakeOnlineResourceXml(self.parameters["this-endpoint"])
 
   def GetDCPTypeInfo(self):


### PR DESCRIPTION
This will allow WMS to work with reverse proxies by returning the correct link to the proxy server instead of the backend GEE server.

I have tested this on CentOS7 with ATAK and QGIS clients.

Note that this won't handle cases where the protocol (http vs https) changes between the proxy server and GEE server. It is a valid case, but not as important right now. It might be a little more work to set that up too since that info wasn't seen in the header from the proxy server.

To test:
1. Set up a reverse proxy to a GEE Server with a WMS-served map
2. Do a GetCapabilitiesRequest to the proxy server, and see in the response that OnlineResource points to the proxy server.
3. Viewing a WMS source should work wether using a reverse proxy or not.

Fixes #1604