### PR TITLE
Fix MrSID build on Ubuntu

### DIFF
--- a/earth_enterprise/src/fusion/khgdal/SConscript
+++ b/earth_enterprise/src/fusion/khgdal/SConscript
@@ -54,7 +54,9 @@ getranslate = env.executable('getranslate', 'getranslate.cpp',
 gereproject = env.executable('gereproject', 'gereproject.cpp',
                              LIBS=['gegdal', 'geutil', 'gdal', 'geos'])
 
-khgdal_test = env.test('khgdal_test', ['khgdal_test.cpp'], LIBS=['gegdal', 'gecommon', 'geos'])
+khgdal_test = env.test('khgdal_test',
+    ['khgdal_test.cpp'],
+    LIBS=['gegdal', 'gecommon', 'geos', 'gtest'])
 
 khGDALReader_unittest = env.test('khGDALReader_unittest',
     ['khGDALReader_unittest.cpp'],

--- a/earth_enterprise/src/fusion/khgdal/SConscript
+++ b/earth_enterprise/src/fusion/khgdal/SConscript
@@ -56,7 +56,7 @@ gereproject = env.executable('gereproject', 'gereproject.cpp',
 
 khgdal_test = env.test('khgdal_test',
     ['khgdal_test.cpp'],
-    LIBS=['gegdal', 'gecommon', 'geos', 'gtest'])
+    LIBS=['gegdal', 'gecommon', 'gdal', 'geos', 'gtest', 'dl'])
 
 khGDALReader_unittest = env.test('khGDALReader_unittest',
     ['khGDALReader_unittest.cpp'],

--- a/earth_enterprise/src/fusion/khgdal/khgdal_test.cpp
+++ b/earth_enterprise/src/fusion/khgdal/khgdal_test.cpp
@@ -15,102 +15,85 @@
 //
 // Unit tests for khgdal.
 
+#include <gtest/gtest.h>
+
 #include "khgdal.h"
 #include <khGeomUtils.h>
-#include <UnitTest.h>
 
-class khgdalTest: public UnitTest<khgdalTest> {
-  // We round upto an integral meter and then compare
-  bool NearlyEqual(double gold, double other) {
-    return ( static_cast<int>(gold + 0.5) == static_cast<int>(other + 0.5) );
-  }
+// We round upto an integral meter and then compare
+bool NearlyEqual(double gold, double other) {
+  return ( static_cast<int>(gold + 0.5) == static_cast<int>(other + 0.5) );
+}
 
- public:
-  bool TestConvertToGdalMeterForMercator(void) {
-    // Expected value for gdal_lat_meter is
-    // ln(tan(lat_deg*pi/180) + sec(lat_deg*pi/180)) * 40075016.6855784 / (2*pi)
-    // In case more inputs are needed the above can be put to google calculator
-    // e.g ln(tan(30*pi/180)+sec(30*pi/180))*40075016.6855784/(2*pi)=3503549.84
-    // e.g ln(tan(50*pi/180)+sec(50*pi/180))*40075016.6855784/(2*pi)=6446275.84
-    const double half_circumference =
-        khGeomUtilsMercator::khEarthCircumference / 2.0;
-    struct {
-      const double deg_latitude;
-      const double gdal_mercator_meter_latitude;
-    } latitudes[] = {
-      {0, 0},
-      {30, 3503549.84},
-      {50, 6446275.84},
-       // If we draw world extents from (85.05113, 180) to (-180, -85.05113)
-       // using Mercator projection, the map shows up as a square
-       // Test for various longitudes at 85.051128779806575 deg latitude
-      {khGeomUtilsMercator::khMaxLatitude, half_circumference},
-    };
+TEST(khGdalTest, ConvertToGdalMeterForMercator) {
+  // Expected value for gdal_lat_meter is
+  // ln(tan(lat_deg*pi/180) + sec(lat_deg*pi/180)) * 40075016.6855784 / (2*pi)
+  // In case more inputs are needed the above can be put to google calculator
+  // e.g ln(tan(30*pi/180)+sec(30*pi/180))*40075016.6855784/(2*pi)=3503549.84
+  // e.g ln(tan(50*pi/180)+sec(50*pi/180))*40075016.6855784/(2*pi)=6446275.84
+  const double half_circumference =
+      khGeomUtilsMercator::khEarthCircumference / 2.0;
+  struct {
+    const double deg_latitude;
+    const double gdal_mercator_meter_latitude;
+  } latitudes[] = {
+    {0, 0},
+    {30, 3503549.84},
+    {50, 6446275.84},
+      // If we draw world extents from (85.05113, 180) to (-180, -85.05113)
+      // using Mercator projection, the map shows up as a square
+      // Test for various longitudes at 85.051128779806575 deg latitude
+    {khGeomUtilsMercator::khMaxLatitude, half_circumference},
+  };
 
-    struct {
-      const double deg_longitude;
-      const double gdal_mercator_meter_longitude;
-    } longitudes[] = {
-      {0, 0},
-      {10, khGeomUtilsMercator::khEarthCircumference * 10 / 360},
-      {63, khGeomUtilsMercator::khEarthCircumference * 63 / 360},
-      {90, khGeomUtilsMercator::khEarthCircumference * 90 / 360},
-      {139, khGeomUtilsMercator::khEarthCircumference * 139 / 360},
-      {180, khGeomUtilsMercator::khEarthCircumference * 180 / 360},
-    };
+  struct {
+    const double deg_longitude;
+    const double gdal_mercator_meter_longitude;
+  } longitudes[] = {
+    {0, 0},
+    {10, khGeomUtilsMercator::khEarthCircumference * 10 / 360},
+    {63, khGeomUtilsMercator::khEarthCircumference * 63 / 360},
+    {90, khGeomUtilsMercator::khEarthCircumference * 90 / 360},
+    {139, khGeomUtilsMercator::khEarthCircumference * 139 / 360},
+    {180, khGeomUtilsMercator::khEarthCircumference * 180 / 360},
+  };
 
-    struct {
-      double lat_multiplier;
-      double lon_multiplier;
-    } sign_multipliers[] = {{-1, -1}, {-1, 1}, {1, -1}, {1, 1}};
+  struct {
+    double lat_multiplier;
+    double lon_multiplier;
+  } sign_multipliers[] = {{-1, -1}, {-1, 1}, {1, -1}, {1, 1}};
 
-    const int num_latitudes = sizeof(latitudes) / sizeof(latitudes[0]);
-    const int num_longitudes = sizeof(longitudes) / sizeof(longitudes[0]);
-    const int num_sign_multipliers =
-        sizeof(sign_multipliers) / sizeof(sign_multipliers[0]);
-    bool ret_val = true;
+  const int num_latitudes = sizeof(latitudes) / sizeof(latitudes[0]);
+  const int num_longitudes = sizeof(longitudes) / sizeof(longitudes[0]);
+  const int num_sign_multipliers =
+      sizeof(sign_multipliers) / sizeof(sign_multipliers[0]);
 
-    fprintf(stdout,
-            "Running TestConvertToGdalMeterForMercator with %d test cases:\n",
-            num_latitudes * num_longitudes * num_sign_multipliers);
-    fflush(stdout);
-
-    for (int i = 0; i < num_latitudes; ++i) {
-      for (int j = 0; j < num_longitudes; ++j) {
-        for (int k = 0; k < num_sign_multipliers; ++k) {
-          const double lat = latitudes[i].deg_latitude *
-                       sign_multipliers[k].lat_multiplier;
-          const double lon = longitudes[j].deg_longitude *
-                       sign_multipliers[k].lon_multiplier;
-          double lat_converted = lat;
-          double lon_converted = lon;
-          ConvertToGdalMeterForMercator(&lat_converted, &lon_converted);
-          const double lat_expected =
-              latitudes[i].gdal_mercator_meter_latitude *
-              sign_multipliers[k].lat_multiplier;
-          const double lon_expected =
-              longitudes[j].gdal_mercator_meter_longitude *
-              sign_multipliers[k].lon_multiplier;
-          if (!NearlyEqual(lat_expected, lat_converted) ||
-              !NearlyEqual(lon_expected, lon_converted)) {
-            fprintf(stderr,
-              "Input: (%f, %f), Expected: (%f, %f), Got: (%f, %f)\n", lat, lon,
-              lat_expected, lon_expected, lat_converted, lon_converted);
-            ret_val = false;
-          }
-        }
+  for (int i = 0; i < num_latitudes; ++i) {
+    for (int j = 0; j < num_longitudes; ++j) {
+      for (int k = 0; k < num_sign_multipliers; ++k) {
+        const double lat = latitudes[i].deg_latitude *
+                      sign_multipliers[k].lat_multiplier;
+        const double lon = longitudes[j].deg_longitude *
+                      sign_multipliers[k].lon_multiplier;
+        double lat_converted = lat;
+        double lon_converted = lon;
+        ConvertToGdalMeterForMercator(&lat_converted, &lon_converted);
+        const double lat_expected =
+            latitudes[i].gdal_mercator_meter_latitude *
+            sign_multipliers[k].lat_multiplier;
+        const double lon_expected =
+            longitudes[j].gdal_mercator_meter_longitude *
+            sign_multipliers[k].lon_multiplier;
+        EXPECT_TRUE(NearlyEqual(lat_expected, lat_converted))
+            << "Latitiude mismatch: expected " << lat_expected << ", got " << lat_converted;
+        EXPECT_TRUE(NearlyEqual(lon_expected, lon_converted))
+            << "Longitude mismatch: expected " << lon_expected << ", got " << lon_converted;
       }
     }
-    return ret_val;
   }
+}
 
-  khgdalTest(void) : BaseClass("khgdalTest") {
-    REGISTER(TestConvertToGdalMeterForMercator);
-  }
-};
-
-int main(int argc, char *argv[]) {
-  khgdalTest tests;
-
-  return tests.Run();
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -34,12 +34,12 @@ gdal_version = 'gdal-2.1.2'
 # Check if MrSID decoding library is installed and get the decoding SDK path
 mrSIDLibName = 'libltidsdk.so'
 mrSIDDSDKPath = ""
-findLibraryCommand = "/sbin/ldconfig -p | grep %s | tr ' ' '\n' | grep /" %mrSIDLibName
+findLibraryCommand = "/sbin/ldconfig -p | grep -E '%s$' | tr ' ' '\n' | grep /" %mrSIDLibName
 mrSIDlibraryFullPath=subprocess.check_output(findLibraryCommand, shell=True)
 if mrSIDlibraryFullPath:
    print "mrSID library was found. GDAL will be built with mrSID raster format support: ", mrSIDlibraryFullPath
    getFolderCommand = "dirname %s" %mrSIDlibraryFullPath
-   mrSIDLibraryPath=subprocess.check_output(getFolderCommand, shell=True).read()
+   mrSIDLibraryPath=subprocess.check_output(getFolderCommand, shell=True)
    mrSIDDSDKPath = os.path.normpath(os.path.join(mrSIDLibraryPath, os.pardir))
    print "mrSID Decoding SDK path is: ", mrSIDDSDKPath
 

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -35,6 +35,7 @@ gdal_version = 'gdal-2.1.2'
 try:
   mrSIDLibName = 'libltidsdk.so'
   findLibraryCommand = "/sbin/ldconfig -p | grep %s | tr ' ' '\n' | grep /" %mrSIDLibName
+  # There may be multiple MrSID paths, so take the first one
   mrSIDlibraryFullPath = subprocess.check_output(findLibraryCommand, shell=True).splitlines()[0]
   print "mrSID library was found. GDAL will be built with mrSID raster format support: ", mrSIDlibraryFullPath
   # Go up two directories

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -27,6 +27,7 @@
 
 Import('third_party_env')
 import os
+import subprocess
 
 gdal_version = 'gdal-2.1.2'
 
@@ -34,11 +35,11 @@ gdal_version = 'gdal-2.1.2'
 mrSIDLibName = 'libltidsdk.so'
 mrSIDDSDKPath = ""
 findLibraryCommand = "/sbin/ldconfig -p | grep %s | tr ' ' '\n' | grep /" %mrSIDLibName
-mrSIDlibraryFullPath=os.popen(findLibraryCommand).read()
+mrSIDlibraryFullPath=subprocess.check_output(findLibraryCommand, shell=True)
 if mrSIDlibraryFullPath:
    print "mrSID library was found. GDAL will be built with mrSID raster format support: ", mrSIDlibraryFullPath
    getFolderCommand = "dirname %s" %mrSIDlibraryFullPath
-   mrSIDLibraryPath=os.popen(getFolderCommand).read()
+   mrSIDLibraryPath=subprocess.check_output(getFolderCommand, shell=True).read()
    mrSIDDSDKPath = os.path.normpath(os.path.join(mrSIDLibraryPath, os.pardir))
    print "mrSID Decoding SDK path is: ", mrSIDDSDKPath
 

--- a/earth_enterprise/src/third_party/gdal/SConscript
+++ b/earth_enterprise/src/third_party/gdal/SConscript
@@ -32,17 +32,18 @@ import subprocess
 gdal_version = 'gdal-2.1.2'
 
 # Check if MrSID decoding library is installed and get the decoding SDK path
-mrSIDLibName = 'libltidsdk.so'
-mrSIDDSDKPath = ""
-findLibraryCommand = "/sbin/ldconfig -p | grep -E '%s$' | tr ' ' '\n' | grep /" %mrSIDLibName
-mrSIDlibraryFullPath=subprocess.check_output(findLibraryCommand, shell=True)
-if mrSIDlibraryFullPath:
-   print "mrSID library was found. GDAL will be built with mrSID raster format support: ", mrSIDlibraryFullPath
-   getFolderCommand = "dirname %s" %mrSIDlibraryFullPath
-   mrSIDLibraryPath=subprocess.check_output(getFolderCommand, shell=True)
-   mrSIDDSDKPath = os.path.normpath(os.path.join(mrSIDLibraryPath, os.pardir))
-   print "mrSID Decoding SDK path is: ", mrSIDDSDKPath
-
+try:
+  mrSIDLibName = 'libltidsdk.so'
+  findLibraryCommand = "/sbin/ldconfig -p | grep %s | tr ' ' '\n' | grep /" %mrSIDLibName
+  mrSIDlibraryFullPath = subprocess.check_output(findLibraryCommand, shell=True).splitlines()[0]
+  print "mrSID library was found. GDAL will be built with mrSID raster format support: ", mrSIDlibraryFullPath
+  # Go up two directories
+  mrSIDDSDKPath = os.path.dirname(os.path.dirname(mrSIDlibraryFullPath))
+  print "mrSID Decoding SDK path is: ", mrSIDDSDKPath
+  assert os.path.isdir(mrSIDDSDKPath), "The mrSID Decoding SDK path is invalid"
+except subprocess.CalledProcessError:
+  # We couldn't find the MrSID library
+  mrSIDDSDKPath = ""
 
 make_cmd_cpu = 'make -j%d' % GetOption('num_jobs')
 


### PR DESCRIPTION
This fixes a segmentation fault that happens during builds on Ubuntu with MrSID support. It includes the following changes:

- Refactor the build code that checks for MrSID to handle multiple paths returned from `ldconfig` and to use Python instead of external executables where possible.
- Refactor khgdal_test to use google-test instead of a custom unit test framework
- Add a test that verifies that MrSID is supported if the library is present on the machine. This test will fail if you build Open GEE first, then install MrSID, then run the test (so don't do that).

Fixes #1645