### PR TITLE
Add the ius repo to RHEL6 instructions

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -39,6 +39,7 @@ sudo subscription-manager repos --enable=rhel-server-dts2-6-rpms
 # For all RHEL 6 Editions:
 sudo subscription-manager repos --enable=rhel-6-server-optional-rpms
 sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+sudo yum install -y https://repo.ius.io/ius-release-el6.rpm
 ```
 
 ## Install Git


### PR DESCRIPTION
Same as [sibling PR](https://github.com/google/earthenterprise/pull/1652) for master. Adds the ius repo to the RHEL6 build instructions. IUS is needed for python2.7.

To test:

- Build on RHEL6 following instructions.