### PR TITLE
Fix issues with external sites loading google maps

### DIFF
--- a/earth_enterprise/src/maps/api/bootstrap.js
+++ b/earth_enterprise/src/maps/api/bootstrap.js
@@ -1,11 +1,11 @@
 //  Copyright 2017 Google Inc.
-// 
+//
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
-// 
+//
 //       http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,21 +22,28 @@ google.maps = google.maps || {};
     document.write('<script src="' + src +
                    '" type="text/javascript"></script>');
   }
-  
+
   GEE_API_PATH = '/maps/api/js';
   FUSION_API_PATH = '/maps/api';
 
   google.maps.Load = function(apiLoad) {
-    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',],[GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
+    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',
+                                                        GEE_BASE_URL /* GE metrics */,
+                                                        ,
+                                                        GEE_BASE_URL /* GE metrics */],
+                                                        [GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
   };
 
   var loadScriptTime = (new Date).getTime();
 
-  getScript(GEE_BASE_URL + '/js/jquery.js');
+  // Only load jQuery if it isn't loaded already.
+  if (!window.jQuery) {
+    getScript(GEE_BASE_URL + '/js/jquery.js');
+  }
+
   getScript(GEE_BASE_URL + GEE_API_PATH + '/main.js');
   getScript(GEE_BASE_URL + GEE_API_PATH + '/../fusion_map_obj_v3.js');
 
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_extended_map.js');
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_utils.js');
 })();
-

--- a/earth_enterprise/src/maps/api/fusion_extended_map.js
+++ b/earth_enterprise/src/maps/api/fusion_extended_map.js
@@ -181,9 +181,14 @@ function geeMapImageryFunc(
  */
 function geeMapEmptyTileFunc() {
   return function(coord, zoom) {
+
+    // If the map isn't hosted on a GE server, use base Url
+    // to point to the GE server.
+    var baseURL = GEE_BASE_URL || "";
+
     // This path should work on both Enterprise and Portable servers.
     // To use a plain medium gray tile instead, simply return null.
-    return "/shared_assets/images/empty4.png";
+    return baseURL + "/shared_assets/images/empty4.png";
   };
 }
 

--- a/earth_enterprise/src/maps/mapfiles/310/bootstrap.js
+++ b/earth_enterprise/src/maps/mapfiles/310/bootstrap.js
@@ -22,12 +22,16 @@ google.maps = google.maps || {};
     document.write('<script src="' + src +
                    '" type="text/javascript"></script>');
   }
-  
+
   GEE_API_PATH='/maps/mapfiles/310/v3';
   FUSION_API_PATH='/maps/api';
 
   google.maps.Load = function(apiLoad) {
-    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',],[GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
+    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',
+                                                        GEE_BASE_URL /* GE metrics */,
+                                                        ,
+                                                        GEE_BASE_URL /* GE metrics */],
+                                                        [GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
   };
 
   var loadScriptTime = (new Date).getTime();
@@ -38,4 +42,3 @@ google.maps = google.maps || {};
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_extended_map.js');
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_utils.js');
 })();
-

--- a/earth_enterprise/src/maps/mapfiles/360/bootstrap.js
+++ b/earth_enterprise/src/maps/mapfiles/360/bootstrap.js
@@ -22,12 +22,16 @@ google.maps = google.maps || {};
     document.write('<script src="' + src +
                    '" type="text/javascript"></script>');
   }
-  
+
   GEE_API_PATH='/maps/mapfiles/360/v3';
   FUSION_API_PATH='/maps/api';
 
   google.maps.Load = function(apiLoad) {
-    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',],[GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
+    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',
+                                                        GEE_BASE_URL /* GE metrics */,
+                                                        ,
+                                                        GEE_BASE_URL /* GE metrics */],
+                                                        [GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
   };
 
   var loadScriptTime = (new Date).getTime();
@@ -38,4 +42,3 @@ google.maps = google.maps || {};
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_extended_map.js');
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_utils.js');
 })();
-

--- a/earth_enterprise/src/maps/mapfiles/390/bootstrap.js
+++ b/earth_enterprise/src/maps/mapfiles/390/bootstrap.js
@@ -22,12 +22,16 @@ google.maps = google.maps || {};
     document.write('<script src="' + src +
                    '" type="text/javascript"></script>');
   }
-  
+
   GEE_API_PATH='/maps/mapfiles/390/v3';
   FUSION_API_PATH='/maps/api';
 
   google.maps.Load = function(apiLoad) {
-    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',],[GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
+    /* http://mt0.google.com/vt */    apiLoad([,[,,,],['en-US',,,,,,GEE_BASE_URL + '/maps/api/icons/',
+                                                        GEE_BASE_URL /* GE metrics */,
+                                                        ,
+                                                        GEE_BASE_URL /* GE metrics */],
+                                                        [GEE_BASE_URL + GEE_API_PATH,'internal'],[0],0.0,,,,,], loadScriptTime);
   };
 
   var loadScriptTime = (new Date).getTime();
@@ -38,4 +42,3 @@ google.maps = google.maps || {};
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_extended_map.js');
   getScript(GEE_BASE_URL + FUSION_API_PATH + '/fusion_utils.js');
 })();
-


### PR DESCRIPTION
Fix issues with applications using Fusion Maps API when they aren't hosted on the GEE Server.

- Fusion maps reloads jQuery, which wipes out the version loaded by application including plugins
- Empty tile image grabbed from the application's server rather than GEE
- Google metrics being sent to application server rather than to GEE

Fixes #1902