### PR TITLE
1749 Enable Serving WMS for 3D Databases

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
@@ -853,11 +853,7 @@ gees.admin.databaseView = {
       },
 
       determineWmsOptions: function(item) {
-        if (gees.tools.is2dDatabase(item)) {
           gees.dom.show('WmsOption');
-        } else {
-          gees.dom.hide('WmsOption');
-        }
       },
 
       determinePoiOptions: function(itemHasPoi) {

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
@@ -853,7 +853,7 @@ gees.admin.databaseView = {
       },
 
       determineWmsOptions: function(item) {
-        if (gees.tools.isPortableDb) {
+        if (gees.tools.isPortableDb(item) && gees.tools.is3dDatabase(item)) {
           gees.dom.hide('WmsOption');
         } else {
           gees.dom.show('WmsOption');

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
@@ -853,7 +853,11 @@ gees.admin.databaseView = {
       },
 
       determineWmsOptions: function(item) {
+        if (gees.tools.isPortableDb) {
+          gees.dom.hide('WmsOption');
+        } else {
           gees.dom.show('WmsOption');
+        }
       },
 
       determinePoiOptions: function(itemHasPoi) {

--- a/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/htdocs/admin/js/database_view.js
@@ -852,6 +852,7 @@ gees.admin.databaseView = {
         this.determinePoiOptions(item.has_poi);
       },
 
+      // Hide the Serve WMS radio option for 3d Portable databases
       determineWmsOptions: function(item) {
         if (gees.tools.isPortableDb(item) && gees.tools.is3dDatabase(item)) {
           gees.dom.hide('WmsOption');

--- a/earth_enterprise/src/server/wsgi/wms/ogc/xml/v130/capabilities_wms.py
+++ b/earth_enterprise/src/server/wsgi/wms/ogc/xml/v130/capabilities_wms.py
@@ -2335,12 +2335,12 @@ class Layer(GeneratedsSuper):
     subclass = None
     superclass = None
     def __init__(self, opaque=False, cascaded=None, fixedHeight=None, fixedWidth=None, noSubsets=False, queryable=False, Name=None, Title=None, Abstract=None, KeywordList=None, CRS=None, EX_GeographicBoundingBox=None, BoundingBox=None, Dimension=None, Attribution=None, AuthorityURL=None, Identifier=None, MetadataURL=None, DataURL=None, FeatureListURL=None, Style=None, MinScaleDenominator=None, MaxScaleDenominator=None, Layer=None):
-        self.opaque = _cast(bool, opaque)
+        self.opaque = _cast(int, opaque)
         self.cascaded = _cast(int, cascaded)
         self.fixedHeight = _cast(int, fixedHeight)
         self.fixedWidth = _cast(int, fixedWidth)
-        self.noSubsets = _cast(bool, noSubsets)
-        self.queryable = _cast(bool, queryable)
+        self.noSubsets = _cast(int, noSubsets)
+        self.queryable = _cast(int, queryable)
         self.Name = Name
         self.Title = Title
         self.Abstract = Abstract


### PR DESCRIPTION
All of the back-end work to publish databases with the proper WMS serve is already in place. This change simply makes the button visible in the geserver user interface.

Fixes #1749