### PR TITLE
1735 Fix offset to vector packet description string in geglxinfo.

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
+++ b/earth_enterprise/src/fusion/portableglobe/geglxinfo.cpp
@@ -352,7 +352,7 @@ void printVectorPacket(const LittleEndianReadBuffer& buffer, std::ostringstream&
         const char *name_str =
           pChildPacketDataBuffer + pVectorPacketData->name_OFFSET + sizeof(etPattern);
         const char *desc_str =
-          pChildPacketDataBuffer + pVectorPacketData->description_OFFSET + sizeof(etPattern);
+          pChildPacketDataBuffer + pVectorPacketData->description_OFFSET;
 
         s << "      name_str: " << name_str << std::endl;
         s << "      desc_str: " << desc_str << std::endl;


### PR DESCRIPTION
#1735

Fix to use the correct buffer offset for the description string in a vector packet.

I don't think this needs to be added to release notes.

Verification:  Run "geglxinfo --extract_packets" against a portable globe with a vector layer that contains POI strings.  Examine the extracted vector packets and verify that the "desc_str" text is complete and correct.