### PR TITLE
I1608: Expand level_dim_sizes_ to handle level 24

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/polygontoqtnodes.cpp
@@ -133,8 +133,9 @@ Grid::Grid(const double west_origin, const double south_origin)
     polygon_north_boundary_(south_origin) {
   // Pre-calculate number of quadtree nodes in each dimension at each level.
   // Dimension size = 2 ^ level
-  level_dim_sizes_.resize(MAX_LEVEL);
-  for (uint32 level = 0; level < MAX_LEVEL; ++level) {
+  // Valid levels are 0 through 24 
+  level_dim_sizes_.resize(MAX_LEVEL + 1);
+  for (uint32 level = 0; level <= MAX_LEVEL; ++level) {
     level_dim_sizes_[level] = static_cast<double>(1L << level);
   }
 }


### PR DESCRIPTION
Addresses #1608 

To verify:
Build and publish a map or globe
Use cutter to create a polygon-based cut with Polygon Level (under Advanced) set to 24.

Note: If your polygon is not very small, then the cut will take a very long time. Zoom all the way in before making the polygon (or use a very small polygon from a KML file).

I performed my testing for this on CentOS 6.10.