### PR TITLE
Issue #1785: Fix imagery project transparency

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
+++ b/earth_enterprise/src/fusion/autoingest/plugins.src/PacketGen.src
@@ -249,18 +249,9 @@ void PacketGenAssetVersionImplD::UpdateChildren(
           // In these cases we pull directly from the product. It
           // will also happen for the last thing on the stack who
           // hasn't had his blendvers filled in yet.
-
-          // Note: Before creating a merge inset, we check if the cached alpha
-          // blend directory exists for the asset since in GEE-5.x we need to
-          // pick up the GEE-4.x Imagery/Terrain Projects (the PacketLevel
-          // assets) that have no alpha blend cached.
           levInputs[inputs_idx+1] = blendVer.Ref();
           levInputVers[inputs_idx+1] = blendVer;
-          const std::string cache_alpha_path =
-              blendVer->GetOutputFilename(0) + "/cache_alpha.pack";
-          if (khExists(cache_alpha_path)) {
-            cached_blend_alpha = blendVer.Ref();
-          }
+          cached_blend_alpha = blendVer.Ref();
           cached_blend = blendVer.Ref();
         }
         packetLevelConfig.insets[merge_idx] =
@@ -283,22 +274,12 @@ void PacketGenAssetVersionImplD::UpdateChildren(
         levInputs.back() = prevLevelVer.Ref();
         levInputVers.back() = prevLevelVer;
 
-
-        // Note: Before creating a merge inset, we check if the cached alpha
-        // blend directory exists for the asset since in GEE-5.x we need to
-        // pick up the GEE-4.x Imagery/Terrain Projects (the PacketLevel
-        // assets) that have no alpha blend cached.
-        const std::string cache_alpha_path =
-            prevLevelVer->GetOutputFilename(0) + "/cache_alpha.pack";
-        const bool cache_alpha_exist = khExists(cache_alpha_path);
-
         packetLevelConfig.insets.push_back
           (PacketLevelConfig::Inset(
               std::string() /* dataRP */,
               std::string() /* alphaRP */,
               prevLevelVer.Ref(), /* cached blend */
-              cache_alpha_exist ?
-                  prevLevelVer.Ref() : SharedString() /* cached blend alpha */));
+              prevLevelVer.Ref() /* cached blend alpha */));
       }
 
       levInputs.erase(std::remove(levInputs.begin(), levInputs.end(), ""), levInputs.end());

--- a/earth_enterprise/src/fusion/rasterfuse/RasterMerger.cpp
+++ b/earth_enterprise/src/fusion/rasterfuse/RasterMerger.cpp
@@ -159,10 +159,18 @@ void MergeInset<DataTile>::InitCachedBlendReaders(
 
     magnifyCoverage = cached_blend_reader->levelCoverage(magnify_level);
 
-    // Initialize cached alpha reader
+    // Initialize cached alpha reader.
     if (cached_blend_alpha_file.size()) {
-      cached_blend_alpha_reader = TransferOwnership(
-          new ffio::raster::Reader<AlphaProductTile>(cached_blend_alpha_file));
+      // Note: we check if the cached alpha blend directory exists for the
+      // asset since in GEE-5.x we need to pick up the GEE-4.x Imagery/Terrain
+      // Projects (the PacketLevel assets) that have no alpha blend cached.
+      if (khExists(cached_blend_alpha_file)) {
+        cached_blend_alpha_reader = TransferOwnership(
+            new ffio::raster::Reader<AlphaProductTile>(cached_blend_alpha_file));
+      }
+      else {
+        notify(NFY_INFO, "Cached blend alpha file %s does not exist.", cached_blend_alpha_file.c_str());
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1785 

Thanks to @duvifn for discovering the problem and suggesting a solution.

The problem:

Fusion caches alpha bands to make building multiple layers more efficient. However, it checks for the existence of the alpha band before using it because 4.x did not cache alpha. This is a problem because sometimes the check for the cached alpha happens before it has been built, so Fusion incorrectly decides that there is no alpha and does not apply transparency correctly.

The fix:

This PR moves the check for the cached alpha folder to just before it is used so that it has time to build it if it needs to.

To verify:

1. Create a flat 2D database containing only blue marble and publish it with WMS enabled.
1. Create a flat 2D database containing only this file: https://drive.google.com/file/d/1IWjQvGDgGNRlGRVuRNImyfuAazGXN6xm/view?usp=sharing and no blue marble. It is important that the imagery resource and project are brand new and have not been built before.
1. View both databases in a tool like QGIS with the clipped file on top of blue marble. You should see a small amount of high resolution imagery in San Francisco and blue marble everywhere else. Without this fix, the clipped image would have an opaque background and you would not see blue marble at all.
