### PR TITLE
Add AbstractFileAccessor::GetFileInfo() for use in geFilePool

### DIFF
--- a/earth_enterprise/src/common/FileAccessor.h
+++ b/earth_enterprise/src/common/FileAccessor.h
@@ -38,6 +38,7 @@ public:
   virtual bool Exists(const std::string &filename) = 0;
   virtual bool GetLinesFromFile(std::vector<std::string> &lines, const std::string &filename);
   virtual void fprintf(const char *format, ...) = 0;
+  virtual bool GetFileInfo(const std::string &fname, std::uint64_t &size, time_t &mtime) = 0;
 };
 
 class FileAccessorFactory {

--- a/earth_enterprise/src/common/FileAccessorPluginLoader_unittest.cpp
+++ b/earth_enterprise/src/common/FileAccessorPluginLoader_unittest.cpp
@@ -54,6 +54,7 @@ public:
   virtual bool Exists(const std::string &filename) {return false;}
   virtual bool GetLinesFromFile(std::vector<std::string> &lines, const std::string &filename) {return false;}
   virtual void fprintf(const char *format, ...) {}
+  virtual bool GetFileInfo(const std::string &fname, std::uint64_t &size, time_t &mtime) { return false; }
 };
 
 class TestAccessor9876: public TestAccessorBase {

--- a/earth_enterprise/src/common/POSIXFileAccessor.cpp
+++ b/earth_enterprise/src/common/POSIXFileAccessor.cpp
@@ -68,3 +68,7 @@ void POSIXFileAccessor::fprintf(const char *format, ...) {
   ::vdprintf(fileDescriptor, format, arguments);
   va_end(arguments);
 }
+
+bool POSIXFileAccessor::GetFileInfo(const std::string &fname, std::uint64_t &size, time_t &mtime) {
+    return khGetFileInfo(fname, size, mtime);
+}

--- a/earth_enterprise/src/common/POSIXFileAccessor.h
+++ b/earth_enterprise/src/common/POSIXFileAccessor.h
@@ -38,6 +38,7 @@ public:
   bool ReadStringFromFile(const std::string &filename, std::string &str, std::uint64_t limit = 0) override;
   bool Exists(const std::string &filename) override;
   void fprintf(const char *format, ...) override;
+  bool GetFileInfo(const std::string &fname, std::uint64_t &size, time_t &mtime) override;
 };
 
 #endif //COMMON_POSIXFILEACCESSOR_H

--- a/earth_enterprise/src/common/geFilePool.cpp
+++ b/earth_enterprise/src/common/geFilePool.cpp
@@ -108,7 +108,8 @@ FileReferenceImpl::FileReferenceImpl(geFilePool &pool_,
 
   if (!IsWriter()) {
     time_t mtime;
-    if (!khGetFileInfo(fname, cachedFilesize, mtime)) {
+    auto afa = AbstractFileAccessor::getAccessor(fname);
+    if (!afa->GetFileInfo(fname, cachedFilesize, mtime)) {
       throw khSimpleException("No such file ") << fname;
     }
   }
@@ -392,7 +393,8 @@ void geFilePool::WriteStringFile(const std::string &fname,
 void geFilePool::ReadStringFile(const std::string &fname, std::string *buf) {
   std::uint64_t size = 0;
   time_t mtime;
-  if (!khGetFileInfo(fname, size, mtime)) {
+  auto afa = AbstractFileAccessor::getAccessor(fname);
+  if (!afa->GetFileInfo(fname, size, mtime)) {
     throw khSimpleException("No such file ") << fname;
   }
 
@@ -417,7 +419,8 @@ void geFilePool::ReadSimpleFileWithCRC(const std::string &fname,
   // get the filesize
   std::uint64_t size = 0;
   time_t mtime;
-  if (!khGetFileInfo(fname, size, mtime)) {
+  auto afa = AbstractFileAccessor::getAccessor(fname);
+  if (!afa->GetFileInfo(fname, size, mtime)) {
     throw khSimpleException("No such file ") << fname;
   }
 

--- a/earth_enterprise/src/common/test_plugins/FileAccessorTestPlugin.cpp
+++ b/earth_enterprise/src/common/test_plugins/FileAccessorTestPlugin.cpp
@@ -34,6 +34,7 @@ public:
   virtual bool Exists(const std::string &filename) {return false;}
   virtual bool GetLinesFromFile(std::vector<std::string> &lines, const std::string &filename) {return false;}
   virtual void fprintf(const char *format, ...) {}
+  virtual bool GetFileInfo(const std::string &fname, std::uint64_t &size, time_t &mtime) { return false; }
 
   // getFD is used by the unit tests to verify which accessor they have
   virtual int getFD() {return 9999;}

--- a/earth_enterprise/src/third_party/libcurl/SConscript
+++ b/earth_enterprise/src/third_party/libcurl/SConscript
@@ -66,7 +66,7 @@ libcurl_configure = libcurl_env.Command(
         ('cd {build_root_escaped}\n'
          'export LD_LIBRARY_PATH={build_lib_dir_escaped}\n'
          '{mod_env}{env_opt} ./configure --prefix={opt_dir_escaped} '
-            '--with-ssl --without-ca-bundle '
+            '--with-ssl={opt_dir_escaped} '
             '--without-zlib --without-libidn --without-krb4 --without-gnutls '
             '--enable-shared --disable-static {config_opt}\n'
          'touch {libcurl_target_escaped}'

--- a/earth_enterprise/src/third_party/libcurl/libcurl-ge.spec
+++ b/earth_enterprise/src/third_party/libcurl/libcurl-ge.spec
@@ -68,8 +68,7 @@ CFLAGS='%{optflags}' CXXFLAGS='%{optflags}' ./configure \
     --prefix=%{_prefix} \
     --mandir=%_mandir \
     --libdir=%{_libdir} \
-    --without-ssl \
-    --without-ca-bundle \
+    --with-ssl=%{_prefix} \
     --without-zlib \
     --without-libidn \
     --without-krb4 \


### PR DESCRIPTION
Created AbstractFileAccessor::GetFileInfo(), and switched calls to khGetFileInfo inside geFilePool.cpp use it instead.