### PR TITLE
Add the ius repo to RHEL6 instructions

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -50,6 +50,7 @@ sudo subscription-manager repos --enable=rhel-server-dts2-6-rpms
 # For All RHEL 6
 sudo subscription-manager repos --enable=rhel-6-server-optional-rpms
 sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+sudo yum install -y https://repo.ius.io/ius-release-el6.rpm
 
 
 ```


### PR DESCRIPTION
The ius repo was missing form the list of RHEL6 repos and is needed for python2.7.

To test:

- Build on RHEL6, following the build instructions.