### PR TITLE
Open dialogue text fix

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/Asset.h
+++ b/earth_enterprise/src/fusion/autoingest/Asset.h
@@ -60,8 +60,9 @@ class AssetImpl : public AssetStorage, public StorageManaged {
   static std::shared_ptr<AssetImpl> Load(const std::string &boundref);
 
   virtual std::string GetName() const { // Returns the name of the asset, e.g., "CombinedRPAsset"
-    assert(false);
-    return "";
+    /*assert(false);
+    return "";*/
+    return this->GetRef().toString();
   }
 
   // Note for future development: It would be good to change SerializeConfig to something like

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -296,13 +296,11 @@ void AssetChooser::accept() {
                          ->getName().toUtf8().constData()) } ,
                   san2 { shortAssetName(assetItem->getAssetHandle()
                          ->getName().toStdString().c_str()) };
-      notify(NFY_WARN, "gname %s san1 %s san2 %s",
-             gname.toStdString().c_str(), san1.c_str(), san2.c_str());
+
       if (san1 == san2)
       {
           gname.clear();
           gname = QString(san2.c_str());
-          notify(NFY_WARN, "setting gname %s", gname.toStdString().c_str());
       }
       if (assetItem != NULL && gname != san2.c_str()) {
 
@@ -318,8 +316,7 @@ void AssetChooser::accept() {
     AssetItem* assetItem = dynamic_cast<AssetItem*>(item);
     if (assetItem != NULL) {
         std::string temp { shortAssetName(assetItem->getAssetHandle()->getName()
-                                          .toStdString().c_str()) }; //.toUtf8().constData()) };
-      notify(NFY_WARN, "assetItem != NULL : temp %s", temp.c_str());
+                                          .toStdString().c_str()) };
       nameEdit->setText(temp.c_str());
       gstAssetHandle asset_handle = assetItem->getAssetHandle();
       Asset asset = asset_handle->getAsset();
@@ -415,10 +412,6 @@ bool AssetChooser::IsCompatibleAsset() const {
 }
 
 QString AssetChooser::getName() const {
-  /*auto temp = nameEdit->text();
-  auto cstr = temp.toStdString();
-  notify(NFY_WARN, "AssetChooser::getName() : temp %s cstr %s",
-         temp.toUtf8().constData(), cstr.c_str());*/
   return nameEdit->text();
 }
 
@@ -429,7 +422,9 @@ const gstAssetFolder& AssetChooser::getFolder() const {
 void AssetChooser::selectItem(QIconViewItem* item) {
   AssetItem* assetItem = dynamic_cast<AssetItem*>(item);
   if (assetItem != NULL) {
-    nameEdit->setText(shortAssetName(assetItem->getAssetHandle()->getName().toUtf8().constData()));
+    std::string aname { assetItem->getAssetHandle()->getName().toStdString() },
+     sname { shortAssetName(aname.c_str()) };
+    nameEdit->setText(sname.c_str());
   }
 }
 

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -292,12 +292,19 @@ void AssetChooser::accept() {
       // If name doesn't match with current item name, then reset item
       // pointer to initiate searching of item by name below.
       auto gname = getName();
-      auto san1 = shortAssetName(assetItem->getAssetHandle()->getName().toUtf8().constData()),
-           san2 = shortAssetName(assetItem->getAssetHandle()->getName().toStdString().c_str());
+      std::string san1 { shortAssetName(assetItem->getAssetHandle()
+                         ->getName().toUtf8().constData()) } ,
+                  san2 { shortAssetName(assetItem->getAssetHandle()
+                         ->getName().toStdString().c_str()) };
       notify(NFY_WARN, "gname %s san1 %s san2 %s",
-             gname.toStdString().c_str(), san1, san2);
-      if (assetItem != NULL &&
-          gname != san2) {
+             gname.toStdString().c_str(), san1.c_str(), san2.c_str());
+      if (san1 == san2)
+      {
+          gname.clear();
+          gname = QString(san2.c_str());
+          notify(NFY_WARN, "setting gname %s", gname.toStdString().c_str());
+      }
+      if (assetItem != NULL && gname != san2.c_str()) {
 
         item = NULL;
       }
@@ -307,7 +314,7 @@ void AssetChooser::accept() {
       // Note: means that name have been edited and we try to find item by name.
       item = iconView->findItem(getName(), QKeySequence::ExactMatch);
     }
-
+    // here
     AssetItem* assetItem = dynamic_cast<AssetItem*>(item);
     if (assetItem != NULL) {
         std::string temp { shortAssetName(assetItem->getAssetHandle()->getName()

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.h
@@ -25,7 +25,6 @@
 #include "assetchooserbase.h"
 #include "fusion/fusionui/AssetDisplayHelper.h"
 #include <Qt/qwidget.h>
-//class QIconViewItem;
 #include <Qt/q3iconview.h>
 #include <Qt/qevent.h>
 using QIconViewItem = Q3IconViewItem;

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1611,7 +1611,7 @@ void AssetManager::assetsChanged(const AssetChanges& changes) {
   }
 
   // convert it to std::string only once for speed
-  std::string curr = currpath.toUtf8().constData();
+  std::string curr = currpath.toStdString();
 
   // check to see if any of the changes are in this directory
   std::set<std::string> changedHere;

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -99,6 +99,7 @@ using QMimeSourceFactory = Q3MimeSourceFactory;
 #include "fusion/gst/gstRegistry.h"
 #include "fusion/fusionversion.h"
 #include "common/notify.h"
+#include <array>
 
 namespace {
 
@@ -300,21 +301,24 @@ bool DatabaseHasValidVersion(const Asset &asset) {
 
 // -----------------------------------------------------------------------------
 
-const AssetDefs::Type TypeSet[] = {
+const std::array<AssetDefs::Type,6> TypeSet =
+{{
   AssetDefs::Invalid,
   AssetDefs::Vector,
   AssetDefs::Imagery,
   AssetDefs::Terrain,
   AssetDefs::Map,
   AssetDefs::Database
-};
-const std::string SubTypeSet[] = {
+}};
+
+const std::array<std::string,5> SubTypeSet =
+{{
   "",
   kResourceSubtype,
   kLayer,
   kProjectSubtype,
   kDatabaseSubtype
-};
+}};
 
 // -----------------------------------------------------------------------------
 
@@ -1711,7 +1715,6 @@ QListViewItem* AssetManager::OpenFolder(const QString& folder) {
   }
 
   categories->setSelected(item, true);
-
   return item;
 }
 

--- a/earth_enterprise/src/fusion/fusionui/MainWindow.cpp
+++ b/earth_enterprise/src/fusion/fusionui/MainWindow.cpp
@@ -563,6 +563,7 @@ void MainWindow::manageLocales() {
 void MainWindow::assetManager() {
   asset_manager_->showNormal();
   asset_manager_->raise();
+  asset_manager_->refresh();
 }
 
 void MainWindow::ShowFeatureEditor() {


### PR DESCRIPTION
to test:

- open asset manager
- new asset
- add resource
- navigate from asset root to a resource that contains and underscore and hyphen
- not that it displays correctly in the file window, that it displays in the "Name:" text edit line, and will try (or will, depending on whether or not it is the correct resource type) to open the resource