### PR TITLE
1868 Build Proxy HTTP Module

### DIFF
--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -130,7 +130,7 @@ config_opt += (
     '--with-crypto  '
     '--with-expat=/opt/google --with-mpm=worker --enable-proxy '
     '--enable-proxy-ajp --disable-proxy-connect --disable-proxy-ftp '
-    '--disable-proxy-http --disable-proxy-balancer --without-sqlite2 '
+    '--disable-proxy-balancer --without-sqlite2 '
     '--without-sqlite3 --without-mysql --with-ldap-include=%sinclude '
     '--with-ldap-lib=%s --with-ldap --enable-ldap --enable-authnz_ldap '
     '--with-included-apr '


### PR DESCRIPTION
The --disable-proxy-http flag was being passed, causing mod_proxy_http.so to not be built. Removing the flag ensures it's included properly.