### PR TITLE
Add delay = 0 option to getop

### DIFF
--- a/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_4.rst
+++ b/docs/geedocs/docsrc/answer/releaseNotes/relNotesGEE5_3_4.rst
@@ -46,12 +46,15 @@ Release notes: Open GEE 5.3.4
          * - Number
            - Description
            - Resolution
-         * - 1604
-           - WMS capability doesn't work with reverse proxies
-           - It now works, as long as the protocol (http vs https) matches
          * - 1579
            - Add an option to misc.xml for disabling minification
            - An option was added to control minification.
+         * - 1604
+           - WMS capability doesn't work with reverse proxies
+           - It now works, as long as the protocol (http vs https) matches
+         * - 1642
+           - Getop does not have an option to display status and exit
+           - A ``--delay 0`` option was added
 
       .. rubric:: Known Issues
 

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -111,8 +111,8 @@ main(int argc, char *argv[])
       usage(progname);
     if (help)
       usage(progname);
-    if (delay <= 0)
-      usage(progname, "--delay must be positive");
+    if (delay < 0)
+      usage(progname, "--delay must not be less than zero");
     if (timeout < 0)
       usage(progname, "--timeout must not be less than zero");
 
@@ -252,7 +252,11 @@ main(int argc, char *argv[])
         outline("Number of strings cached: %u", taskLists.str_store_size);
 
       }
-      sleep(delay);
+
+      if (delay)
+        sleep(delay);
+      else
+        break;
     };
   } catch (const std::exception &e) {
     notify(NFY_FATAL, "%s", e.what());

--- a/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/getop.cpp
@@ -181,8 +181,10 @@ main(int argc, char *argv[])
           pclose(tputFILE);
         }
 
-        // clear screen
-        (void)clearscreen.System();
+        if (delay) {
+          // clear screen when looping
+          (void)clearscreen.System();
+        }
 
         // emit khtop header
         outline("FUSION VERSION: %s", GEE_VERSION);


### PR DESCRIPTION
#1642
Add "--delay 0" option to getop to exit after printing status so it can be used from scripts. The default behavior is to loop and display status every 5 seconds.