### PR TITLE
1621: Change Scons to use Python2.7 on EL6

### DIFF
--- a/earth_enterprise/BUILD.md
+++ b/earth_enterprise/BUILD.md
@@ -73,7 +73,7 @@ platforms on how to setup the dependencies, tools, and compilers.
 
     ```bash
     cd earthenterprise/earth_enterprise
-    scons -j8 release=1 build
+    python2.7 /usr/bin/scons -j8 release=1 build
     ```
 
 5. Run unit tests (note: that the `REL` part of the path will vary if you use

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -77,17 +77,8 @@ sudo yum install -y git-lfs
 
 For all versions of CentOS and RHEL, install the standard development/build tools:
 
-### EL7
-
 ```bash
 sudo yum install -y ant bzip2 doxygen gcc-c++ patch python-argparse python-lxml python-setuptools \
-  swig tar
-```
-
-### EL6
-
-```bash
-sudo yum install -y ant bzip2 doxygen gcc-c++ patch python-argparse python27-lxml python27-setuptools \
   swig tar
 ```
 
@@ -143,11 +134,12 @@ Execute:
 ```bash
 sudo yum install -y \
   bison-devel boost-devel cmake daemonize freeglut-devel \
-  gdbm-devel geos-devel gettext giflib-devel GitPython \
+  gdbm-devel geos-devel gettext giflib-devel \
   libcap-devel libmng-devel libpng-devel libX11-devel libXcursor-devel \
   libXft-devel libXinerama-devel libxml2-devel libXmu-devel libXrandr-devel \
   ogdi-devel openjpeg-devel openjpeg2-devel openssl-devel pcre pcre-devel \
-  perl-Alien-Packages perl-Perl4-CoreLibs proj-devel python-devel python27-devel python-unittest2 \
+  perl-Alien-Packages perl-Perl4-CoreLibs proj-devel python-devel python27 \
+  python27-pip python27-devel python27-lxml python27-setuptools python-unittest2 \
   rpm-build rpmrebuild rsync scons shunit2 \
   xerces-c xerces-c-devel xorg-x11-server-devel yaml-cpp-devel zlib-devel
 ```
@@ -211,16 +203,16 @@ sudo yum install -y http://download-ib01.fedoraproject.org/pub/epel/6/x86_64/Pac
 
 shunit2 was installed in a previous step.
 
-## Install Python 2.7
+## Install Python 2.7 Packages
 
 ### CentOS 7 and RHEL 7
 
-Python 2.7 is installed as a system default.
+Python 2.7 is installed as a system default, so no additional packages are needed.
 
 ### CentOS 6 and RHEL 6
 
 ```bash
-sudo yum install -y python27
+sudo pip2.7 install gitpython
 ```
 
 ### Building on fips-enabled machines
@@ -228,7 +220,7 @@ sudo yum install -y python27
 In some circumstances on stig-ed machines, where md5 cryptography is used, fips will prevent OpenGee from being built. When trying to build, a message similar to the following will be displayed 
 
 ```bash
-$ scons -j4 internal=1 build
+$ python2.7 /usr/bin/scons -j4 internal=1 build
 scons: Reading SConscript files ... 
 scons: done reading SConscript files.
 scons: Building targets ... 

--- a/earth_enterprise/BUILD_RPMS.md
+++ b/earth_enterprise/BUILD_RPMS.md
@@ -41,7 +41,7 @@ from the *earth_enterprise* subdirectory.  This can be used after
 This will setup the stage install directory, install Gradle if needed, and
 then uses Gradle to generate RPMs.  The RPMs are created in the
 *rpms/build/distributions* subdirectory.  A typical invocation for building
-release RPMs might be ```scons -j8 release=1 package_install```.  All other
+release RPMs might be ```python2.7 /usr/bin/scons -j8 release=1 package_install```.  All other
 files related to RPM generation are found in the *rpms* sub-directory as
 well. Scripts for pre/post install operations are found under the related
 package directory in *rpms*, and common templates for package script generation

--- a/earth_enterprise/SConstruct
+++ b/earth_enterprise/SConstruct
@@ -154,14 +154,14 @@ num_jobs = GetOption('num_jobs')
 
 # Build Fusion and Server
 build_cmds = {'build': [
-    'cd src; scons -j%d %s third_party' % (num_jobs, arg_vars),
-    'cd src; scons -j%d %s' % (num_jobs, arg_vars)
+    'cd src; python2.7 /usr/bin/scons -j%d %s third_party' % (num_jobs, arg_vars),
+    'cd src; python2.7 /usr/bin/scons -j%d %s' % (num_jobs, arg_vars)
 ]}
 run_build = env.PhonyTargets(**build_cmds)
 
 # Copy the binaries to the install staging directory
 stage_bin_cmds = {'stage_bin': [
-    'cd src; scons -j%d installdir="%s" %s install' % (num_jobs, installdir, arg_vars)
+    'cd src; python2.7 /usr/bin/scons -j%d installdir="%s" %s install' % (num_jobs, installdir, arg_vars)
 ]}
 stage_bin = env.PhonyTargets(**stage_bin_cmds)
 
@@ -177,7 +177,7 @@ env.copyfile(inst_common_dir('.'), './src/version.txt')
 
 # Copy the tutorial to the install staging directory if it exists.
 stage_tutorial_cmds = {'stage_tutorial': [
-    'cd tutorial; if [ -d FusionTutorial ]; then scons -j%d installdir="%s"; else echo "Skipping tutorial; no tutorial files found."; fi' % (num_jobs, installdir)
+    'cd tutorial; if [ -d FusionTutorial ]; then python2.7 /usr/bin/scons -j%d installdir="%s"; else echo "Skipping tutorial; no tutorial files found."; fi' % (num_jobs, installdir)
 ]}
 stage_tutorial = env.PhonyTargets(**stage_tutorial_cmds)
 env.Depends(stage_tutorial, stage_data)

--- a/earth_enterprise/src/installer/common.sh
+++ b/earth_enterprise/src/installer/common.sh
@@ -188,7 +188,7 @@ show_no_tmp_dir_message()
 {
     echo -e "\nThe temp install directory specified [$1] does not exist."
     echo -e "Please specify the path of the extracted install files or first run"
-    echo -e "scons [-j8] release=1 [installdir=$1] stage_install\n"
+    echo -e "python2.7 /usr/bin/scons [-j8] release=1 [installdir=$1] stage_install\n"
 }
 
 show_corrupt_tmp_dir_message()
@@ -196,7 +196,7 @@ show_corrupt_tmp_dir_message()
     echo -e "\nThe temp install directory specified [$1] is corrupt (failed on copy)."
     echo -e "Please see $2 for details"
     echo -e "Please specify the path of the extracted install files or first run"
-    echo -e "scons [-j8] release=1 [installdir=$1] stage_install\n"
+    echo -e "python2.7 /usr/bin/scons [-j8] release=1 [installdir=$1] stage_install\n"
 }
 
 check_bad_hostname() {

--- a/earth_enterprise/src/rpm/GoogleEarthEnterprise.spec
+++ b/earth_enterprise/src/rpm/GoogleEarthEnterprise.spec
@@ -164,7 +164,7 @@ rm %{buildroot}/opt/google/search/tabs/Street_Geocoder.gestd
 
 
 # build and install the scons portion of our tree
-cd .. ; scons -j $NRPROC release=1 installdir=%{buildroot} install
+cd .. ; python2.7 /usr/bin/scons -j $NRPROC release=1 installdir=%{buildroot} install
 
 # make some convenience symlinks
 ln -s /etc/opt/google     %{buildroot}/opt/google/etc

--- a/earth_enterprise/src/server/wsgi/scripts/updatewsgi.sh
+++ b/earth_enterprise/src/server/wsgi/scripts/updatewsgi.sh
@@ -21,7 +21,7 @@
 # Simply run this script after building and it will install wsgi modules under
 # the /opt/google/gehttpd/wsg-bin/.
 #
-# Note: to build python modules run 'scons -j8 optimize=1 build_py'
+# Note: to build python modules run 'python2.7 /usr/bin/scons -j8 optimize=1 build_py'
 
 set -x
 set -e

--- a/earth_enterprise/src/server/wsgi/update_wsgi.sh
+++ b/earth_enterprise/src/server/wsgi/update_wsgi.sh
@@ -24,7 +24,7 @@
 # ./update_bin -h|-help|--help reports usage.
 #
 # Note: Needs to be run with "sudo".
-# Note: To build python modules, run 'scons -j8 optimize=1 build_py'
+# Note: To build python modules, run 'python2.7 /usr/bin/scons -j8 optimize=1 build_py'
 
 set -e
 

--- a/scripts/ci/build_fusion_and_test.sh
+++ b/scripts/ci/build_fusion_and_test.sh
@@ -49,6 +49,6 @@ if [ -f $HOME/cache/third_party$CPP_STD.tgz ]; then
 fi
 
 cd ..
-scons -j3 $BUILD_TYPE=1 cpp_standard=gnu++$CPP_STD build > build.log
+python2.7 /usr/bin/scons -j3 $BUILD_TYPE=1 cpp_standard=gnu++$CPP_STD build > build.log
 cd src/NATIVE-REL-x86_64/bin/tests
 ./RunAllTests.pl

--- a/scripts/ci/build_third_party.sh
+++ b/scripts/ci/build_third_party.sh
@@ -48,7 +48,7 @@ if [ -f $HOME/cache/third_party$CPP_STD.tgz ]; then
     tar xf $HOME/cache/third_party$CPP_STD.tgz;
 fi
 
-scons -j3 $BUILD_TYPE=1 cpp_standard=gnu++$CPP_STD third_party > build.log
+python2.7 /usr/bin/scons -j3 $BUILD_TYPE=1 cpp_standard=gnu++$CPP_STD third_party > build.log
 mkdir -p $HOME/cache
 tar cfz $HOME/cache/third_party$CPP_STD.tgz NATIVE-REL-x86_64 .sconsign.dblite .sconf_temp
 


### PR DESCRIPTION
#1621 

Changes scons to use Python2.7 on el6 and updates docs to reflect these changes. This brings parity el6 and el7.

To test:

- Build OpenGEE, stage the OpenGEE install, build OpenGEE RPMS, build portable, and install OpenGEE on EL6, El7, and Ubuntu 16.