### PR TITLE
Fix #1761: Fusion resource tab order

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/rasterassetwidgetbase.ui
+++ b/earth_enterprise/src/fusion/fusionui/rasterassetwidgetbase.ui
@@ -903,6 +903,10 @@
     <tabstop>clamp_elev_check</tabstop>
     <tabstop>lutfile_chooser_btn</tabstop>
     <tabstop>lutfile_delete_btn</tabstop>
+    <tabstop>south_boundary</tabstop>
+    <tabstop>north_boundary</tabstop>
+    <tabstop>west_boundary</tabstop>
+    <tabstop>east_boundary</tabstop>
     <tabstop>source_list</tabstop>
     <tabstop>add_src_btn</tabstop>
     <tabstop>delete_src_btn</tabstop>

--- a/earth_enterprise/src/fusion/fusionui/vectorassetwidgetbase.ui
+++ b/earth_enterprise/src/fusion/fusionui/vectorassetwidgetbase.ui
@@ -555,12 +555,12 @@
     <tabstop>acquisition_date_year</tabstop>
     <tabstop>acquisition_date_month</tabstop>
     <tabstop>acquisition_date_day</tabstop>
-    <tabstop>codec_combo</tabstop>
-    <tabstop>elev_units_combo</tabstop>
-    <tabstop>force_feature_type_combo</tabstop>
     <tabstop>provider_combo</tabstop>
+    <tabstop>codec_combo</tabstop>
     <tabstop>layer_spin</tabstop>
+    <tabstop>elev_units_combo</tabstop>
     <tabstop>ignore_bad_features_check</tabstop>
+    <tabstop>force_feature_type_combo</tabstop>
     <tabstop>do_not_fix_invalid_geometries_check</tabstop>
     <tabstop>south_boundary</tabstop>
     <tabstop>north_boundary</tabstop>


### PR DESCRIPTION
Hi. This PR fixes order of switching by tab on Imagery, Vector and Terrain Resource
Fixes #1761