### PR TITLE
Set the umask in RPM scripts where necessary

### DIFF
--- a/earth_enterprise/rpms/opengee-fusion/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/snippets/post-install.sh
@@ -16,6 +16,7 @@
 
 # NOTE: requires xmllint from libxml2-utils
 
+umask 002
 
 #------------------------------------------------------------------------------
 # Definitions


### PR DESCRIPTION
Adds a umask command in an RPM script that creates directories. This avoids problems on systems with restrictive umasks.