### PR TITLE
Fix Asset adding/saving paths in dialogs

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -266,13 +266,10 @@ void AssetChooser::keyPressEvent(QKeyEvent* e) {
 
 void AssetChooser::customEvent(QEvent *e) {
   // Make sure this is really an event that we sent.
-  switch (int(e->type())) {
-    case ChangeDirEventId: {
-      ChangeDirEvent* cdEvent = dynamic_cast<ChangeDirEvent*>(e);
-      iconView->clearSelection();
-      updateView(cdEvent->folder_);
-      break;
-    }
+  if (int(e->type()) == ChangeDirEventId) {
+    ChangeDirEvent* cdEvent = dynamic_cast<ChangeDirEvent*>(e);
+    iconView->clearSelection();
+    updateView(cdEvent->folder_);
   }
 }
 

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -35,7 +35,7 @@
 
 namespace {
 
-const int ChangeDirEventId  = static_cast<int>(QEvent::User);
+const int ChangeDirEventId  = static_cast<int>(QEvent::registerEventType());
 
 class ChangeDirEvent : public QCustomEvent {
  public:
@@ -264,7 +264,7 @@ void AssetChooser::keyPressEvent(QKeyEvent* e) {
   }
 }
 
-void AssetChooser::customEvent(QCustomEvent *e) {
+void AssetChooser::customEvent(QEvent *e) {
   // Make sure this is really an event that we sent.
   switch (static_cast<int>(e->type())) {
     case ChangeDirEventId: {

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -35,7 +35,7 @@
 
 namespace {
 
-const int ChangeDirEventId  = static_cast<int>(QEvent::registerEventType());
+int ChangeDirEventId  = int(QEvent::registerEventType());
 
 class ChangeDirEvent : public QCustomEvent {
  public:
@@ -266,7 +266,7 @@ void AssetChooser::keyPressEvent(QKeyEvent* e) {
 
 void AssetChooser::customEvent(QEvent *e) {
   // Make sure this is really an event that we sent.
-  switch (static_cast<int>(e->type())) {
+  switch (int(e->type())) {
     case ChangeDirEventId: {
       ChangeDirEvent* cdEvent = dynamic_cast<ChangeDirEvent*>(e);
       iconView->clearSelection();

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.h
@@ -72,7 +72,7 @@ class AssetChooser : public AssetChooserBase {
 
   // from QWidget
   virtual void keyPressEvent(QKeyEvent* e);
-  virtual void customEvent(QCustomEvent *e);
+  virtual void customEvent(QEvent *e);
 
   // from QDialog
   virtual void accept();

--- a/earth_enterprise/src/fusion/fusionui/MapLayer.cpp
+++ b/earth_enterprise/src/fusion/fusionui/MapLayer.cpp
@@ -609,7 +609,7 @@ QString MapLayerWidget::RuleName(const QString& caption,
   return text;
 }
 
-void MapLayerWidget::customEvent(QCustomEvent* e) {
+void MapLayerWidget::customEvent(QEvent* e) {
   QListViewItem *listItem = 0;
 
   // Make sure this is really an event that we sent.

--- a/earth_enterprise/src/fusion/fusionui/MapLayer.h
+++ b/earth_enterprise/src/fusion/fusionui/MapLayer.h
@@ -117,7 +117,7 @@ class MapLayerWidget : public MapLayerWidgetBase,
   void UpdateButtons(QListViewItem* item);
   virtual void CurrentItemChanged(QListViewItem* item);
 
-  virtual void customEvent(QCustomEvent *e);
+  virtual void customEvent(QEvent *e);
 
   bool SubLayerHasSearchField(QString field);
 

--- a/earth_enterprise/src/fusion/fusionui/ProjectManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/ProjectManager.cpp
@@ -2315,7 +2315,7 @@ QString ProjectManager::CleanupDropText(const QString &text) {
   return modstr;
 }
 
-void ProjectManager::customEvent(QCustomEvent *e) {
+void ProjectManager::customEvent(QEvent *e) {
   int filterId = 0;
   Q3ListViewItem *listItem = 0;
 

--- a/earth_enterprise/src/fusion/fusionui/ProjectManager.h
+++ b/earth_enterprise/src/fusion/fusionui/ProjectManager.h
@@ -164,7 +164,7 @@ class ProjectManager : public Q3ListView {
   void selectionChanged(Q3ListViewItem* item);
 
   // from QWidget
-  virtual void customEvent(QCustomEvent*);
+  virtual void customEvent(QEvent*);
  private:
   void DrawEditBuffer(const gstDrawState& state);
   GeodeList edit_buffer_;


### PR DESCRIPTION
Allows assets from outside the asset root to be selected by allowing navigation of other folders. Saving outside the asset root is is fixed as well. Also the QEvent ID used by the change directory event is now properly selected (and reserved), rather than just using the min custom event ID (1000). 

To test:

- Build and install.
- Save a resource in a subdir of the asset root.
- Add said resource to a project.