### PR TITLE
Qt4 database push bug fix

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1271,7 +1271,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    QObject::connect(&push_thread, SIGNAL(sfinished()), &push_thread, SLOT(deleteLater()));
+    //QObject::connect(&push_thread, SIGNAL(sfinished()), &push_thread, SLOT(deleteLater()));
 
     push_thread.start();
     push_assistant.Start();
@@ -1401,7 +1401,7 @@ void AssetManager::PublishDatabase(const gstAssetHandle& handle) {
                      &publish_assistant, SLOT(SetCanceled()));
     QObject::connect(
         &publish_thread, SIGNAL(sfinished()), &publish_assistant, SLOT(Stop()));
-    QObject::connect(&publish_thread, SIGNAL(sfinished()), &publish_thread, SLOT(deleteLater()));
+    //QObject::connect(&publish_thread, SIGNAL(sfinished()), &publish_thread, SLOT(deleteLater()));
 
     publish_thread.start();
     publish_assistant.Start();

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -1271,7 +1271,7 @@ void AssetManager::PushDatabase(const gstAssetHandle& handle) {
     QObject::connect(&progress_dialog, SIGNAL(canceled()),
                      &push_assistant, SLOT(SetCanceled()));
     QObject::connect(&push_thread, SIGNAL(sfinished()), &push_assistant, SLOT(Stop()));
-    //QObject::connect(&push_thread, SIGNAL(sfinished()), &push_thread, SLOT(deleteLater()));
+    // TODO: may still need? QObject::connect(&push_thread, SIGNAL(sfinished()), &push_thread, SLOT(deleteLater()));
 
     push_thread.start();
     push_assistant.Start();
@@ -1401,7 +1401,7 @@ void AssetManager::PublishDatabase(const gstAssetHandle& handle) {
                      &publish_assistant, SLOT(SetCanceled()));
     QObject::connect(
         &publish_thread, SIGNAL(sfinished()), &publish_assistant, SLOT(Stop()));
-    //QObject::connect(&publish_thread, SIGNAL(sfinished()), &publish_thread, SLOT(deleteLater()));
+    // TODO: May still need? QObject::connect(&publish_thread, SIGNAL(sfinished()), &publish_thread, SLOT(deleteLater()));
 
     publish_thread.start();
     publish_assistant.Start();


### PR DESCRIPTION
Commenting out the two connect() lines that cause the segfaults. They don't seem to be required for cleanup, and databases are pushed successfully to the server.  It seems as though the push and publish threads are attempting to schedule themselves for deletion by themselves (?) but according to the Qt documentation it seems as though this should happen automatically when the dialog boxes are closed. 