### PR TITLE
QT4 (EL8) Database Push Error Fix

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -642,7 +642,6 @@ void AssetManager::HandleNewWindow(AssetBase* asset_window) {
                             asset_window->AssetSubtype());
   AssetAction* action = new AssetAction(this, asset_window);
   action->addTo(Window);
-  sleep(60);
   asset_window->setIcon(helper.GetPixmap());
   asset_window->move(QCursor::pos());
   asset_window->show();
@@ -1265,7 +1264,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(QObject::deleteLater));
+    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater));
     //QObject::connect(&push_thread, SIGNAL(static_cast<void(QThread::*)()>(&QThread::finished)), &push_thread, SLOT(&QThread::quit), Qt::DirectConnection);
     //FIXME
     //QObject::connect(&push_thread, QThread::finished, &push_thread, &QThread::quit, Qt::DirectConnection);
@@ -1278,7 +1277,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
         qApp->processEvents();
     }
   }
-  
+ 
   if (progress_dialog.wasCanceled()) {
     QMessageBox::critical(this, "Push Interrupted",
                           tr("Push Interrupted"), 0, 0, 0);

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1277,7 +1277,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
         qApp->processEvents();
     }
   }
- 
+
   if (progress_dialog.wasCanceled()) {
     QMessageBox::critical(this, "Push Interrupted",
                           tr("Push Interrupted"), 0, 0, 0);

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1264,7 +1264,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater));
+    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater()));
     //QObject::connect(&push_thread, SIGNAL(static_cast<void(QThread::*)()>(&QThread::finished)), &push_thread, SLOT(&QThread::quit), Qt::DirectConnection);
     //FIXME
     //QObject::connect(&push_thread, QThread::finished, &push_thread, &QThread::quit, Qt::DirectConnection);
@@ -1397,7 +1397,7 @@ void AssetManager::PublishDatabase(const gstAssetHandle& handle) {
                      &publish_assistant, SLOT(SetCanceled()));
     QObject::connect(
         &publish_thread, SIGNAL(sfinished()), &publish_assistant, SLOT(Stop()));
-    QObject::connect(&publish_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater));
+    QObject::connect(&publish_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater()));
     //FIXME
     //connect(&publish_thread, static_cast<void(QThread::*)()>(&QThread::finished), &publish_thread, &QThread::quit);
 

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1264,7 +1264,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater()));
+    QObject::connect(&push_thread, SIGNAL(sfinished()), &push_thread, SLOT(deleteLater()));
     //QObject::connect(&push_thread, SIGNAL(static_cast<void(QThread::*)()>(&QThread::finished)), &push_thread, SLOT(&QThread::quit), Qt::DirectConnection);
     //FIXME
     //QObject::connect(&push_thread, QThread::finished, &push_thread, &QThread::quit, Qt::DirectConnection);
@@ -1397,7 +1397,7 @@ void AssetManager::PublishDatabase(const gstAssetHandle& handle) {
                      &publish_assistant, SLOT(SetCanceled()));
     QObject::connect(
         &publish_thread, SIGNAL(sfinished()), &publish_assistant, SLOT(Stop()));
-    QObject::connect(&publish_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater()));
+    QObject::connect(&publish_thread, SIGNAL(sfinished()), &publish_thread, SLOT(deleteLater()));
     //FIXME
     //connect(&publish_thread, static_cast<void(QThread::*)()>(&QThread::finished), &publish_thread, &QThread::quit);
 

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -478,7 +478,7 @@ void ServeAssistant::Stop() {
 }
 
 void ServeAssistant::SetCanceled() {
-  //progress_->setCanceled();
+  progress_->setCanceled();
 }
 
 void ServeAssistant::Perform() {
@@ -642,6 +642,7 @@ void AssetManager::HandleNewWindow(AssetBase* asset_window) {
                             asset_window->AssetSubtype());
   AssetAction* action = new AssetAction(this, asset_window);
   action->addTo(Window);
+  sleep(60);
   asset_window->setIcon(helper.GetPixmap());
   asset_window->move(QCursor::pos());
   asset_window->show();
@@ -1264,7 +1265,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(&QObject::deleteLater));
+    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(QObject::deleteLater()));
     //QObject::connect(&push_thread, SIGNAL(static_cast<void(QThread::*)()>(&QThread::finished)), &push_thread, SLOT(&QThread::quit), Qt::DirectConnection);
     //FIXME
     //QObject::connect(&push_thread, QThread::finished, &push_thread, &QThread::quit, Qt::DirectConnection);
@@ -1273,9 +1274,11 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     push_assistant.Start();
     progress_dialog.show();
 
-    qApp->exec();
+    while (push_thread.isRunning()) {
+        qApp->processEvents();
+    }
   }
-
+  
   if (progress_dialog.wasCanceled()) {
     QMessageBox::critical(this, "Push Interrupted",
                           tr("Push Interrupted"), 0, 0, 0);

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1265,7 +1265,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(QObject::deleteLater()));
+    QObject::connect(&push_thread, SIGNAL(sfinished()), qApp, SLOT(QObject::deleteLater));
     //QObject::connect(&push_thread, SIGNAL(static_cast<void(QThread::*)()>(&QThread::finished)), &push_thread, SLOT(&QThread::quit), Qt::DirectConnection);
     //FIXME
     //QObject::connect(&push_thread, QThread::finished, &push_thread, &QThread::quit, Qt::DirectConnection);
@@ -1405,8 +1405,10 @@ void AssetManager::PublishDatabase(const gstAssetHandle& handle) {
     publish_thread.start();
     publish_assistant.Start();
     progress_dialog.show();
-
-    qApp->exec();
+ 
+    while (publish_thread.isRunning()) {
+        qApp->processEvents();
+    } 
   }
 
   if (progress_dialog.wasCanceled()) {

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -656,7 +656,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
       return false;
     }
     notify(NFY_DEBUG, "Created gepublish tempdir");
-    sleep(10);
+
     // Create a guard object that ensures that the temporary directory gets
     // deleted automatically when we return.
     khCallGuard<const std::string&, bool> prune_guard(khPruneDir, tmpdir);
@@ -666,7 +666,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
     db_manifest.GetPushManifest(file_pool, &manifest_entries,
                                 &manifest_entries, tmpdir, publish_prefix);
     notify(NFY_DEBUG, "GetPushManifest");
-    sleep(10);
+
     // chmod all the temporary files to 0755 so that the publisher servlet
     // can access it just in case the user's umask disables access to all
     // completely.
@@ -686,7 +686,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
       return false;
     }
     notify(NFY_DEBUG, "SyncFiles(STREAM_SERVER) done.");
-    sleep(10);
+
     // Transfer search data (POI files), create POI tables.
     notify(NFY_DEBUG, "SyncFiles(SEARCH_SERVER)...");
     if (!SyncFiles(SEARCH_SERVER, args, manifest_entries, tmpdir)) {
@@ -695,7 +695,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
     }
     notify(NFY_DEBUG, "SyncFiles(SEARCH_SERVER) done.");
     notify(NFY_DEBUG, "-----------------SyncDatabase successful\n.");
-    sleep(10);
+
     return true;
   } catch(const std::exception &e) {
     AppendErrMsg(e.what());

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -625,7 +625,6 @@ bool PublisherClient::PushDatabase(const std::string& db_name) {
   notify(NFY_DEBUG, "Push Database Contacted SEARCH_SERVER");
 
   std::string norm_db_name = NormalizeDbName(db_name);
-
   // Sync Stream and Search data for specified database.
   return SyncDatabase(norm_db_name);
 }
@@ -657,7 +656,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
       return false;
     }
     notify(NFY_DEBUG, "Created gepublish tempdir");
-
+    sleep(10);
     // Create a guard object that ensures that the temporary directory gets
     // deleted automatically when we return.
     khCallGuard<const std::string&, bool> prune_guard(khPruneDir, tmpdir);
@@ -667,7 +666,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
     db_manifest.GetPushManifest(file_pool, &manifest_entries,
                                 &manifest_entries, tmpdir, publish_prefix);
     notify(NFY_DEBUG, "GetPushManifest");
-
+    sleep(10);
     // chmod all the temporary files to 0755 so that the publisher servlet
     // can access it just in case the user's umask disables access to all
     // completely.
@@ -687,7 +686,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
       return false;
     }
     notify(NFY_DEBUG, "SyncFiles(STREAM_SERVER) done.");
-
+    sleep(10);
     // Transfer search data (POI files), create POI tables.
     notify(NFY_DEBUG, "SyncFiles(SEARCH_SERVER)...");
     if (!SyncFiles(SEARCH_SERVER, args, manifest_entries, tmpdir)) {
@@ -696,7 +695,7 @@ bool PublisherClient::SyncDatabase(const std::string& db_name) {
     }
     notify(NFY_DEBUG, "SyncFiles(SEARCH_SERVER) done.");
     notify(NFY_DEBUG, "-----------------SyncDatabase successful\n.");
-
+    sleep(10);
     return true;
   } catch(const std::exception &e) {
     AppendErrMsg(e.what());

--- a/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
+++ b/earth_enterprise/src/fusion/gepublish/PublisherClient.cpp
@@ -625,6 +625,7 @@ bool PublisherClient::PushDatabase(const std::string& db_name) {
   notify(NFY_DEBUG, "Push Database Contacted SEARCH_SERVER");
 
   std::string norm_db_name = NormalizeDbName(db_name);
+
   // Sync Stream and Search data for specified database.
   return SyncDatabase(norm_db_name);
 }


### PR DESCRIPTION
Fixes the error dialog that occurs during a database push on EL8.

To test:

1. Install on EL8.
2. Build a database.
3. Push the database to the server.
4. Verify that no error dialog pops up, and that the progress dialog appears (may be very fast).
5. For bonus points: Slow down your localhost network connection and verify that the progress dialog works correctly (`tc qdisc add dev lo root handle 1:0 netem delay 500msec` will do the trick).