### PR TITLE
1778 Fix Cutter SSL Crash

### DIFF
--- a/docs/geedocs/5.3.5/answer/releaseNotes/relNotesGEE5_3_5.html
+++ b/docs/geedocs/5.3.5/answer/releaseNotes/relNotesGEE5_3_5.html
@@ -106,9 +106,9 @@ correctly to the new PostgreSQL version used by Open GEE 5.3.5.</p>
 </tr>
 </thead>
 <tbody valign="top">
-<tr class="row-even"><td>9999</td>
-<td>Add description</td>
-<td>Add resolution</td>
+<tr class="row-even"><td>1778</td>
+<td>Cutter fails over SSL virtual host DB</td>
+<td>Fix certificate bypass logic</td>
 </tr>
 </tbody>
 </table>

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
@@ -18,7 +18,8 @@
 """Module implementing core cutting functionality."""
 
 import json
-import urllib
+import ssl
+import urllib2
 
 from core import search_tab_template
 
@@ -41,10 +42,13 @@ class GlobeCutter(object):
     """
     search_tabs = ""
     url = "%s/search_json" % source
-    fp = urllib.urlopen(url)
-    if fp.getcode() == 200:
-      search_tabs = fp.read()
-    fp.close()
+    try:
+      fp = urllib2.urlopen(url, context=ssl._create_unverified_context())
+      if fp.getcode() == 200:
+          search_tabs = fp.read()
+      fp.close()
+    except:
+      pass
 
     return search_tabs
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2.7
 #
 # Copyright 2017 Google Inc.
+# Copyright 2020 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/core/globe_cutter.py
@@ -49,7 +49,7 @@ class GlobeCutter(object):
           search_tabs = fp.read()
       fp.close()
     except:
-      pass
+      print ("No search tabs found.")
 
     return search_tabs
 

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 #
 # Copyright 2017 Google Inc.
-# Copyright 2019 Open GEE Contributors
+# Copyright 2020 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/globe_cutter_app.py
@@ -375,7 +375,7 @@ class GlobeBuilder(object):
           context = ssl.create_default_context()
           context.check_hostname = False
           context.verify_mode = ssl.CERT_NONE
-        with closing(urllib2.urlopen(url)) as fp:
+        with closing(urllib2.urlopen(url, context=context)) as fp:
           http_status_code = fp.getcode()
           response_data = fp.read()
 


### PR DESCRIPTION
Fixes an issue where cutter runs into a certificate error when it's almost done. This is due to not passing the proper context in one location, and not setting a default context in another.

Fixes #1778