### PR TITLE
Issue #1741: update build instructions

### DIFF
--- a/earth_enterprise/BUILD.md
+++ b/earth_enterprise/BUILD.md
@@ -6,20 +6,19 @@ __NOTE:__ If you want to build, install, or run Portable server, see the
 Building is currently supported for 64-bit versions of Ubuntu 16.04 LTS,
 RHEL 6, RHEL 7, CentOS 6, and CentOS 7.
 
-## GEE 5.3.4 Build Prerequisites (all platforms)
+## GEE Build Prerequisites - all platforms
 
-1. Setup required Tools and Dependencies:
+1. Setup required tools and dependencies. Different operating systems have different means to setup up these dependencies.
+Please follow the instructions in either the [Redhat and CentOS Setup Instructions](./BUILD_RHEL_CentOS.md)
+or the [Ubuntu Setup Instructions](./BUILD_Ubuntu.md). Open GEE
+requires specific versions of some build tools, as noted below. If you follow
+the instructions linked above, these required versions will be installed.
 
     * git 1.8.4+  __NOTE:__ git 1.7.1+ will build GEE but may miscalculate product version
     * git lfs
     * gcc 4.8.x
     * scons 2.0.x
     * python 2.6.x or python 2.7.x. __Python 3.0+ is not supported.__
-
-Different operating systems have different means to setup up these dependencies.
-For Linux build environments, see either the [Redhat and Centos Setup Instructions](./BUILD_RHEL_CentOS.md)
-or the [Ubuntu Setup Instructions](./BUILD_Ubuntu.md) for those specific
-platforms on how to setup the dependencies, tools, and compilers.
 
 2. Clone the _earthenterprise_ repository in your build environment:
 
@@ -42,7 +41,7 @@ platforms on how to setup the dependencies, tools, and compilers.
         git lfs pull
         ```
 
-3. In the build instructions below, the scons commands for building GEE/Fusion
+3. Build Earth Enterprise Fusion and Server. In the build instructions below, the scons commands for building Open GEE
     have the following options:
 
     * `internal=1`: Build using non-optimized code, best for development and
@@ -69,14 +68,14 @@ platforms on how to setup the dependencies, tools, and compilers.
         the configuration to run again, otherwise the scons build may complain
         about missing libraries
 
-4. Build Earth Enterprise Fusion and Server:
+    Run the following commands to build Open GEE:
 
     ```bash
     cd earthenterprise/earth_enterprise
     python2.7 /usr/bin/scons -j8 release=1 build
     ```
 
-5. Run unit tests (note: that the `REL` part of the path will vary if you use
+4. Run unit tests (note: that the `REL` part of the path will vary if you use
     `internal=1` or `optimize=1` instead of `release=1` or the full path may be
     something completly different if you used `build_folder`):
 

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -58,21 +58,30 @@ sudo yum install -y https://repo.ius.io/ius-release-el6.rpm
 It's recommended to install a recent version of Git from the [IUS repositories](https://ius.io),
 but the older RedHat or Centos packages can also be used.
 
+### RHEL 6 and CentOS 6
+
 ```bash
-# To install Git 2.16 on RHEL 6 and Centos 6
 sudo yum install -y https://repo.ius.io/ius-release-el6.rpm
-sudo yum install -y git216
+sudo yum install -y git222
+```
 
+### RHEL 7 and CentOS 7
 
-# To install Git 2.16 on RHEL 7 and CentOS 7
+```bash
 sudo yum install -y https://repo.ius.io/ius-release-el7.rpm
-sudo yum install -y git216
+sudo yum install -y git222
+```
 
-# To install the system default version:
+### (Optional) System default version - all platforms
+
+Instead of installing git from the IUS repositories you can use the system
+default version. This version of git is older than the IUS version.
+
+```bash
 sudo yum install -y git
 ```
 
-## Install Git LFS
+## Install Git LFS - all platforms
 
 OpenGEE uses Git LFS to store large binary files.  To install Git LFS, use the following commands:
 
@@ -85,14 +94,14 @@ sudo yum install -y git-lfs
 ## GCC 4.8
 
 
-### RHEL 7 And Centos 7
+### RHEL 7 And CentOS 7
 For all versions of CentOS and RHEL, install the standard development/build tools:
 
 ```bash
 sudo yum install -y ant bzip2 doxygen gcc-c++ patch python python-argparse python-defusedxml python-setuptools tar
 ```
 
-### For RHEL6 and Centos 6
+### RHEL6 and Centos 6
 
 ```bash
 sudo yum install -y ant bzip2 doxygen gcc-c++ patch tar python27 python-argparse python27-defusedxml python27-setuptools
@@ -119,7 +128,7 @@ __NOTE:__ If you are upgrading from GEE 5.1.3 or earlier, you must run this step
 _after_ uninstalling older versions of GEE. Otherwise, some of the
 prerequisites will be missing and the build will fail.
 
-### CentOS 7 and RHEL 7
+### RHEL 7 and CentOS 7
 
 Execute:
 
@@ -135,7 +144,8 @@ sudo yum install -y \
   xerces-c xerces-c-devel xorg-x11-server-devel yaml-cpp-devel zlib-devel
 ```
 
-### CentOS 6 and RHEL 6
+###  RHEL 6 and CentOS 6
+
 Execute:
 
 ```bash
@@ -156,7 +166,7 @@ experimenting with the `--skip-broken` parameter.
 
 ## GTest 1.8
 
-### CentOS 7 and RHEL 7
+###  RHEL 7 and CentOS 7
 
 GTest is included in the EPEL and RHEL Extra Repositories. Install the RPM with:
 
@@ -164,7 +174,7 @@ GTest is included in the EPEL and RHEL Extra Repositories. Install the RPM with:
 sudo yum install -y gtest-devel
 ```
 
-### CentOS 6 and RHEL 6
+### RHEL 6 and CentOS 6
 
 You will need to compile, package, and install an updated version of GTest as an
 RPM for RHEL6. This build process also depends on GCC 4.8, as does
@@ -191,12 +201,13 @@ Install the RPM:
 ```bash
 sudo yum install -y ./build/RPMS/x86_64/gtest-devtoolset2-1.8.0-1.x86_64.rpm
 ```
+
 ## shunit2
 
 shunit2 is used for unit testing shell scripts in the GEE repository.
 It is currently used only for testing package-building scripts.
 
-### CentOS 7 and RHEL 7
+### RHEL 7 and CentOS 7
 
 The EPEL repositories for RHEL and CentOS 7 do not include shunit2.
 If you want to run these tests on one of these platforms, you must install
@@ -207,18 +218,17 @@ To do so run the following:
 sudo yum install -y http://download-ib01.fedoraproject.org/pub/epel/6/x86_64/Packages/s/shunit2-2.1.6-3.el6.noarch.rpm
 ```
 
-### CentOS 6 and RHEL 6
+### RHEL 6 and CentOS 6
 
 shunit2 was installed in a previous step.
 
-
 ## Install Python 2.7 Packages
 
-### CentOS 7 and RHEL 7
+### RHEL 7 and CentOS 7
 
 Python 2.7 is installed as a system default, so no additional packages are needed.
 
-### CentOS 6 and RHEL 6
+### RHEL 6 and CentOS 6
 
 ```bash
 sudo pip2.7 install gitpython
@@ -356,4 +366,3 @@ Reboot and then confirm that fips has been enabled
 $ cat /proc/sys/crypto/fips_enabled
 1
 ```
-

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -62,14 +62,14 @@ but the older RedHat or Centos packages can also be used.
 
 ```bash
 sudo yum install -y https://repo.ius.io/ius-release-el6.rpm
-sudo yum install -y git222
+sudo yum install -y git224
 ```
 
 ### RHEL 7 and CentOS 7
 
 ```bash
 sudo yum install -y https://repo.ius.io/ius-release-el7.rpm
-sudo yum install -y git222
+sudo yum install -y git224
 ```
 
 ### (Optional) System default version - all platforms


### PR DESCRIPTION
Fixes #1741 

Updates the name of the git package in the IUS repo in the CentOS and RHEL build instructions. Also includes some other cleanup to make the build instructions easier to understand.