### PR TITLE
changes to portable server while loading 3D globes

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/local/preview/js/main.js
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/preview/js/main.js
@@ -416,14 +416,7 @@ function initServing() {
 
 // Initializes Earth plugin serving.
 function init3DServing() {
-  if (operatingSystemName == 'Linux') {
-    document.getElementById('NoMap').style.display = 'block';
-    document.getElementById('ZmControls').style.display = 'none';
-  } else {
-    initEarth();
-    loadIframes();
-    initSearchPane();
-  }
+  document.getElementById('NoMap').style.display = 'block';
 }
 
 // Initializes Map serving.

--- a/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
@@ -44,9 +44,7 @@
   <div id="earth"></div>
   <div id="NoMap" style="display: none;">
     <div class="GlobeImgText">
-      <span>There was a problem loading the Google Earth Plugin.</span>
-      <span>The Google Earth Plugin is currently only available on <b>Windows</b> and <b>Mac OS X 10.6+</b>.</span>
-      <span><a href="http://earth.google.com/intl/en/plugin/">Click here to learn more.</a></span>
+      <span>3D previews are not available, please use the <b>GEEC</b> to view your globe.</span>
     </div>
   </div>
 

--- a/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
+++ b/earth_enterprise/src/fusion/portableglobe/servers/local/preview/setup.html
@@ -44,7 +44,7 @@
   <div id="earth"></div>
   <div id="NoMap" style="display: none;">
     <div class="GlobeImgText">
-      <span>3D previews are not available, please use the <b>GEEC</b> to view your globe.</span>
+      <span>3D previews are not available in a web browser. Please use the <b>Google Earth Enterprise Client</b> to view your globe.</span>
     </div>
   </div>
 

--- a/earth_enterprise/src/portableserver/resources/portable.cfg
+++ b/earth_enterprise/src/portableserver/resources/portable.cfg
@@ -6,5 +6,5 @@ database file
 local_override True
 fill_missing_map_tiles True
 max_missing_map_tile_ancestor 24
-globe_name tutorial_sf.glb
+globe_name tutorial_sf.glm
 use_plugin True


### PR DESCRIPTION
Fixes #1666  Changed the msg to : 3D previews not available, please use the GEEC to view your globe
while loading 3d globes in portable server.
Change the default globe loaded to tutorial_sf.glm, so that on localhost:9335, 2D map is displayed. 
