### PR TITLE
Fix server existence check

### DIFF
--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/geecheck_tests/common.py
@@ -61,7 +61,7 @@ def IsFusionInstalled():
 
 def IsGeeServerInstalled():
   """Check if GEE Server is installed."""
-  gee_server_start_script = '/etc/init.d/gefusion'
+  gee_server_start_script = '/etc/init.d/geserver'
   return os.path.exists(gee_server_start_script)
 
 


### PR DESCRIPTION
Fixes #1772 

To test:
1. Install only Server on a machine (not Fusion)
1. Run the diagnostics
1. Verify that the only reason listed for skipping tests is because Fusion is not installed. No tests should be skipped because Server is not installed.