### PR TITLE
Delete FileUnpacker default constructor

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
@@ -38,7 +38,7 @@ class GlcReader;
 class FileUnpacker {
  public:
   FileUnpacker(const GlcReader& glc_reader, std::uint64_t offset, std::uint64_t size);
-  FileUnpacker() = default;
+  FileUnpacker() = delete;
   ~FileUnpacker();
   FileUnpacker(const FileUnpacker&) = delete;
   FileUnpacker(FileUnpacker&&) = delete;

--- a/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
+++ b/earth_enterprise/src/fusion/portableglobe/servers/fileunpacker/shared/file_unpacker.h
@@ -38,7 +38,6 @@ class GlcReader;
 class FileUnpacker {
  public:
   FileUnpacker(const GlcReader& glc_reader, std::uint64_t offset, std::uint64_t size);
-  FileUnpacker() = delete;
   ~FileUnpacker();
   FileUnpacker(const FileUnpacker&) = delete;
   FileUnpacker(FileUnpacker&&) = delete;


### PR DESCRIPTION
The constructor is implicitly deleted, so making it default caused compilation issues.