### PR TITLE
opengee-extra RPM fails to register plugin on when using peer authentication

### DIFF
--- a/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
@@ -24,7 +24,7 @@ main_postinstall()
         # Set up the ExampleSearch plugin. The opengee-server-core RPM does
         # this by calling geresetpgdb, but there's no need to do a full reset
         # here.
-       "$BASEINSTALLDIR_OPT/bin/psql" -q -d gesearch geuser -f "$SQLDIR/examplesearch.sql"
+        run_as_user "$GEPGUSER" "$BASEINSTALLDIR_OPT/bin/psql -q -d gesearch geuser -f $SQLDIR/examplesearch.sql"
 
         service geserver restart
     fi

--- a/earth_enterprise/rpms/opengee-extra/snippets/pre-uninstall.sh
+++ b/earth_enterprise/rpms/opengee-extra/snippets/pre-uninstall.sh
@@ -23,7 +23,7 @@ main_preuninstall()
     if [ -f "/etc/init.d/geserver" ]; then
         echo "Deleting SearchExample Database"
         run_as_user "$GEPGUSER" "/opt/google/share/searchexample/searchexample delete"
-        "$BASEINSTALLDIR_OPT/bin/psql" -q -d gesearch geuser -f "$SQLDIR/examplesearch_delete.sql"
+        run_as_user "$GEPGUSER"  "$BASEINSTALLDIR_OPT/bin/psql -q -d gesearch geuser -f $SQLDIR/examplesearch_delete.sql"
         service geserver restart
     fi
 

--- a/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
@@ -214,7 +214,7 @@ install_search_databases()
     #  If 'Extra' already installed, don't delete
     if [ ! -f "$SQLDIR/examplesearch_delete.sql" ]; then
         echo "# d) Turn off examplesearch"
-        "$BASEINSTALLDIR_OPT/bin/psql" -q -d gesearch geuser -f "$SQLDIR/examplesearch_2delete.sql"
+        run_as_user "$GEPGUSER" "$BASEINSTALLDIR_OPT/bin/psql -q -d gesearch geuser -f $SQLDIR/examplesearch_2delete.sql"
     fi
 
     # e) Stop the PSQL Server


### PR DESCRIPTION
If peer authentication is configured for PostgreSQL, the ExampleSearch will not be registered properly if the *NIX user is not in the user map. This change runs the command as `gepguser` to ensure it executes properly.