### PR TITLE
Fix intermittent failure in integration tests

### DIFF
--- a/earth_enterprise/integration_test/specs/state_propagation.spec
+++ b/earth_enterprise/integration_test/specs/state_propagation.spec
@@ -527,6 +527,7 @@ Build database
   |------------|
   | InProgress |
   | Queued     |
+  | Succeeded  |
 * Verify that the state of vector resource "CA_POIs_Merc" is "Succeeded"
 * Verify that the state of mercator imagery project "StatePropagationTest_Mercator" is "Waiting"
 * Verify that the state of mercator imagery resource "BlueMarble_Mercator" is "InProgress"


### PR DESCRIPTION
Fixes an intermittent failure in the integration tests where an asset finishes building before the test can check that it's in progress.