### PR TITLE
add protobuf generated dependencies explicitly

### DIFF
--- a/earth_enterprise/src/common/SConscript
+++ b/earth_enterprise/src/common/SConscript
@@ -80,6 +80,17 @@ commonsources = [ '../third_party/rsa_md5/md5c.c',
                   'timeutils.cpp',
                   streaming_imagery[0]  # generated .cc file
                  ]
+
+# scons seems to have issues resolving dependencies of dependencies when 
+# the first file is generated (in this case the .cc file). Scons does
+# not seem to properly resolve the .cc file needs the .h file (also generated)
+# and there by this means the .so file needs the .h file too.
+# This can lead to build errors if the generated files are not created
+# soon enough. So adding dependencies explicitly
+streaming_imagery_basename = os.path.splitext(str(streaming_imagery[0]))[0]
+env.Depends(streaming_imagery_basename+'.os', streaming_imagery_basename+'.h')
+env.Depends(streaming_imagery_basename+'.os', streaming_imagery_basename+'.cc')
+
 # Check environment for png.h file
 conf = Configure(env)
 

--- a/earth_enterprise/src/common/gedbroot/SConscript
+++ b/earth_enterprise/src/common/gedbroot/SConscript
@@ -15,6 +15,7 @@
 
 #-*- Python -*-
 Import('env')
+import os
 
 dbroot_v2 = env.ProtocolBuffer(
     '#/keyhole/proto/dbroot/dbroot_v2.proto');
@@ -35,6 +36,17 @@ gedbroot = env.sharedLib('gedbroot',
                                'geprotobuf',
                                'qt-mt',
                                ])
+
+# scons seems to have issues resolving dependencies of dependencies when 
+# the first file is generated (in this case the .cc file). Scons does
+# not seem to properly resolve the .cc file needs the .h file (also generated)
+# and there by this means the .so file needs the .h file too.
+# This can lead to build errors if the generated files are not created
+# soon enough. So adding dependencies explicitly
+dbroot_v2_basename = os.path.splitext(str(dbroot_v2[0]))[0]
+env.Depends(dbroot_v2_basename+'.os', dbroot_v2_basename+'.h')
+env.Depends(dbroot_v2_basename+'.os', dbroot_v2_basename+'.cc')
+
 env.install('common_lib', [gedbroot])
 
 # we want to be careful and make sure we depend on only the minimal set of

--- a/earth_enterprise/src/keyhole/earth_client_protobuf/SConscript
+++ b/earth_enterprise/src/keyhole/earth_client_protobuf/SConscript
@@ -36,5 +36,16 @@ env['CPPFLAGS'] += [
 objects = map(lambda f: env.StaticObject(f), proto_inputs)
 geprotos = env.staticLib('geprotos', objects)
 
+for gen_pb_file in proto_inputs:
+  # scons seems to have issues resolving dependencies of dependencies when 
+  # the first file is generated (in this case the .cc file). Scons does
+  # not seem to properly resolve the .cc file needs the .h file (also generated)
+  # and there by this means the .so file needs the .h file too.
+  # This can lead to build errors if the generated files are not created
+  # soon enough. So adding dependencies explicitly
+  proto_out_basename = os.path.splitext(str(gen_pb_file))[0]
+  env.Depends(proto_out_basename+'.os', proto_out_basename+'.h')
+  env.Depends(proto_out_basename+'.os', proto_out_basename+'.cc')
+
 env.test('protobuf_unittest', 'protobuf_unittest.cpp',
          LIBS=[geprotos, 'geprotobuf'])


### PR DESCRIPTION
Scons has issues resolving dependencies of generated files and this can lead to build errors if the dependencies themselves are also generated and do not get created soon enough.
Fixes issue: #1697 