### PR TITLE
make get version python3 compatable

### DIFF
--- a/docs/geedocs/docsrc/conf.py
+++ b/docs/geedocs/docsrc/conf.py
@@ -25,8 +25,12 @@ import getversion
 # Check version of git -- may not be able to reliably generate correct opengee version string.
 gee_version_number = getversion.open_gee_version.get_short()
 if getversion.open_gee_version.get_warning_message():
-    print getversion.open_gee_version.get_warning_message()
-print gee_version_number
+    sys.stderr.write(getversion.open_gee_version.get_warning_message())
+    sys.stderr.write('\n')
+    sys.stderr.flush()
+sys.stdout.write(gee_version_number)
+sys.stdout.write('\n')
+sys.stdout.flush()
 
 # -- Project information -----------------------------------------------------
 

--- a/earth_enterprise/src/scons/getversion.py
+++ b/earth_enterprise/src/scons/getversion.py
@@ -384,11 +384,15 @@ def main():
     parser.add_argument("-l", "--long", action="store_true", help="Output long format of version string")
     args = parser.parse_args()
 
-    print open_gee_version.get_long() if args.long else open_gee_version.get_short()
+    sys.stdout.write(open_gee_version.get_long() if args.long else open_gee_version.get_short())
+    sys.stdout.write('\n')
+    sys.stdout.flush()
 
     warning_message = open_gee_version.get_warning_message()
     if warning_message is not None:
-        print >> sys.stderr, warning_message
+        sys.stderr.write(warning_message)
+        sys.stderr.write('\n')
+        sys.stderr.flush()
 
 
 __all__ = ['open_gee_version']


### PR DESCRIPTION
Getting ready for Python 3.  This change will allow documents to build with python 3 and python 2 both while we transition to python 3.

Partially addresses #1690 