### PR TITLE
Limit / correct assetmanager window size

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.cpp
@@ -563,6 +563,13 @@ AssetManager::AssetManager(QWidget* parent)
       subtypeCombo->setCurrentItem(filter_subtype_);
 
       // update position
+      if(layout_persist_.width > 4000 || layout_persist_.width < 100) {
+          layout_persist_.width = DEFAULT_WINDOW_WIDTH;
+      }
+      if(layout_persist_.height > 4000 || layout_persist_.height < 100) {
+          layout_persist_.height = DEFAULT_WINDOW_HEIGHT;
+      }
+
       resize(layout_persist_.width, layout_persist_.height);
       move(layout_persist_.xpos, layout_persist_.ypos);
 

--- a/earth_enterprise/src/fusion/fusionui/AssetManager.h
+++ b/earth_enterprise/src/fusion/fusionui/AssetManager.h
@@ -45,6 +45,9 @@ using QListViewItem = Q3ListViewItem;
 #define ASSET_MANAGER  0x00ff0001
 #define ASSET_FOLDER   0x00ff0002
 
+#define DEFAULT_WINDOW_HEIGHT 646
+#define DEFAULT_WINDOW_WIDTH 816
+
 class AssetBase;
 class AssetChanges;
 class geGuiProgress;

--- a/earth_enterprise/src/fusion/fusionui/assetmanagerbase.ui
+++ b/earth_enterprise/src/fusion/fusionui/assetmanagerbase.ui
@@ -23,6 +23,18 @@
             <height>646</height>
         </rect>
     </property>
+    <property name="maximumSize">
+        <size>
+            <width>3000</width>
+            <height>3000</height>
+        </size>
+    </property>
+    <property name="minimumSize">
+        <size>
+            <width>50</width>
+            <height>50</height>
+        </size>
+    </property>
     <property name="caption">
         <string>Asset Manager</string>
     </property>


### PR DESCRIPTION
Verification steps:
1. Cannot stretch the assetmanager window to be wider or taller than 3000 pixels
2. While fusionui is not running, edit ~/.fusion/assetmanager.layout to have a width of some enormous size such as 100000
3. Relaunch fusionui. It does not segfault. Open assetmanager. It is a normal size. 
4. Click on a couple of things and maybe resize the assetmanager window and then close it. Open assetmanager.layout again. The incorrect size is set to something more normal