### PR TITLE
Allow missing rows in publish_context_table

### DIFF
--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -150,14 +150,18 @@ class PublishManagerHelper(stream_manager.StreamManager):
             db_publish_path, target_path))
 
   def IsDefaultDatabase(self, publish_context_id):
-    query_string = ("""
-        SELECT publish_context_table.ec_default_db
-        FROM publish_context_table
-        WHERE publish_context_table.publish_context_id = %s AND
-        publish_context_table.ec_default_db = TRUE
-        """)
-    results = self.DbQuery(query_string, (publish_context_id,))
-    return bool(results)
+    # Ensure the publish_context_id is valid
+    if publish_context_id != 0:
+      query_string = ("""
+          SELECT publish_context_table.ec_default_db
+          FROM publish_context_table
+          WHERE publish_context_table.publish_context_id = %s AND
+          publish_context_table.ec_default_db = TRUE
+          """)
+      results = self.DbQuery(query_string, (publish_context_id,))
+      if results:
+        return True
+    return False
 
   def HandleQueryRequest(self, request, response):
     """Handles query requests.

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -150,8 +150,20 @@ class PublishManagerHelper(stream_manager.StreamManager):
             db_publish_path, target_path))
 
   def IsDefaultDatabase(self, publish_context_id):
-    # Ensure the publish_context_id is valid
-    if publish_context_id != 0:
+    """
+    Checks whether the passed-in database is the default database or not. When
+    upgrading from older releases such as 5.1.2, the publish_context_table may
+    not have an entry for a published database, so we have to perform two
+    queries: one to get the list of databases and one to check if each database
+    is the default. It would simplify things somewhat to move the ec_default_db
+    field to the target_table database so that we can get all the data we want
+    with a single query. However, this would make the upgrade code more
+    complicated because we would have to manage 3 schemas: one from before we
+    added ec_default_db and two with the ec_default_db in different places.
+    This method seems to be the simplest overall option even though it requires
+    multiple queries.
+    """
+    if publish_context_id != 0: # Ensure the publish_context_id is valid
       query_string = ("""
           SELECT publish_context_table.ec_default_db
           FROM publish_context_table

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -149,7 +149,7 @@ class PublishManagerHelper(stream_manager.StreamManager):
         PublishManagerHelper.TARGET_PATH_TEMPL.format(
             db_publish_path, target_path))
 
-  def IsDefaultDb(self, publish_context_id):
+  def IsDefaultDatabase(self, publish_context_id):
     query_string = ("""
         SELECT publish_context_table.ec_default_db
         FROM publish_context_table

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -156,13 +156,8 @@ class PublishManagerHelper(stream_manager.StreamManager):
         WHERE publish_context_table.publish_context_id = %s AND
         publish_context_table.ec_default_db = TRUE
         """)
-
     results = self.DbQuery(query_string, (publish_context_id,))
-
-    if results:
-      return True
-    else:
-      return False
+    return bool(results)
 
   def HandleQueryRequest(self, request, response):
     """Handles query requests.

--- a/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
+++ b/earth_enterprise/src/server/wsgi/serve/publish/publish_manager_helper.py
@@ -149,6 +149,21 @@ class PublishManagerHelper(stream_manager.StreamManager):
         PublishManagerHelper.TARGET_PATH_TEMPL.format(
             db_publish_path, target_path))
 
+  def IsDefaultDb(self, publish_context_id):
+    query_string = ("""
+        SELECT publish_context_table.ec_default_db
+        FROM publish_context_table
+        WHERE publish_context_table.publish_context_id = %s AND
+        publish_context_table.ec_default_db = TRUE
+        """)
+
+    results = self.DbQuery(query_string, (publish_context_id,))
+
+    if results:
+      return True
+    else:
+      return False
+
   def HandleQueryRequest(self, request, response):
     """Handles query requests.
 
@@ -225,13 +240,13 @@ class PublishManagerHelper(stream_manager.StreamManager):
             virtual_host_table.virtual_host_name,
             virtual_host_table.virtual_host_url,
             virtual_host_table.virtual_host_ssl,
-            target_table.target_path, target_table.serve_wms, publish_context_table.ec_default_db
-          FROM target_table, target_db_table, db_table, virtual_host_table, publish_context_table
+            target_table.target_path, target_table.serve_wms,
+            target_db_table.publish_context_id
+          FROM target_table, target_db_table, db_table, virtual_host_table
           WHERE target_table.target_path = %s AND
             target_table.target_id = target_db_table.target_id AND
             target_db_table.db_id = db_table.db_id AND
-            target_db_table.virtual_host_id = virtual_host_table.virtual_host_id AND
-            publish_context_table.publish_context_id = target_db_table.publish_context_id
+            target_db_table.virtual_host_id = virtual_host_table.virtual_host_id
           """)
 
       results = self.DbQuery(query_string, (norm_target_path,))
@@ -240,7 +255,8 @@ class PublishManagerHelper(stream_manager.StreamManager):
         assert isinstance(results, list) and len(results) == 1
         (r_host_name, r_db_path, r_db_name, r_db_timestamp, r_db_size,
          r_virtual_host_name, r_virtual_host_url, r_virtual_host_ssl,
-         r_target_path, r_serve_wms, r_default_database) = results[0]
+         r_target_path, r_serve_wms, publish_context_id) = results[0]
+        r_default_database = self.IsDefaultDatabase(publish_context_id)
 
         db_info = basic_types.DbInfo()
         # TODO: make re-factoring - implement some Set function
@@ -618,13 +634,12 @@ class PublishManagerHelper(stream_manager.StreamManager):
     target_details = {}
     query_string = ("""SELECT db_table.host_name, db_table.db_name,
               virtual_host_table.virtual_host_name, target_table.serve_wms
-              FROM target_table, target_db_table, db_table, virtual_host_table, publish_context_table
+              FROM target_table, target_db_table, db_table, virtual_host_table
               WHERE target_table.target_path = %s AND
               target_table.target_id = target_db_table.target_id AND
               target_db_table.db_id = db_table.db_id AND
               target_db_table.virtual_host_id =
-              virtual_host_table.virtual_host_id AND
-              publish_context_table.publish_context_id = target_db_table.publish_context_id""")
+              virtual_host_table.virtual_host_id""")
 
     result = self.DbQuery(query_string, (target_path,))
 
@@ -1455,18 +1470,19 @@ class PublishManagerHelper(stream_manager.StreamManager):
     query_db_target = (
         "SELECT target_db_table.db_id,"
         " virtual_host_table.virtual_host_name,"
-        " target_table.target_path, target_table.serve_wms, publish_context_table.ec_default_db"
-        " FROM target_db_table, target_table, virtual_host_table, publish_context_table"
+        " target_table.target_path, target_table.serve_wms,"
+        " target_db_table.publish_context_id"
+        " FROM target_db_table, target_table, virtual_host_table"
         " WHERE target_table.target_id = target_db_table.target_id AND"
-        " virtual_host_table.virtual_host_id = target_db_table.virtual_host_id AND"
-        " publish_context_table.publish_context_id = target_db_table.publish_context_id")
+        " virtual_host_table.virtual_host_id = target_db_table.virtual_host_id")
     results = self.DbQuery(query_db_target)
 
     # Build a dictionary.
     db_to_publish_info_dct = dict(
         (db_id, []) for (db_id, unused_vh_name, unused_target_path,
                          unused_serve_wms, unused_default_db) in results)
-    for db_id, vh_name, target_path, serve_wms, default_database in results:
+    for db_id, vh_name, target_path, serve_wms, publish_context_id in results:
+      default_database = self.IsDefaultDatabase(publish_context_id)
       db_to_publish_info_dct[db_id].append(
           (vh_name, target_path, serve_wms, default_database))
 


### PR DESCRIPTION
The flag indicating whether a database is the default is stored in the publish_context_table. However, if the Open GEE installation is upgraded from an older version (such as 5.1.2), the publish_context_table may be empty. This causes some queries to return no results, making it appear as if published databases were not published at all. This PR fixes this issue by querying the publish_context_table separately from other tables so that we can handle cases where the row we are looking for is missing.

I have not added this change to the release notes because the bug was introduced and fixed in 5.3.3.

Fixes #1616