### PR TITLE
Duplicate WMS proxy fix for 5.3.3 if desired

### DIFF
--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019-2020 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
@@ -104,7 +104,11 @@ def GetParameters(environ):
   # Examples for "this-endpoint" would be 'http://localhost/<target_path>/wms'
   # or 'http://servername/<target_path>/wms'
   (parameters["server-url"],
-   parameters["this-endpoint"]) = GetServerURL(environ)
+   parameters["this-endpoint"],
+   parameters["proxy-endpoint"]) = GetServerURL(environ)
+
+  if parameters["proxy-endpoint"] is None:
+    del parameters["proxy-endpoint"]
 
   return parameters
 
@@ -137,7 +141,14 @@ def GetServerURL(environ):
   complete_url += urllib.quote(environ.get("REDIRECT_URL", ""))
   complete_url += urllib.quote(environ.get("PATH_INFO", ""))
 
-  return server_url, complete_url
+  if environ.get("HTTP_X_FORWARDED_HOST"):
+    proxy_url = environ["wsgi.url_scheme"] + "://" + environ["HTTP_X_FORWARDED_HOST"]
+    proxy_url += urllib.quote(environ.get("REDIRECT_URL", ""))
+    proxy_url += urllib.quote(environ.get("PATH_INFO", ""))
+  else:
+    proxy_url = None
+
+  return server_url, complete_url, proxy_url
 
 
 def main():

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019-2020 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v111.py
@@ -115,6 +115,8 @@ class GetCapabilitiesRequest(object):
         xlink_href=url)
 
   def GetOnlineResource(self):
+    if "proxy-endpoint" in self.parameters:
+        return self._MakeOnlineResourceXml(self.parameters["proxy-endpoint"])
     return self._MakeOnlineResourceXml(self.parameters["this-endpoint"])
 
   def GetExceptionInfo(self):

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
@@ -113,6 +113,8 @@ class GetCapabilitiesRequest(object):
     return (limits.x0, limits.y0, limits.x1, limits.y1)
 
   def GetOnlineResource(self):
+    if "proxy-endpoint" in self.parameters:
+        return self._MakeOnlineResourceXml(self.parameters["proxy-endpoint"])
     return self._MakeOnlineResourceXml(self.parameters["this-endpoint"])
 
   def GetDCPTypeInfo(self):

--- a/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/implementation/impl_v130.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 #
 # Copyright 2017 Google Inc.
+# Copyright 2019-2020 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fix was already merged into master (5.3.4) but there was talk of wanting to merge this into 5.3.3 if possible. So here is the PR if we want to do that, @tst-ccamp @tst-rcrihfield @tst-dsugar 

We'd probably want release notes updated as well, but it looks like there's still an open PR for that, so I'm guessing best to handle it there @tst-mswartz .

The original issue is https://github.com/google/earthenterprise/issues/1604

Verification steps:
1. Set up a reverse proxy to a GEE Server with a WMS-served map
2. Do a GetCapabilitiesRequest to the proxy server, and see in the response that OnlineResource points to the proxy server.
3. Viewing a WMS source should work wether using a reverse proxy or not.