### PR TITLE
Refactor job loop

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -62,14 +62,14 @@ class MockResourceProvider : public khResourceProvider {
       success = !(waitFors == failStatusOn);
     }
     virtual void DeleteJob(
-        std::vector<Job>::iterator which,
+        JobIter which,
         bool success = false,
         time_t beginTime = 0, time_t endTime = 0) override {
       ++deletes;
       delSuccess = success;
       delTime = beginTime;
     }
-    virtual Job* FindJobById(uint32 jobid, std::vector<Job>::iterator &found) override {
+    virtual Job* FindJobById(uint32 jobid, JobIter &found) override {
       ++findJobs;
       return (findJobs == failFindJobOn ? nullptr : &myJob);
     }

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -18,8 +18,41 @@
 
 #include "khResourceProvider.h"
 
-TEST(JobLoopTest, CreateResourceProvider) {
-  khResourceProvider resProv;
+class MockResourceProvider : public khResourceProvider
+{
+  private:
+    virtual void StartLogFile(Job * job, const std::string &logfile) override {}
+    virtual void LogJobResults(
+        Job * job,
+        const std::string &status_string,
+        int signum,
+        bool coredump,
+        bool success,
+        time_t cmdtime,
+        time_t endtime) override {}
+    virtual void LogTotalTime(Job * job, uint32 elapsed) override {}
+    virtual bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline) override { return true; }
+    virtual void SendProgress(uint32 jobid, double progress, time_t progressTime) override {}
+    virtual void GetProcessStatus(pid_t pid, std::string* status_string,
+                                  bool* success, bool* coredump, int* signum) override {}
+    virtual void WaitForPid(pid_t waitfor, bool &success, bool &coredump,
+                            int &signum) override {}
+    virtual void DeleteJob(
+        std::vector<Job>::iterator which,
+        bool success = false,
+        time_t beginTime = 0, time_t endTime = 0) override {}
+    virtual Job* FindJobById(uint32 jobid, std::vector<Job>::iterator &found) override { return nullptr; }
+  public:
+    void RunJobLoop(StartJobMsg msg) { JobLoop(msg); }
+};
+
+class JobLoopTest : public testing::Test {
+  protected:
+    MockResourceProvider resProv;
+};
+
+TEST_F(JobLoopTest, CreateResourceProvider) {
+  resProv.RunJobLoop(StartJobMsg());
 }
 
 int main(int argc, char **argv) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 The Open GEE Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -320,11 +320,6 @@ TEST_F(JobLoopTest, NoCommands) {
   ASSERT_FALSE(resProv.delSuccess);
 }
 
-/*
-TODO:
-- set begin time on first command
-*/
-
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc,argv);
   return RUN_ALL_TESTS();

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -16,6 +16,12 @@
 
 #include <gtest/gtest.h>
 
+#include "khResourceProvider.h"
+
+TEST(JobLoopTest, CreateResourceProvider) {
+  khResourceProvider resProv;
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc,argv);
   return RUN_ALL_TESTS();

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -296,9 +296,22 @@ TEST_F(JobLoopTest, MultiCommandFailWaitFor) {
   ASSERT_FALSE(resProv.delSuccess);
 }
 
+TEST_F(JobLoopTest, MultiCommandFailFind) {
+  resProv.failFindJobOn = 3;
+  resProv.RunJobLoop(true);
+  ASSERT_EQ(resProv.logStarted, 1);
+  ASSERT_EQ(resProv.executes, 2);
+  ASSERT_EQ(resProv.progSent, 1);
+  ASSERT_EQ(resProv.getStatus, 2);
+  ASSERT_EQ(resProv.waitFors, 0);
+  ASSERT_EQ(resProv.resultsLogged, 1);
+  ASSERT_EQ(resProv.timeLogged, 0);
+  ASSERT_EQ(resProv.deletes, 0);
+  ASSERT_FALSE(resProv.delSuccess);
+}
+
 /*
 TODO:
-- multiple commands where one fails second FindJobById
 - no commands
 - set begin time on first command
 - locking behavior

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -47,7 +47,7 @@ class MockResourceProvider : public khResourceProvider {
       ++executes;
       return !(executes == failExecOn);
     }
-    virtual void SendProgress(JobIter job, double progress, time_t progressTime) override {
+    virtual void SendProgress(uint32 job, double progress, time_t progressTime) override {
       assert(progress == 0);
       ++progSent;
     }

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -43,11 +43,11 @@ class MockResourceProvider : public khResourceProvider {
     virtual void LogTotalTime(Job * job, uint32 elapsed) override {
       ++timeLogged;
     }
-    virtual bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline) override {
+    virtual bool ExecCmdline(Job * job, const std::vector<std::string> &cmdline) override {
       ++executes;
       return !(executes == failExecOn);
     }
-    virtual void SendProgress(uint32 jobid, double progress, time_t progressTime) override {
+    virtual void SendProgress(Job * job, double progress, time_t progressTime) override {
       assert(progress == 0);
       ++progSent;
     }

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -35,9 +35,13 @@ class MockResourceProvider : public khResourceProvider {
       ++executes;
       return execPasses;
     }
-    virtual void SendProgress(uint32 jobid, double progress, time_t progressTime) override {}
+    virtual void SendProgress(uint32 jobid, double progress, time_t progressTime) override {
+      ++progSent;
+    }
     virtual void GetProcessStatus(pid_t pid, std::string* status_string,
-                                  bool* success, bool* coredump, int* signum) override {}
+                                  bool* success, bool* coredump, int* signum) override {
+      ++getStatus;
+    }
     virtual void WaitForPid(pid_t waitfor, bool &success, bool &coredump,
                             int &signum) override {
       ++waitFors;
@@ -59,6 +63,8 @@ class MockResourceProvider : public khResourceProvider {
 
     // These variables record what the class does
     uint executes;
+    uint progSent;
+    uint getStatus;
     uint waitFors;
     uint deletes;
 
@@ -67,6 +73,8 @@ class MockResourceProvider : public khResourceProvider {
         jobPointer(&myJob),
         execPasses(true),
         executes(0),
+        progSent(0),
+        getStatus(0),
         waitFors(0),
         deletes(0) {}
     void RunJobLoop() { JobLoop(StartJobMsg(1, "test.log", {{"cmd1"}})); }
@@ -81,6 +89,8 @@ TEST_F(JobLoopTest, NoJob) {
   resProv.jobPointer = nullptr;
   resProv.RunJobLoop();
   ASSERT_EQ(resProv.executes, 0);
+  ASSERT_EQ(resProv.progSent, 0);
+  ASSERT_EQ(resProv.getStatus, 0);
   ASSERT_EQ(resProv.waitFors, 0);
   ASSERT_EQ(resProv.deletes, 0);
 }
@@ -89,6 +99,8 @@ TEST_F(JobLoopTest, ExecFails) {
   resProv.execPasses = false;
   resProv.RunJobLoop();
   ASSERT_EQ(resProv.executes, 1);
+  ASSERT_EQ(resProv.progSent, 0);
+  ASSERT_EQ(resProv.getStatus, 0);
   ASSERT_EQ(resProv.waitFors, 0);
   ASSERT_EQ(resProv.deletes, 1);
 }

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Open GEE Contributors
+ * Copyright 2020 The Open GEE Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/JobLoop_unittest.cpp
@@ -30,7 +30,7 @@ class MockResourceProvider : public khResourceProvider {
         job->logfile = stdout;
       }
     }
-    virtual void LogJobResults(
+    virtual void LogCmdResults(
         JobIter job,
         const std::string &status_string,
         int signum,

--- a/earth_enterprise/src/fusion/autoingest/sysman/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/SConscript
@@ -103,7 +103,7 @@ sysmanFiles = ['AssetD.cpp', 'AssetVersionD.cpp',
   'ResourceProviderProxy.cpp', 'Reservation.cpp',
   'SysManExtra.cpp', 'SysManFromStorage.cpp', 'InsetInfo.cpp'] + \
   pluginFiles
-extraObjs = [TaskStorageObj, JobStorageObj, NextTaskIdObj, TaskRuleObj,
+sysmanExtraObjs = [TaskStorageObj, JobStorageObj, NextTaskIdObj, TaskRuleObj,
   FusionUniqueIdObj] + \
   commonobj + \
   env.ObjFromOtherDir(otherDirObjs)
@@ -111,21 +111,23 @@ sysmanObjs = map(lambda f: str(f).replace(".cpp", ".o"), sysmanFiles)
 sysmanLibs = ['gegdal', 'geraster', 'gesearchtabs', 'genet', 'gepublish', 'gefconfigutil',
   'geindex_r', 'geutil', 'gecommon', 'gexml', 'gemiscconfig', 'qt-mt', 'xerces-c', 'geos',
   'gomp']
-testLibs = sysmanLibs + ['gtest']
+sysmanTestLibs = sysmanLibs + ['gtest']
+
+resprovFiles = ['khResourceProvider.cpp', 'khResourceManagerProxy.cpp',
+  'khResourceProviderDispatch.cpp']
+resprovObjs = map(lambda f: str(f).replace(".cpp", ".o"), resprovFiles)
+resprovExtraObjs = [TaskStorageObj, JobStorageObj, env['FUSIONVER'], env['BUILDDATE']]
+resprovLibs = ['geautoingest', 'geconfigutil', 'gefconfigutil', 'geutil', 'gecommon', 'gexml', 'gemiscconfig', 'xerces-c', 'qt-mt']
+resprovTestLibs = resprovLibs + ['gtest']
+
 
 gesystemmanager = env.executable('gesystemmanager',
-    [ 'gesystemmanager_main.cpp', env['FUSIONVER'] ] + sysmanFiles + extraObjs,
+    [ 'gesystemmanager_main.cpp', env['FUSIONVER'] ] + sysmanFiles + sysmanExtraObjs,
     LIBS=sysmanLibs)
 
 geresourceprovider = env.executable('geresourceprovider',
-    ['geresourceprovider_main.cpp',
-     'khResourceProvider.cpp',
-     'khResourceManagerProxy.cpp', 'khResourceProviderDispatch.cpp',
-     TaskStorageObj, JobStorageObj,
-     env['FUSIONVER'],
-     env['BUILDDATE'],
-     ],
-    LIBS=['geautoingest', 'geconfigutil', 'gefconfigutil', 'geutil', 'gecommon', 'gexml', 'gemiscconfig', 'xerces-c', 'qt-mt'])
+    ['geresourceprovider_main.cpp'] + resprovFiles + resprovExtraObjs,
+    LIBS=resprovLibs)
 
 
 env.install('fusion_bin', [ gesystemmanager, geresourceprovider ] )
@@ -134,32 +136,32 @@ env.install('fusion_root', [ 'gefusion' ], 'etc/init.d')
 
 SConscript(
     'parse-raster-project-xml-no-content_unittest/SConscript',
-    exports=['env', 'sysmanObjs', 'extraObjs', 'testLibs'])
+    exports=['env', 'sysmanObjs', 'sysmanExtraObjs', 'sysmanTestLibs'])
 
 SConscript(
     'memory-tests/SConscript',
-    exports=['env', 'sysmanObjs', 'extraObjs', 'testLibs'])
+    exports=['env', 'sysmanObjs', 'sysmanExtraObjs', 'sysmanTestLibs'])
 
 env.test('LeafAssetVersion_unittest',
-    sysmanObjs + extraObjs + [ 'LeafAssetVersion_unittest.cpp' ],
-    LIBS=testLibs)
+    sysmanObjs + sysmanExtraObjs + [ 'LeafAssetVersion_unittest.cpp' ],
+    LIBS=sysmanTestLibs)
 
 env.test('StateUpdater_unittest',
-    sysmanObjs + extraObjs + [ 'StateUpdater_unittest.cpp' ],
-    LIBS=testLibs)
+    sysmanObjs + sysmanExtraObjs + [ 'StateUpdater_unittest.cpp' ],
+    LIBS=sysmanTestLibs)
 
 env.test('StorageManagerAssetFactory_unittest',
-    sysmanObjs + extraObjs + [ 'StorageManagerAssetFactory_unittest.cpp' ],
-    LIBS=testLibs)
+    sysmanObjs + sysmanExtraObjs + [ 'StorageManagerAssetFactory_unittest.cpp' ],
+    LIBS=sysmanTestLibs)
 
 env.test('AssetOperation_unittest',
-    sysmanObjs + extraObjs + ['AssetOperation_unittest.cpp'],
-    LIBS=testLibs)
+    sysmanObjs + sysmanExtraObjs + ['AssetOperation_unittest.cpp'],
+    LIBS=sysmanTestLibs)
 
 env.test('CalcState_unittest',
-    sysmanObjs + extraObjs + [ 'CalcState_unittest.cpp' ],
-    LIBS=testLibs)
+    sysmanObjs + sysmanExtraObjs + [ 'CalcState_unittest.cpp' ],
+    LIBS=sysmanTestLibs)
 
 env.test('JobLoop_unittest',
-         ['JobLoop_unittest.cpp'],
-         LIBS=['gtest'])
+    ['JobLoop_unittest.cpp'] + resprovObjs + resprovExtraObjs,
+    LIBS=resprovTestLibs)

--- a/earth_enterprise/src/fusion/autoingest/sysman/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/SConscript
@@ -159,3 +159,7 @@ env.test('AssetOperation_unittest',
 env.test('CalcState_unittest',
     sysmanObjs + extraObjs + [ 'CalcState_unittest.cpp' ],
     LIBS=testLibs)
+
+env.test('JobLoop_unittest',
+         ['JobLoop_unittest.cpp'],
+         LIBS=['gtest'])

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -798,20 +798,22 @@ khResourceProvider::StopJob(const StopJobMsg &stop)
   assert(!mutex.trylock());
 
   JobIter job = FindJobById(stop.jobid);
-  if (Valid(job) && job->pid > 0) {
-    // It's already running, so try to kill it. Killing -pid instead
-    // of pid says to send the signal to all processes in the
-    // process group pid. When we fork our chid we make it a process
-    // group leader.
-    notify(NFY_DEBUG, "Killing pgid %d", -job->pid);
-    if (!khKillPid(-job->pid)) {
-      // warning has already been emitted
+  if (Valid(job)) {
+    if (job->pid > 0) {
+      // It's already running, so try to kill it. Killing -pid instead
+      // of pid says to send the signal to all processes in the
+      // process group pid. When we fork our chid we make it a process
+      // group leader.
+      notify(NFY_DEBUG, "Killing pgid %d", -job->pid);
+      if (!khKillPid(-job->pid)) {
+        // warning has already been emitted
+        DeleteJob(job);
+      }
+    } else {
+      // it's not running yet, taking it out of the list
+      // will keep it from ever running
       DeleteJob(job);
     }
-  } else {
-    // it's not running yet, taking it out of the list
-    // will keep it from ever running
-    DeleteJob(job);
   }
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -647,8 +647,9 @@ khResourceProvider::JobLoop(StartJobMsg start)
 
     // ***** Launch the command *****
     cmdtime = time(0);
-    if (!job->beginTime)
+    if (!job->beginTime) {
       job->beginTime = cmdtime;
+    }
 
     if (!job->logfile) {
       StartLogFile(job, start.logfile);

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -641,48 +641,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
       StartLogFile(job, start.logfile);
     }
 
-    success = false;
-    if (ExecCmdline(job, start.commands[cmdnum])) {
-      pid_t waitfor = job->pid;
-
-      // ***** wait for command to finish *****
-      bool coredump = false;
-      int  signum   = -1;
-      std::string status_string;
-      {
-        // release the lock while we wait for the process to finish
-        khUnlockGuard unlock(mutex);
-
-        // notify the resource manager the first time
-        if (cmdnum == 0) {
-          SendProgress(job, 0, time(0));
-        }
-
-        if (job->logfile) {
-          // Collect process status summary just before it exits.
-          GetProcessStatus(waitfor, &status_string, &success, &coredump, &signum);
-        } else {
-          WaitForPid(waitfor, success, coredump, signum);
-        }
-
-        // get the endtime before re reacquire the lock
-        endtime = time(0);
-      }
-      // now that we have the lock again, make sure the job hasn't been
-      // deleted while we were waiting for it to finish
-      job = FindJobById(job->jobid);
-      if (Valid(job)) {
-        job->pid = 0;
-
-        // ***** report command status *****
-        if (job->logfile) {
-          LogCmdResults(job, status_string, signum, coredump, success, cmdtime, endtime);
-        }
-      }
-    }
-    else {
-      logTotalTime = false;
-    }
+    success = RunCmd(job, start.commands[cmdnum], cmdnum == 0, cmdtime, endtime, logTotalTime);
     if (!success || !Valid(job)) break;
   } /* for cmdnum */
 
@@ -693,6 +652,59 @@ khResourceProvider::JobLoop(StartJobMsg start)
 
     DeleteJob(job, success, job->beginTime, endtime);
   }
+}
+
+bool
+khResourceProvider::RunCmd(
+    JobIter & job,
+    const std::vector<std::string> & commands,
+    bool sendProgress,
+    time_t cmdtime,
+    time_t & endtime,
+    bool & logTotalTime) {
+  bool success = false;
+  if (ExecCmdline(job, commands)) {
+    pid_t waitfor = job->pid;
+
+    // ***** wait for command to finish *****
+    bool coredump = false;
+    int  signum   = -1;
+    std::string status_string;
+    {
+      // release the lock while we wait for the process to finish
+      khUnlockGuard unlock(mutex);
+
+      // notify the resource manager the first time
+      if (sendProgress) {
+        SendProgress(job, 0, time(0));
+      }
+
+      if (job->logfile) {
+        // Collect process status summary just before it exits.
+        GetProcessStatus(waitfor, &status_string, &success, &coredump, &signum);
+      } else {
+        WaitForPid(waitfor, success, coredump, signum);
+      }
+
+      // get the endtime before re reacquire the lock
+      endtime = time(0);
+    }
+    // now that we have the lock again, make sure the job hasn't been
+    // deleted while we were waiting for it to finish
+    job = FindJobById(job->jobid);
+    if (Valid(job)) {
+      job->pid = 0;
+
+      // ***** report command status *****
+      if (job->logfile) {
+        LogCmdResults(job, status_string, signum, coredump, success, cmdtime, endtime);
+      }
+    }
+  }
+  else {
+    logTotalTime = false;
+  }
+  return success;
 }
 
 void

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -393,16 +393,14 @@ khResourceProvider::PruneLoop(void)
 // ***  ProgressLoop
 // ****************************************************************************
 void
-khResourceProvider::SendProgress(uint32 jobid, double progress,
+khResourceProvider::SendProgress(Job * job, double progress,
                                  time_t progressTime) {
   khLockGuard lock(mutex);
-  std::vector<Job>::iterator unused;
-  Job *job = FindJobById(jobid, unused);
   if (job) {
     // notify the resource manager
     sendQueue->push
       (SendCmd(std::mem_fun(&khResourceManagerProxy::JobProgress),
-               JobProgressMsg(jobid,
+               JobProgressMsg(job->jobid,
                               job->beginTime,
                               progressTime,
                               progress),
@@ -667,7 +665,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
 
         // notify the resource manager the first time
         if (cmdnum == 0) {
-          SendProgress(jobid, 0, time(0));
+          SendProgress(job, 0, time(0));
         }
 
         if (job->logfile) {

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -793,7 +793,6 @@ khResourceProvider::StopJob(const StopJobMsg &stop)
   // the mutex must be locked
   assert(!mutex.trylock());
 
-  JobIter found;
   JobIter job = FindJobById(stop.jobid);
   if (Valid(job) && job->pid > 0) {
     // It's already running, so try to kill it. Killing -pid instead
@@ -803,12 +802,12 @@ khResourceProvider::StopJob(const StopJobMsg &stop)
     notify(NFY_DEBUG, "Killing pgid %d", -job->pid);
     if (!khKillPid(-job->pid)) {
       // warning has already been emitted
-      DeleteJob(found);
+      DeleteJob(job);
     }
   } else {
     // it's not running yet, taking it out of the list
     // will keep it from ever running
-    DeleteJob(found);
+    DeleteJob(job);
   }
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -621,17 +621,18 @@ khResourceProvider::ExecCmdline(JobIter job,
 void
 khResourceProvider::JobLoop(StartJobMsg start)
 {
-  khLockGuard lock(mutex);
   uint32 jobid = start.jobid;
+  time_t endtime = 0;
+  bool success = false;
+  bool logTotalTime = false;
+
+  khLockGuard lock(mutex);
   JobIter job = FindJobById(jobid);
   if (!Valid(job)) {
     // somebody already asked for me to go away
     return;
   }
 
-  time_t endtime = 0;
-  bool success = false;
-  bool logTotalTime = false;
   for (uint cmdnum = 0; cmdnum < start.commands.size(); ++cmdnum) {
     logTotalTime = (cmdnum > 0);
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -680,12 +680,9 @@ khResourceProvider::JobLoop(StartJobMsg start)
 
       if (job->logfile) {
         // Collect process status summary just before it exits.
-        ProcPidStats::GetProcessStatus(waitfor, &status_string, &success,
-                                       &coredump, &signum);
+        GetProcessStatus(waitfor, &status_string, &success, &coredump, &signum);
       } else {
-        // I don't care about the return value, the pass by ref params will
-        // be set correctly either way
-        (void)khWaitForPid(waitfor, success, coredump, signum, NULL);
+        WaitForPid(waitfor, success, coredump, signum);
       }
 
       // get the endtime before re reacquire the lock
@@ -736,6 +733,20 @@ khResourceProvider::StartLogFile(Job * job, const std::string &logfile) {
     fprintf(job->logfile, "STARTTIME: %s\n",
             GetFormattedTimeString(job->beginTime).c_str());
   }
+}
+
+void
+khResourceProvider::GetProcessStatus(pid_t pid, std::string* status_string,
+                                     bool* success, bool* coredump, int* signum) {
+  ProcPidStats::GetProcessStatus(pid, status_string, success, coredump, signum);
+}
+
+void
+khResourceProvider::WaitForPid(pid_t waitfor, bool &success, bool &coredump,
+                               int &signum) {
+  // I don't care about the return value, the pass by ref params will
+  // be set correctly either way
+  (void)khWaitForPid(waitfor, success, coredump, signum, NULL);
 }
 
 void

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -619,8 +619,7 @@ void
 khResourceProvider::JobLoop(StartJobMsg start)
 {
   khLockGuard lock(mutex);
-  uint32 jobid = start.jobid;
-  JobIter job = FindJobById(jobid);
+  JobIter job = FindJobById(start.jobid);
   if (!Valid(job)) {
     // somebody already asked for me to go away
     return;
@@ -671,13 +670,13 @@ khResourceProvider::JobLoop(StartJobMsg start)
       }
       // now that we have the lock again, make sure the job hasn't been
       // deleted while we were waiting for it to finish
-      job = FindJobById(jobid);
+      job = FindJobById(job->jobid);
       if (Valid(job)) {
         job->pid = 0;
 
         // ***** report command status *****
         if (job->logfile) {
-          LogJobResults(job, status_string, signum, coredump, success, cmdtime, endtime);
+          LogCmdResults(job, status_string, signum, coredump, success, cmdtime, endtime);
         }
       }
     }
@@ -730,7 +729,7 @@ khResourceProvider::WaitForPid(pid_t waitfor, bool &success, bool &coredump,
 }
 
 void
-khResourceProvider::LogJobResults(
+khResourceProvider::LogCmdResults(
     JobIter job,
     const std::string &status_string,
     int signum,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -387,17 +387,20 @@ khResourceProvider::PruneLoop(void)
 // ***  ProgressLoop
 // ****************************************************************************
 void
-khResourceProvider::SendProgress(JobIter job, double progress,
+khResourceProvider::SendProgress(uint32 jobid, double progress,
                                  time_t progressTime) {
   khLockGuard lock(mutex);
-  // notify the resource manager
-  sendQueue->push
-    (SendCmd(std::mem_fun(&khResourceManagerProxy::JobProgress),
-              JobProgressMsg(job->jobid,
-                            job->beginTime,
-                            progressTime,
-                            progress),
-              0 /* timeout */));
+  JobIter job = FindJobById(jobid);
+  if (Valid(job)) {
+    // notify the resource manager
+    sendQueue->push
+      (SendCmd(std::mem_fun(&khResourceManagerProxy::JobProgress),
+               JobProgressMsg(jobid,
+                              job->beginTime,
+                              progressTime,
+                              progress),
+               0 /* timeout */));
+  }
 }
 
 
@@ -680,7 +683,7 @@ khResourceProvider::RunCmd(
 
     // notify the resource manager the first time
     if (sendProgress) {
-      SendProgress(job, 0, time(0));
+      SendProgress(jobid, 0, time(0));
     }
 
     // ***** wait for command to finish *****

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -686,29 +686,26 @@ khResourceProvider::JobLoop(StartJobMsg start)
       // now that we have the lock again, make sure the job hasn't been
       // deleted while we were waiting for it to finish
       job = FindJobById(jobid, found);
-      if (!job) {
+      if (job) {
+        job->pid = 0;
+
+
+        // ***** report command status *****
+        if (job->logfile) {
+          LogJobResults(job, status_string, signum, coredump, success, cmdtime, endtime);
+        }
+      }
+      else {
         // somebody already asked for me to go away
         logTotalTime = false;
         doDelete = false;
-        break;
-      }
-      job->pid = 0;
-
-
-      // ***** report command status *****
-      if (job->logfile) {
-        LogJobResults(job, status_string, signum, coredump, success, cmdtime, endtime);
-      }
-
-      if (!success) {
-        ++cmdnum;
-        break;
+        success = false;
       }
     }
     else {
       logTotalTime = false;
-      break;
     }
+    if (!success) break;
   } /* for cmdnum */
 
   if (logTotalTime) {
@@ -718,11 +715,6 @@ khResourceProvider::JobLoop(StartJobMsg start)
   if (doDelete) {
     DeleteJob(found, success, job->beginTime, endtime);
   }
-}
-
-void
-khResourceProvider::RunJob(std::vector<Job>::iterator job) {
-
 }
 
 void

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -650,21 +650,8 @@ khResourceProvider::JobLoop(StartJobMsg start)
     if (!job->beginTime)
       job->beginTime = cmdtime;
 
-    if (!job->logfile &&
-        ((job->logfile = fopen(start.logfile.c_str(), "w")))) {
-      // if this is first command, open the logfile & write the header
-      fprintf(job->logfile, "BUILD HOST: %s\n",
-              khHostname().c_str());
-      fprintf(job->logfile, "FUSION VERSION %s, BUILD %s\n",
-              GEE_VERSION, BUILD_DATE);
-      {
-        QString runtimeDesc = RuntimeOptions::DescString();
-        if (!runtimeDesc.isEmpty()) {
-          fprintf(job->logfile, "OPTIONS: %s\n", runtimeDesc.latin1());
-        }
-      }
-      fprintf(job->logfile, "STARTTIME: %s\n",
-              GetFormattedTimeString(job->beginTime).c_str());
+    if (!job->logfile) {
+      StartLogFile(job, start.logfile);
     }
 
     if (ExecCmdline(job, start.commands[cmdnum])) {
@@ -758,6 +745,24 @@ khResourceProvider::JobLoop(StartJobMsg start)
   DeleteJob(found, success, job->beginTime, endtime);
 }
 
+void
+khResourceProvider::StartLogFile(Job * job, const std::string &logfile) {
+  if (job->logfile = fopen(logfile.c_str(), "w")) {
+    // if this is first command, open the logfile & write the header
+    fprintf(job->logfile, "BUILD HOST: %s\n",
+            khHostname().c_str());
+    fprintf(job->logfile, "FUSION VERSION %s, BUILD %s\n",
+            GEE_VERSION, BUILD_DATE);
+    {
+      QString runtimeDesc = RuntimeOptions::DescString();
+      if (!runtimeDesc.isEmpty()) {
+        fprintf(job->logfile, "OPTIONS: %s\n", runtimeDesc.latin1());
+      }
+    }
+    fprintf(job->logfile, "STARTTIME: %s\n",
+            GetFormattedTimeString(job->beginTime).c_str());
+  }
+}
 
 // ****************************************************************************
 // ***  StopJob

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -702,32 +702,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
 
     // ***** report command status *****
     if (job->logfile) {
-      fflush(job->logfile);
-      // If process status information has been collected print that to log.
-      if (!status_string.empty()) {
-        fprintf(job->logfile, "%s", status_string.c_str());
-      }
-      fprintf(job->logfile,
-              "---------- End Command Output ----------\n");
-      if (signum != -1) {
-        fprintf(job->logfile,
-                "Process terminated by signal %d%s\n",
-                signum,
-                coredump ? " (core dumped)" : "");
-      }
-
-      fprintf(job->logfile, "ENDTIME: %s\n",
-              GetFormattedTimeString(endtime).c_str());
-      uint32 elapsed = endtime - cmdtime;
-      fprintf(job->logfile, "ELAPSEDTIME: %s\n",
-              GetFormattedElapsedTimeString(elapsed).c_str());
-      if (success) {
-        fprintf(job->logfile, "COMPLETED SUCCESSFULLY\n");
-      } else if ((signum == 2) || (signum == 15)) {
-        fprintf(job->logfile, "CANCELED\n");
-      } else {
-        fprintf(job->logfile, "FAILED\n");
-      }
+      LogJobResults(job, status_string, signum, coredump, success, cmdtime, endtime);
     }
 
     if (!success) {
@@ -761,6 +736,43 @@ khResourceProvider::StartLogFile(Job * job, const std::string &logfile) {
     }
     fprintf(job->logfile, "STARTTIME: %s\n",
             GetFormattedTimeString(job->beginTime).c_str());
+  }
+}
+
+void
+khResourceProvider::LogJobResults(
+    Job * job,
+    const std::string &status_string,
+    int signum,
+    bool coredump,
+    bool success,
+    time_t cmdtime,
+    time_t endtime) {
+  fflush(job->logfile);
+  // If process status information has been collected print that to log.
+  if (!status_string.empty()) {
+    fprintf(job->logfile, "%s", status_string.c_str());
+  }
+  fprintf(job->logfile,
+          "---------- End Command Output ----------\n");
+  if (signum != -1) {
+    fprintf(job->logfile,
+            "Process terminated by signal %d%s\n",
+            signum,
+            coredump ? " (core dumped)" : "");
+  }
+
+  fprintf(job->logfile, "ENDTIME: %s\n",
+          GetFormattedTimeString(endtime).c_str());
+  uint32 elapsed = endtime - cmdtime;
+  fprintf(job->logfile, "ELAPSEDTIME: %s\n",
+          GetFormattedElapsedTimeString(elapsed).c_str());
+  if (success) {
+    fprintf(job->logfile, "COMPLETED SUCCESSFULLY\n");
+  } else if ((signum == 2) || (signum == 15)) {
+    fprintf(job->logfile, "CANCELED\n");
+  } else {
+    fprintf(job->logfile, "FAILED\n");
   }
 }
 

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -56,8 +56,7 @@ khResourceProvider theResourceProvider;
 // ***  FindJobBy* routines
 // ****************************************************************************
 khResourceProvider::Job*
-khResourceProvider::FindJobById(uint32 jobid,
-                                std::vector<Job>::iterator &found)
+khResourceProvider::FindJobById(uint32 jobid, JobIter &found)
 {
   found = std::find_if(jobs.begin(), jobs.end(),
                        mem_var_pred_ref<std::equal_to>(&Job::jobid, jobid));
@@ -627,7 +626,7 @@ void
 khResourceProvider::JobLoop(StartJobMsg start)
 {
   khLockGuard lock(mutex);
-  std::vector<Job>::iterator found;
+  JobIter found;
   uint32 jobid = start.jobid;
   Job *job = FindJobById(jobid, found);
   if (!job) {
@@ -790,7 +789,7 @@ khResourceProvider::StopJob(const StopJobMsg &stop)
   // the mutex must be locked
   assert(!mutex.trylock());
 
-  std::vector<Job>::iterator found;
+  JobIter found;
   Job *job = FindJobById(stop.jobid, found);
   if (job) {
     if (job->pid > 0) {
@@ -877,7 +876,7 @@ khResourceProvider::ChangeVolumeReservations(const VolumeReservations &res)
 }
 
 void
-khResourceProvider::DeleteJob(std::vector<Job>::iterator which,
+khResourceProvider::DeleteJob(JobIter which,
                               bool success,
                               time_t beginTime, time_t endTime)
 {

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -619,7 +619,8 @@ void
 khResourceProvider::JobLoop(StartJobMsg start)
 {
   khLockGuard lock(mutex);
-  JobIter job = FindJobById(start.jobid);
+  uint32 jobid = start.jobid;
+  JobIter job = FindJobById(jobid);
   if (!Valid(job)) {
     // somebody already asked for me to go away
     return;
@@ -640,7 +641,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
       StartLogFile(job, start.logfile);
     }
 
-    success = RunCmd(job, start.commands[cmdnum], cmdnum == 0, cmdtime, endtime, logTotalTime);
+    success = RunCmd(job, jobid, start.commands[cmdnum], cmdnum == 0, cmdtime, endtime, logTotalTime);
     if (!Valid(job)) return;  // check if somebody already asked for me to go away
     if (!success) break;
   } /* for cmdnum */
@@ -655,6 +656,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
 bool
 khResourceProvider::RunCmd(
     JobIter & job,
+    uint32 jobid,
     const std::vector<std::string> & commands,
     bool sendProgress,
     time_t cmdtime,
@@ -695,7 +697,7 @@ khResourceProvider::RunCmd(
 
   // now that we have the lock again, make sure the job hasn't been
   // deleted while we were waiting for it to finish
-  job = FindJobById(job->jobid);
+  job = FindJobById(jobid);
   if (!Valid(job)) return false;
 
   job->pid = 0;

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.cpp
@@ -712,9 +712,7 @@ khResourceProvider::JobLoop(StartJobMsg start)
   } /* for cmdnum */
 
   if (cmdnum > 1) {
-    uint32 elapsed = endtime - job->beginTime;
-    fprintf(job->logfile, "\nTOTAL ELAPSEDTIME: %s\n",
-            GetFormattedElapsedTimeString(elapsed).c_str());
+    LogTotalTime(job, endtime - job->beginTime);
   }
 
   DeleteJob(found, success, job->beginTime, endtime);
@@ -774,6 +772,12 @@ khResourceProvider::LogJobResults(
   } else {
     fprintf(job->logfile, "FAILED\n");
   }
+}
+
+void
+khResourceProvider::LogTotalTime(Job * job, uint32 elapsed) {
+  fprintf(job->logfile, "\nTOTAL ELAPSEDTIME: %s\n",
+          GetFormattedElapsedTimeString(elapsed).c_str());
 }
 
 // ****************************************************************************

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -79,6 +79,7 @@ class khResourceProvider
 
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
+  void RunJob(std::vector<Job>::iterator job);
   virtual void StartLogFile(Job * job, const std::string &logfile);
   virtual void LogJobResults(
       Job * job,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -79,6 +79,13 @@ class khResourceProvider
 
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
+  bool RunCmd(
+      JobIter & job,
+      const std::vector<std::string> & commands,
+      bool sendProgress,
+      time_t cmdtime,
+      time_t & endtime,
+      bool & logTotalTime);
   virtual void StartLogFile(JobIter job, const std::string &logfile);
   virtual void LogCmdResults(
       JobIter job,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -90,7 +90,7 @@ class khResourceProvider
       time_t endtime);
   virtual void LogTotalTime(Job * job, uint32 elapsed);
   virtual bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline);
-  virtual void SendProgress(uint32 jobid, double progress, time_t progressTime);
+  virtual void SendProgress(Job * job, double progress, time_t progressTime);
   virtual void GetProcessStatus(pid_t pid, std::string* status_string,
                                 bool* success, bool* coredump, int* signum);
   virtual void WaitForPid(pid_t waitfor, bool &success, bool &coredump,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -77,6 +77,7 @@ class khResourceProvider
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
   void JobLoop(StartJobMsg start); // pass by value because thread func
+  void StartLogFile(Job * job, const std::string &logfile);
   bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline);
   void SendProgress(uint32 jobid, double progress, time_t progressTime);
 #if 0

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -79,18 +79,18 @@ class khResourceProvider
 
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
-  virtual void StartLogFile(Job * job, const std::string &logfile);
+  virtual void StartLogFile(JobIter job, const std::string &logfile);
   virtual void LogJobResults(
-      Job * job,
+      JobIter job,
       const std::string &status_string,
       int signum,
       bool coredump,
       bool success,
       time_t cmdtime,
       time_t endtime);
-  virtual void LogTotalTime(Job * job, uint32 elapsed);
-  virtual bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline);
-  virtual void SendProgress(Job * job, double progress, time_t progressTime);
+  virtual void LogTotalTime(JobIter job, uint32 elapsed);
+  virtual bool ExecCmdline(JobIter job, const std::vector<std::string> &cmdline);
+  virtual void SendProgress(JobIter job, double progress, time_t progressTime);
   virtual void GetProcessStatus(pid_t pid, std::string* status_string,
                                 bool* success, bool* coredump, int* signum);
   virtual void WaitForPid(pid_t waitfor, bool &success, bool &coredump,
@@ -115,8 +115,8 @@ class khResourceProvider
   VolResMap volResMap;
 
 
-  virtual Job* FindJobById(uint32 jobid, JobIter &found);
-  virtual bool ValidJob(JobIter job) { return job != jobs.end(); }
+  virtual JobIter FindJobById(uint32 jobid);
+  virtual inline bool Valid(JobIter job) const { return job != jobs.end(); }
   bool WantExit(void) {
     khLockGuard lock(mutex);
     return wantexit;

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -81,6 +81,7 @@ class khResourceProvider
   khThreadPool     *jobThreads;
   bool RunCmd(
       JobIter & job,
+      uint32 jobid,
       const std::vector<std::string> & commands,
       bool sendProgress,
       time_t cmdtime,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -86,6 +86,7 @@ class khResourceProvider
       bool success,
       time_t cmdtime,
       time_t endtime);
+  void LogTotalTime(Job * job, uint32 elapsed);
   bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline);
   void SendProgress(uint32 jobid, double progress, time_t progressTime);
 #if 0

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -79,7 +79,6 @@ class khResourceProvider
 
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
-  void RunJob(std::vector<Job>::iterator job);
   virtual void StartLogFile(Job * job, const std::string &logfile);
   virtual void LogJobResults(
       Job * job,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -107,8 +107,8 @@ class khResourceProvider
   void ReadProgress(int readfd, uint32 jobid);
 #endif
   virtual void DeleteJob(JobIter which,
-                 bool success = false,
-                 time_t beginTime = 0, time_t endTime = 0);
+                         bool success = false,
+                         time_t beginTime = 0, time_t endTime = 0);
 
   // ***** stuff for CheckVolumeAvailLoop *****
   void CheckVolumeAvailLoop(void);

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -78,6 +78,14 @@ class khResourceProvider
   khThreadPool     *jobThreads;
   void JobLoop(StartJobMsg start); // pass by value because thread func
   void StartLogFile(Job * job, const std::string &logfile);
+  void LogJobResults(
+      Job * job,
+      const std::string &status_string,
+      int signum,
+      bool coredump,
+      bool success,
+      time_t cmdtime,
+      time_t endtime);
   bool ExecCmdline(Job *job, const std::vector<std::string> &cmdline);
   void SendProgress(uint32 jobid, double progress, time_t progressTime);
 #if 0

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -80,7 +80,7 @@ class khResourceProvider
   // ***** stuff for handling jobs *****
   khThreadPool     *jobThreads;
   virtual void StartLogFile(JobIter job, const std::string &logfile);
-  virtual void LogJobResults(
+  virtual void LogCmdResults(
       JobIter job,
       const std::string &status_string,
       int signum,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -98,7 +98,7 @@ class khResourceProvider
       time_t endtime);
   virtual void LogTotalTime(JobIter job, uint32 elapsed);
   virtual bool ExecCmdline(JobIter job, const std::vector<std::string> &cmdline);
-  virtual void SendProgress(JobIter job, double progress, time_t progressTime);
+  virtual void SendProgress(uint32 jobid, double progress, time_t progressTime);
   virtual void GetProcessStatus(pid_t pid, std::string* status_string,
                                 bool* success, bool* coredump, int* signum);
   virtual void WaitForPid(pid_t waitfor, bool &success, bool &coredump,

--- a/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
+++ b/earth_enterprise/src/fusion/autoingest/sysman/khResourceProvider.h
@@ -36,9 +36,9 @@ class khResourceProvider
     pid_t  pid;
     time_t beginTime;
 
-
     Job(uint32 jobid) : jobid(jobid), logfile(0), pid(0), beginTime(0) { }
   };
+  using JobIter = std::vector<Job>::iterator;
 
   void JobLoop(StartJobMsg start); // pass by value because thread func
 
@@ -98,7 +98,7 @@ class khResourceProvider
 #if 0
   void ReadProgress(int readfd, uint32 jobid);
 #endif
-  virtual void DeleteJob(std::vector<Job>::iterator which,
+  virtual void DeleteJob(JobIter which,
                  bool success = false,
                  time_t beginTime = 0, time_t endTime = 0);
 
@@ -115,7 +115,8 @@ class khResourceProvider
   VolResMap volResMap;
 
 
-  virtual Job* FindJobById(uint32 jobid, std::vector<Job>::iterator &found);
+  virtual Job* FindJobById(uint32 jobid, JobIter &found);
+  virtual bool ValidJob(JobIter job) { return job != jobs.end(); }
   bool WantExit(void) {
     khLockGuard lock(mutex);
     return wantexit;

--- a/earth_enterprise/src/fusion/autoingest/sysman/memory-tests/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/memory-tests/SConscript
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-Import('env', 'sysmanObjs', 'extraObjs', 'testLibs')
+Import('env', 'sysmanObjs', 'sysmanExtraObjs', 'sysmanTestLibs')
 
 env = env.Clone()
 
 env.test('build-raster-project_resourcetest',
-    map(lambda o: "../" + o, sysmanObjs) + extraObjs + \
+    map(lambda o: "../" + o, sysmanObjs) + sysmanExtraObjs + \
     ['build-raster-project_resourcetest.cc'],
-    LIBS = [ 'dbmanifest', 'geautoingest', 'yaml-cpp' ] + testLibs)
+    LIBS = [ 'dbmanifest', 'geautoingest', 'yaml-cpp' ] + sysmanTestLibs)

--- a/earth_enterprise/src/fusion/autoingest/sysman/parse-raster-project-xml-no-content_unittest/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/sysman/parse-raster-project-xml-no-content_unittest/SConscript
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-Import('env', 'sysmanObjs', 'extraObjs', 'testLibs')
+Import('env', 'sysmanObjs', 'sysmanExtraObjs', 'sysmanTestLibs')
 
 env = env.Clone()
 
 env.test('parse-raster-project-xml-no-content_unittest',
-    map(lambda o: "../" + o, sysmanObjs) + extraObjs + \
+    map(lambda o: "../" + o, sysmanObjs) + sysmanExtraObjs + \
     ['parse-raster-project-xml-no-content_unittest.cc'],
-    LIBS = [ 'dbmanifest', 'geautoingest', 'yaml-cpp' ] + testLibs)
+    LIBS = [ 'dbmanifest', 'geautoingest', 'yaml-cpp' ] + sysmanTestLibs)


### PR DESCRIPTION
Refactors the job loop to make it easier to retry failed commands. This PR should not include any function changes; only refactoring and new unit tests. The unit tests were written as early as possible during the refactor and used to ensure that changes did not break or change functionality.