### PR TITLE
Fix Asset Window MenuBar Overlap

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -215,7 +215,7 @@ shunit2 from the EPEL repositories for RHEL and CentOS 6.
 To do so run the following:
 
 ```bash
-sudo yum install -y http://download-ib01.fedoraproject.org/pub/epel/6/x86_64/Packages/s/shunit2-2.1.6-3.el6.noarch.rpm
+sudo yum install -y http://archives.fedoraproject.org/pub/archive/epel/6/x86_64/Packages/s/shunit2-2.1.6-3.el6.noarch.rpm
 ```
 
 ### RHEL 6 and CentOS 6

--- a/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
@@ -92,7 +92,7 @@ AssetBase::AssetBase(QWidget* parent)
   hidden_action_->addTo(edit_menu_);
   menu_bar_->insertItem(QString(""), edit_menu_, 2);
   
-  main_frame_layout_->setMenuBar(menu_bar);
+  main_frame_layout_->setMenuBar(menu_bar_);
 
   languageChange();
   //resize(QSize(545, 317).expandedTo(minimumSizeHint()));

--- a/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetBase.cpp
@@ -91,6 +91,8 @@ AssetBase::AssetBase(QWidget* parent)
   notes_action_->addTo(edit_menu_);
   hidden_action_->addTo(edit_menu_);
   menu_bar_->insertItem(QString(""), edit_menu_, 2);
+  
+  main_frame_layout_->setMenuBar(menu_bar);
 
   languageChange();
   //resize(QSize(545, 317).expandedTo(minimumSizeHint()));


### PR DESCRIPTION
In windows where assets are created, the menubar would overlap with the window contents. This fix forces the layout manager to take the menu bar into account, and put all child widgets below it.

To test:
1) Build and install fusion
2) Open windows to create new assets, projects, databases
3) Verify the menu bar (File/Edit Bar) does not overlap with any contents of the window.