### PR TITLE
#1650: WMS now uses forwarded protocol

### DIFF
--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
@@ -143,6 +143,10 @@ def GetServerURL(environ):
   complete_url += urllib.quote(environ.get("PATH_INFO", ""))
 
   if environ.get("HTTP_X_FORWARDED_HOST"):
+    proxy_scheme = environ["wsgi.url_scheme"]
+    if environ.get("HTTP_X_FORWARDED_PROTO"):
+      proxy_scheme = environ["HTTP_X_FORWARDED_PROTO"]
+
     proxy_url = environ["wsgi.url_scheme"] + "://" + environ["HTTP_X_FORWARDED_HOST"]
     proxy_url += urllib.quote(environ.get("REDIRECT_URL", ""))
     proxy_url += urllib.quote(environ.get("PATH_INFO", ""))

--- a/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/common/utils.py
@@ -147,7 +147,7 @@ def GetServerURL(environ):
     if environ.get("HTTP_X_FORWARDED_PROTO"):
       proxy_scheme = environ["HTTP_X_FORWARDED_PROTO"]
 
-    proxy_url = environ["wsgi.url_scheme"] + "://" + environ["HTTP_X_FORWARDED_HOST"]
+    proxy_url = proxy_scheme + "://" + environ["HTTP_X_FORWARDED_HOST"]
     proxy_url += urllib.quote(environ.get("REDIRECT_URL", ""))
     proxy_url += urllib.quote(environ.get("PATH_INFO", ""))
   else:


### PR DESCRIPTION
WMS payloads now use the X-Forwarded-Proto header to set the url protocol in the payload. This allows WMS to work through reverse proxies that use a different protocol.

To test:
- Build and install OpenGEE.
- Build and publish a 2D database with WMS enabled.
- Setup a reverse proxy that accepts https and forwards to the OpenGEE server on http.
- Verify that the WMS payloads have the proper url and protocol for the proxy:
    - `curl --insecure  "https://<proxy_fqdn>/<db_name>/wms?SERVICE=WMS&REQUEST=GetCapabilities"`