### PR TITLE
Added 'host' option to PostgreSQL connection settings

### DIFF
--- a/earth_enterprise/src/common/config/gePrompt.cpp
+++ b/earth_enterprise/src/common/config/gePrompt.cpp
@@ -116,11 +116,11 @@ enterDirname(const std::string msg, const std::string &dflt,
 "%1 does not exist.\n"
 "Should this tool create it now")
                   .arg(dir), 'Y')) {
-        geCapabilitiesGuard cap_guard(
-            CAP_DAC_OVERRIDE,     // let me read all files
-            CAP_DAC_READ_SEARCH,  // let me traverse all dirs
-            CAP_CHOWN,            // let me chown files
-            CAP_FOWNER);          // let me chmod files I dont own
+        // geCapabilitiesGuard cap_guard(
+        //     CAP_DAC_OVERRIDE,     // let me read all files
+        //     CAP_DAC_READ_SEARCH,  // let me traverse all dirs
+        //     CAP_CHOWN,            // let me chown files
+        //     CAP_FOWNER);          // let me chmod files I dont own
         if (khMakeDir(dir)) {
           done = true;
         }

--- a/earth_enterprise/src/fusion/config/AssetRootStatus.cpp
+++ b/earth_enterprise/src/fusion/config/AssetRootStatus.cpp
@@ -65,9 +65,9 @@ AssetRootStatus::AssetRootStatus(const std::string &dirname,
 {
   // since this may be an old assetroot (owned by a different user)
   // we need to beef up our capabilities while making these checks
-  geCapabilitiesGuard cap_guard(
-      CAP_DAC_OVERRIDE,      // let me read all files
-      CAP_DAC_READ_SEARCH);  // let me traverse all dirs
+  // geCapabilitiesGuard cap_guard(
+   //   CAP_DAC_OVERRIDE,      // let me read all files
+   //   CAP_DAC_READ_SEARCH);  // let me traverse all dirs
 
   if (assetroot_.empty()) {
     return;

--- a/earth_enterprise/src/fusion/config/geconfigureassetroot.cpp
+++ b/earth_enterprise/src/fusion/config/geconfigureassetroot.cpp
@@ -333,11 +333,11 @@ void MakeNewAssetRoot(const AssetRootStatus &status,
 
   // escalate my permissions and try to create the assetroot
   {
-    geCapabilitiesGuard cap_guard(
-        CAP_DAC_OVERRIDE,     // let me read all files
-        CAP_DAC_READ_SEARCH,  // let me traverse all dirs
-        CAP_CHOWN,            // let me chown files
-        CAP_FOWNER);          // let me chmod files I dont own
+    // geCapabilitiesGuard cap_guard(
+    //     CAP_DAC_OVERRIDE,     // let me read all files
+    //     CAP_DAC_READ_SEARCH,  // let me traverse all dirs
+    //     CAP_CHOWN,            // let me chown files
+    //     CAP_FOWNER);          // let me chmod files I dont own
 
     if (MakeSpecialDirs(status.assetroot_, fusion_user, secure)) {
       // we had to chown some of them. There might be more too.
@@ -362,10 +362,10 @@ void MakeNewAssetRoot(const AssetRootStatus &status,
     // Need to create the source volume directory if it doesn't exist.
     if (!khDirExists(srcvol)) {
       geCapabilitiesGuard cap_guard(
-          CAP_DAC_OVERRIDE,     // let me read all files
-          CAP_DAC_READ_SEARCH,  // let me traverse all dirs
-          CAP_CHOWN,            // let me chown files
-          CAP_FOWNER);          // let me chmod files I dont own
+          // CAP_DAC_OVERRIDE,     // let me read all files
+          // CAP_DAC_READ_SEARCH,  // let me traverse all dirs
+          // CAP_CHOWN,            // let me chown files
+          // CAP_FOWNER);          // let me chmod files I dont own
       if (!khMakeDir(srcvol)) {
         notify(NFY_WARN, "Unable to create %s", srcvol.c_str());
       }

--- a/earth_enterprise/src/fusion/config/geconfigureassetroot.cpp
+++ b/earth_enterprise/src/fusion/config/geconfigureassetroot.cpp
@@ -361,7 +361,7 @@ void MakeNewAssetRoot(const AssetRootStatus &status,
   if (noprompt) {
     // Need to create the source volume directory if it doesn't exist.
     if (!khDirExists(srcvol)) {
-      geCapabilitiesGuard cap_guard(
+      //geCapabilitiesGuard cap_guard(
           // CAP_DAC_OVERRIDE,     // let me read all files
           // CAP_DAC_READ_SEARCH,  // let me traverse all dirs
           // CAP_CHOWN,            // let me chown files

--- a/earth_enterprise/src/fusion/config/geselectassetroot.cpp
+++ b/earth_enterprise/src/fusion/config/geselectassetroot.cpp
@@ -68,11 +68,12 @@ void usage(const char* prog, const char* msg = 0, ...) {
 enum Role { RoleMaster, RoleSlave };
 
 void SaveSystemrcOrThrow(const Systemrc &rc) {
-  geCapabilitiesGuard cap_guard(
-      CAP_DAC_OVERRIDE,     // let me read/write all files
-      CAP_DAC_READ_SEARCH,  // let me traverse all dirs
-      CAP_CHOWN,            // let me chown files
-      CAP_FOWNER);          // let me chmod files I dont own
+  // geCapabilitiesGuard cap_guard(
+  //     CAP_DAC_OVERRIDE,     // let me read/write all files
+  //     CAP_DAC_READ_SEARCH,  // let me traverse all dirs
+  //     CAP_CHOWN,            // let me chown files
+  //     CAP_FOWNER);          // let me chmod files I dont own
+  // 
   if (!rc.Save()) {
     throw khException(
         kh::tr("Unable to save systemrc"));

--- a/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/postgres_manager_wrap.py
+++ b/earth_enterprise/src/fusion/portableglobe/cutter/cgi-bin/common/postgres_manager_wrap.py
@@ -35,6 +35,7 @@ import postgres_properties
 
 class PostgresManagerWrap(object):
   DB_PORT = postgres_properties.PostgresProperties().GetPortNumber()
+  DB_HOST = postgres_properties.PostgresProperties().GetHost()
   DB_USER = "geuser"
 
   @staticmethod
@@ -52,7 +53,7 @@ class PostgresManagerWrap(object):
     db_con = postgres_manager.PostgresConnection(
         db,
         PostgresManagerWrap.DB_USER,
-        '/tmp',
+        PostgresManagerWrap.DB_HOST,
         PostgresManagerWrap.DB_PORT,
         logging.getLogger())
     results = db_con.Query(query, parameters)

--- a/earth_enterprise/src/server/wsgi/common/postgres_manager.py
+++ b/earth_enterprise/src/server/wsgi/common/postgres_manager.py
@@ -125,7 +125,19 @@ class PostgresConnection(object):
 
     with self._Cursor() as cursor:
       self._logger.debug(cursor.mogrify(query, parameters))
-      cursor.execute(query, parameters)
+      try: 
+          cursor.execute(query, parameters)
+      except psycopg2.ProgrammingError as exc:
+          print exc.message
+          self._logger.error(exc.message)
+          # conn.rollback()
+      except psycopg2.InterfaceError as exc:
+          print exc.message
+          # conn = psycopg2.connect(....)
+          # cursor = conn.cursor()
+
+
+
       self._logger.debug("ok: number of rows: %s", cursor.rowcount)
       for row in cursor:
         if len(row) == 1:

--- a/earth_enterprise/src/server/wsgi/common/postgres_properties.py
+++ b/earth_enterprise/src/server/wsgi/common/postgres_properties.py
@@ -16,6 +16,9 @@
 
 """Postgres database properties loader."""
 import utils
+import logging
+
+logger = logging.getLogger( "ge_stream_publisher")
 
 
 class PostgresProperties(object):
@@ -26,6 +29,10 @@ class PostgresProperties(object):
     self.port_number = utils.GetPostgresPortNumber()
     if not self.port_number:
       self.port_number = "5432"
+    self.host = utils.GetPostgresHost()
+    if not self.host:
+      self.host = "/tmp"
+    logger.info("Postgresql Connection configuration: host=%s, port= %s", self.host, self.port_number )
 
   def GetPortNumber(self):
     """Get the port number for the Postgres database.
@@ -34,3 +41,11 @@ class PostgresProperties(object):
       the port number string.
     """
     return self.port_number
+
+  def GetHost(self):
+    """Get the host for the Postgres database.
+
+    Returns:
+      the host number string.
+    """
+    return self.host

--- a/earth_enterprise/src/server/wsgi/common/utils.py
+++ b/earth_enterprise/src/server/wsgi/common/utils.py
@@ -274,6 +274,21 @@ def GetPostgresPortNumber():
 
   return None
 
+def GetPostgresHost():
+  """Gets Postgres host or unix domain socket from Host directive of postgres config file.
+
+  Returns:
+    Host number to connect to Postgres database server or None.
+  """
+  pattern = r"^\s*host\s*=\s*(\S{4,})\s*"
+
+  match = MatchPattern(POSTGRES_PROPERTIES_PATH, pattern)
+  if match:
+    host = match[0]
+    return host
+
+  return None
+
 
 def HtmlEscape(text):
   """Escapes a string for HTML.

--- a/earth_enterprise/src/server/wsgi/search/common/geconstants.py
+++ b/earth_enterprise/src/server/wsgi/search/common/geconstants.py
@@ -30,7 +30,7 @@ class Constants(object):
     self.defaults = {
         # database settings default values.
         "port": postgres_properties.PostgresProperties().GetPortNumber(),
-        "host": "127.0.0.1",
+        "host": postgres_properties.PostgresProperties().GetHost(),
         "user": "geuser",
         "minimumconnectionpoolsize": 1,
         "maximumconnectionpoolsize": 20,

--- a/earth_enterprise/src/server/wsgi/serve/push/search/core/search_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/push/search/core/search_manager.py
@@ -42,12 +42,12 @@ class SearchManager(object):
     super(SearchManager, self).__init__()
 
     # Init database connections
-    self._host = '/tmp'
     self._search_database = "gesearch"
     self._poi_database = "gepoi"
     self._db_user = "geuser"
     postgres_prop = postgres_properties.PostgresProperties()
     self._port = postgres_prop.GetPortNumber()
+    self._host = postgres_prop.GetHost()
 
     # Create DB connection to gesearch database.
     self._search_db_connection = postgres_manager.PostgresConnection(

--- a/earth_enterprise/src/server/wsgi/serve/snippets_db_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/snippets_db_manager.py
@@ -44,11 +44,12 @@ class SnippetsDbManager(object):
     super(SnippetsDbManager, self).__init__()
 
     # Init database connection.
-    self._host = '/tmp'
     self._snippets_db_name = "geendsnippet"
     self._db_user = "geuser"
     postgres_prop = postgres_properties.PostgresProperties()
     self._port = postgres_prop.GetPortNumber()
+    self._host = postgres_prop.GetHost()
+
 
     # Create DB connection to gesnippets database.
     self._snippets_db_connection = postgres_manager.PostgresConnection(

--- a/earth_enterprise/src/server/wsgi/serve/stream_manager.py
+++ b/earth_enterprise/src/server/wsgi/serve/stream_manager.py
@@ -59,6 +59,7 @@ class StreamManager(object):
     self._db_user = "geuser"
     postgres_prop = postgres_properties.PostgresProperties()
     self._port = postgres_prop.GetPortNumber()
+    self._host = postgres_prop.GetHost()
     self.stream_db = postgres_manager.PostgresConnection(
         self._database, self._db_user, self._host, self._port, logger)
 


### PR DESCRIPTION
Added 'host' option to PostgreSQL connection settings, defined in postgres.properties.  Default setting is still '/tmp', for unix-domain sockets, but changing it can support remote PostgreSQL connections, more suitable for clustered server deployments.  

To test: 
* Validate that the `geserveradmin --adddb ...` command works, as well as `--pushdb`, `--publishdb`, etc.  with the default configurations (i.e., no config changes) on a single GEE Server instance. 
* Validate functionality of the web admin console on the GEE Server.
* Configure a remote PostgreSQL database (Note: PostgreSQL config files (`/var/opt/google/pgsql/data/postgresql.conf` and `/var/opt/google/pgsql/data/pg_hba.conf` must be configured to allow the remote connections.  Also ensure that firewalls/security groups/VPC etc. allow remote connections.  )
* Configure a separate GEE Server to connect to that database, e.g. by adding `host=your.postgressqlhost.fqdn.net` to the `/opt/google/gehttpd/wsgi-bin/conf/postgres.properties` file. 
* Validate that the `geserveradmin --adddb ...` command works, as well as `--pushdb`, `--publishdb`, etc. work with the new configuration
* Validate functionality of the web admin console on the GEE Server works with the new configuration. 
