### PR TITLE
Build libcurl with bundled OpenSSL and with CA bundle enabled.

### DIFF
--- a/earth_enterprise/src/third_party/libcurl/SConscript
+++ b/earth_enterprise/src/third_party/libcurl/SConscript
@@ -66,7 +66,7 @@ libcurl_configure = libcurl_env.Command(
         ('cd {build_root_escaped}\n'
          'export LD_LIBRARY_PATH={build_lib_dir_escaped}\n'
          '{mod_env}{env_opt} ./configure --prefix={opt_dir_escaped} '
-            '--with-ssl --without-ca-bundle '
+            '--with-ssl={opt_dir_escaped} '
             '--without-zlib --without-libidn --without-krb4 --without-gnutls '
             '--enable-shared --disable-static {config_opt}\n'
          'touch {libcurl_target_escaped}'

--- a/earth_enterprise/src/third_party/libcurl/libcurl-ge.spec
+++ b/earth_enterprise/src/third_party/libcurl/libcurl-ge.spec
@@ -68,8 +68,7 @@ CFLAGS='%{optflags}' CXXFLAGS='%{optflags}' ./configure \
     --prefix=%{_prefix} \
     --mandir=%_mandir \
     --libdir=%{_libdir} \
-    --without-ssl \
-    --without-ca-bundle \
+    --with-ssl=%{_prefix} \
     --without-zlib \
     --without-libidn \
     --without-krb4 \


### PR DESCRIPTION
These changes allow the bundled libcurl to access HTTPS.