### PR TITLE
1891 update libcurl

### DIFF
--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -214,7 +214,6 @@ else:
     python_home = '/usr'
 
 # setup platform specific operations
-is_os_ubuntu = False
 is_min_ubuntu = True
 # /etc/issue was the previous method of checking Ubuntu release version
 # however, some flavors of Ubuntu e.g. MATE, have used varying formats

--- a/earth_enterprise/src/SConstruct
+++ b/earth_enterprise/src/SConstruct
@@ -218,23 +218,17 @@ is_os_ubuntu = False
 is_min_ubuntu = True
 # /etc/issue was the previous method of checking Ubuntu release version
 # however, some flavors of Ubuntu e.g. MATE, have used varying formats
-# using ilsb_release, subprocess and re is more readable than awk parsing also
-try:
-  vstring=subprocess.check_output('lsb_release -i',shell=True)
-  system=re.split('[\t\.\n]',vstring)
-  if system[1] == "Ubuntu":
-    is_os_ubuntu = True
+# using lsb_release, subprocess and re is more readable than awk parsing also
+if not os.path.isfile('/etc/redhat-release'):
   vstring=subprocess.check_output('lsb_release -r',shell=True)
   arr=re.split('[\t\.\n]',vstring)
   major=int(arr[1])
   minor=int(arr[2])
   el_ver = ''
-  if arr[1] < 16:
+  if major < 16:
     print 'Unknown Ubuntu version, minimum required version is 16.04.'
     Exit(1)
-    is_min_ubuntu = False
-# lsb_release is not present, must be RHEL or CentOS, move on
-except:
+else:
     print "OS is not Ubuntu"
 
 extragccflags = []

--- a/earth_enterprise/src/third_party/apache2/apache-ge-httpd-ssl.conf.in.patch
+++ b/earth_enterprise/src/third_party/apache2/apache-ge-httpd-ssl.conf.in.patch
@@ -18,7 +18,7 @@
 -SSLProtocol all -SSLv3
 +#SSLProtocol all -SSLv3
 +# Limit SSL protocols.
-+SSLProtocol -ALL +TLSv1.2 +SSLv3 +TLSv1
++SSLProtocol -ALL +TLSv1.2 +TLSv1
  SSLProxyProtocol all -SSLv3
  
  #   Pass Phrase Dialog:

--- a/earth_enterprise/src/third_party/libcurl/SConscript
+++ b/earth_enterprise/src/third_party/libcurl/SConscript
@@ -1,6 +1,7 @@
 #-*- Python -*-
 #
 # Copyright 2017 Google Inc.
+# Copyright 2021 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@
 
 
 Import('third_party_env')
-libcurl_version = 'curl-7.45.0'
+libcurl_version = 'curl-7.74.0'
 ge_version = libcurl_version.replace('curl', 'curl-ge')
 
 num_cpu = GetOption('num_jobs')

--- a/earth_enterprise/src/third_party/mod_wsgi/SConscript
+++ b/earth_enterprise/src/third_party/mod_wsgi/SConscript
@@ -95,6 +95,9 @@ else:
                     mod_wsgi_env['ENV']['mod_env'], env_opt, config_opt, root_dir,
                     mod_wsgi_target))
 
+print('AAAA> el_ver: ' + mod_wsgi_env['el_ver'])
+print('AAAA> configure_cmd: ' + configure_cmd)
+
 
 
 mod_wsgi_configure = mod_wsgi_env.Command(

--- a/earth_enterprise/src/third_party/mod_wsgi/SConscript
+++ b/earth_enterprise/src/third_party/mod_wsgi/SConscript
@@ -95,9 +95,6 @@ else:
                     mod_wsgi_env['ENV']['mod_env'], env_opt, config_opt, root_dir,
                     mod_wsgi_target))
 
-print('AAAA> el_ver: ' + mod_wsgi_env['el_ver'])
-print('AAAA> configure_cmd: ' + configure_cmd)
-
 
 
 mod_wsgi_configure = mod_wsgi_env.Command(

--- a/earth_enterprise/third_party/libcurl/README.google
+++ b/earth_enterprise/third_party/libcurl/README.google
@@ -1,5 +1,5 @@
 URL:  http://curl.haxx.se
-Version: 7.45.0
+Version: 7.74.0
 License: MIT/X
 License File: COPYING
 Description: curl is a command line tool for transferring files with URL

--- a/earth_enterprise/third_party/libcurl/curl-7.45.0.tar.gz
+++ b/earth_enterprise/third_party/libcurl/curl-7.45.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02c78c8060d587422e2826f622c729189b56084bba365140f13af3d402b6cb6b
-size 4516213

--- a/earth_enterprise/third_party/libcurl/curl-7.74.0.tar.gz
+++ b/earth_enterprise/third_party/libcurl/curl-7.74.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e56b3921eeb7a2951959c02db0912b5fcd5fdba5aca071da819e1accf338bbd7
+size 4043409


### PR DESCRIPTION
These are a few changes related to the upcoming OpenSSL 1.1.1 upgrade.

* The most significant is an upgrade to the bundled libcurl to the latest upstream version, 4.74.0
* Disabling SSLv3 in Apache
* A small fix to the mod_wsgi configuration that fixes a bug on EL 6 platforms.