### PR TITLE
Correction to portable server README

### DIFF
--- a/earth_enterprise/src/portableserver/README.md
+++ b/earth_enterprise/src/portableserver/README.md
@@ -64,7 +64,8 @@ If you're running an old version of a Red Hat distribution, such as Cent OS or R
 
 Run
 
-    earthenterprise/earth_enterprise/src/portableserver/build.py
+    cd earthenterprise/earth_enterprise/src/portableserver
+    ./build.py
 
 The build script will produce a compressed archive with a name that looks like `earthenterprise/earth_enterprise/src/portableserver/build/portableserver-linux-5.1.3-20170412.tar.gz`. The build date part of the file name will change depending on the day you build.
 
@@ -72,7 +73,8 @@ You can install the built Portable Server from this `.tar.gz` archive.
 
 To clean build files, run 
 
-    earthenterprise/earth_enterprise/src/portableserver/build.py --clean
+    cd earthenterprise/earth_enterprise/src/portableserver
+    ./build.py --clean
 
 
 ## Installing on Linux

--- a/earth_enterprise/src/portableserver/README.md
+++ b/earth_enterprise/src/portableserver/README.md
@@ -140,7 +140,8 @@ C:\swigwin-3.0.12;C:\Python27;C:\MinGW\bin;C:\Program Files\ . . .
 
 Run
 
-    python earthenterprise\earth_enterprise\src\portableserver\build.py
+    cd earthenterprise\earth_enterprise\src\portableserver
+    python build.py
 
 The build script will produce a compressed archive with a name that looks like `earthenterprise\earth_enterprise\src\portableserver\build\portableserver-windows-5.1.3-20170412.zip`. The build date part of the file name will change depending on the day you build.
 
@@ -148,7 +149,8 @@ You can install the built Portable Server from this Zip archive.
 
 To clean build files, run 
 
-    python earthenterprise\earth_enterprise\src\portableserver\build.py --clean
+    cd earthenterprise\earth_enterprise\src\portableserver
+    python build.py --clean
 
 
 ## Installing on Windows


### PR DESCRIPTION
The instructions needed to indicate that build.py should be run from within the `earthenterprise/earth_enterprise/src/portableserver` directory.