### PR TITLE
Upgrade to OpenSSL 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
       libstdc++6 libtool libgif-dev libtiff-dev libgtk2.0-dev libglib2.0-dev
       libx11-dev libxcursor-dev libxerces-c-dev libxft-dev libxinerama-dev
       libxml2-dev libxml2-utils libxmu-dev libxrandr-dev libyaml-cpp-dev libpcre3-dev
-    openssl shunit2 git git-lfs libqt4-dev qt4-default libqt4-opengl-dev
+    shunit2 git git-lfs libqt4-dev qt4-default libqt4-opengl-dev
     python-dev python-git python-imaging python-setuptools python-psycopg2 python-lxml
     swig xorg-dev zlib1g-dev
 script: echo "Running build..."

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -138,7 +138,7 @@ sudo yum install -y \
   gdbm-devel geos-devel giflib-devel glib2-devel GitPython gtk2-devel \
   libcap-devel libicu-devel libmng-devel libpng-devel libtiff-devel libX11-devel libXcursor-devel \
   libXft-devel libXinerama-devel libxml2-devel libXmu-devel libXrandr-devel \
-  ogdi-devel openjpeg-devel openjpeg2-devel openssl-devel \
+  ogdi-devel openjpeg-devel openjpeg2-devel \
   perl-Alien-Packages perl-Perl4-CoreLibs proj-devel python-devel \
   rpm-build rpmrebuild rsync scons \
   xerces-c xerces-c-devel xorg-x11-server-devel yaml-cpp-devel zlib-devel
@@ -154,7 +154,7 @@ sudo yum install -y \
   gdbm-devel geos-devel gettext giflib-devel gtk2-devel \
   libcap-devel libmng-devel libpng-devel libX11-devel libXcursor-devel \
   libXft-devel libXinerama-devel libxml2-devel libXmu-devel libXrandr-devel \
-  ogdi-devel openjpeg-devel openjpeg2-devel openssl-devel pcre pcre-devel \
+  ogdi-devel openjpeg-devel openjpeg2-devel pcre pcre-devel \
   proj-devel python27 glib2-devel libtiff-devel \
   python27-pip python27-devel python27-setuptools python-unittest2 \
   python-devel rpm-build rpmrebuild rsync scons shunit2 \

--- a/earth_enterprise/BUILD_Ubuntu.md
+++ b/earth_enterprise/BUILD_Ubuntu.md
@@ -38,7 +38,7 @@ sudo apt-get install \
     libstdc++6 libtool libgif-dev libtiff-dev libgtk2.0-dev libglib2.0-dev \
     libx11-dev libxcursor-dev libxerces-c-dev libxft-dev libxinerama-dev \
     libxml2-dev libxml2-utils libxmu-dev libxrandr-dev libyaml-cpp-dev \
-    openssl libpcre3 libpcre3-dev \
+    libpcre3 libpcre3-dev \
     python-dev python-imaging python-psycopg2 \
     python-setuptools python2.7 python2.7-dev python-git \
     scons shunit2 xorg-dev zlib1g-dev

--- a/earth_enterprise/BUILD_Ubuntu.md
+++ b/earth_enterprise/BUILD_Ubuntu.md
@@ -35,7 +35,7 @@ sudo apt-get install \
     libgdbm-dev libgeos-dev libgeos++-dev libgif-dev libgtest-dev \
     libjpeg-dev libjpeg8-dev libmng-dev libogdi3.2-dev \
     libperl4-corelibs-perl libpng12-0 libpng12-dev libpq-dev libproj-dev \
-    libstdc++6 libtool libgif-dev libtiff-dev libgtk2.0-dev libglib2.0-dev \
+    libstdc++6 libtool libtiff-dev libgtk2.0-dev libglib2.0-dev \
     libx11-dev libxcursor-dev libxerces-c-dev libxft-dev libxinerama-dev \
     libxml2-dev libxml2-utils libxmu-dev libxrandr-dev libyaml-cpp-dev \
     libpcre3 libpcre3-dev \

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2017 - 2020 the Open GEE Contributors
+// Copyright 2017 - 2021 the Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -932,6 +932,7 @@ task openGeeExtraInitScripts(type: Copy, dependsOn: openGeeSharedFiles) {
 
     CopySpecTemplates.expand(delegate, [
             'openGeeVersion': ospackage.version,
+            'openGeeRelease': ospackage.release,
             'project': project
         ])
 }

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -258,7 +258,16 @@ task openGeePostGisRpm(type: GeeRpm) {
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
+    // In this case, opengee-postgis doesn't have a pre- or post-install script
+    // to worry about, but we do need to make sure that opengee-common's
+    // pre-install script runs first.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
+
     // The code in GeeRpm decides that this RPM should depend on proj, but
     // it actually depends on proj-devel.
     requires('proj-devel')
@@ -535,9 +544,14 @@ task openGeeServerRpm(type: GeeRpm, dependsOn: openGeeServerInitScripts) {
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
     requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
     requires('opengee-postgis', '2.3.9', GREATER | EQUAL)
+    requiresPre('opengee-postgis', '2.3.9', GREATER | EQUAL)
     conflicts('opengee-postgis', '2.0', LESS )
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
     requires('python-unittest2')
@@ -769,7 +783,12 @@ built from raster, vector, and location properties data.
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
     requires('proj-devel') /* This dependency is not being picked up automatically by GeeRpm task */
     requires('/etc/rc.d/init.d/functions')
     requiresCommands(
@@ -937,13 +956,10 @@ task openGeeExtraRpm(type: GeeRpm, dependsOn: openGeeExtraInitScripts) {
     autoFindRequiresFilter = rpmCapabilityFilter
     requiresCommandFilter = rpmCommandFilter
 
-    // opengee-extra can be installed independently, but if Server or Fusion
-    // have been previously installed they must be upgraded before upgrading
-    // opengee-extra. This is because extra will use binaries installed by
-    // Server and Fusion if they are available to set up the tutorial volume
-    // and install example search.
-    conflicts('opengee-server', ospackage.version, LESS)
-    conflicts('opengee-fusion', ospackage.version, LESS)
+    // This package contains files that were in opengee-server and
+    // opengee-fusion in versions 5.3.4.1 and before.
+    conflicts('opengee-server', "5.3.4.1", LESS | EQUAL)
+    conflicts('opengee-fusion', "5.3.4.1", LESS | EQUAL)
 
     postInstall = file("${buildDir}/opengee-extra/post-install.sh")
     preUninstall = file("${buildDir}/opengee-extra/pre-uninstall.sh")
@@ -1039,13 +1055,10 @@ task openGeeExtraDeb(type: GeeDeb, dependsOn: openGeeExtraInitScripts) {
     license = openGeeExtraRpm.license
     url = openGeeExtraRpm.url
 
-    // opengee-extra can be installed independently, but if Server or Fusion
-    // have been previously installed they must be upgraded before upgrading
-    // opengee-extra. This is because extra will use binaries installed by
-    // Server and Fusion if they are available to set up the tutorial volume
-    // and install example search.
-    conflicts('opengee-server', ospackage.version, LESS)
-    conflicts('opengee-fusion', ospackage.version, LESS)
+    // This package contains files that were in opengee-server and
+    // opengee-fusion in versions 5.3.4.1 and before.
+    conflicts('opengee-server', "5.3.4.1", LESS | EQUAL)
+    conflicts('opengee-fusion', "5.3.4.1", LESS | EQUAL)
 
     postInstallFile file("${buildDir}/opengee-extra/post-install.sh")
     preUninstallFile file("${buildDir}/opengee-extra/pre-uninstall.sh")

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -937,10 +937,13 @@ task openGeeExtraRpm(type: GeeRpm, dependsOn: openGeeExtraInitScripts) {
     autoFindRequiresFilter = rpmCapabilityFilter
     requiresCommandFilter = rpmCommandFilter
 
-    // This package contains files that were in opengee-server and
-    // opengee-fusion in versions 5.3.4.1 and before.
-    conflicts('opengee-server', "5.3.4.1", LESS | EQUAL)
-    conflicts('opengee-fusion', "5.3.4.1", LESS | EQUAL)
+    // opengee-extra can be installed independently, but if Server or Fusion
+    // have been previously installed they must be upgraded before upgrading
+    // opengee-extra. This is because extra will use binaries installed by
+    // Server and Fusion if they are available to set up the tutorial volume
+    // and install example search.
+    conflicts('opengee-server', ospackage.version, LESS)
+    conflicts('opengee-fusion', ospackage.version, LESS)
 
     postInstall = file("${buildDir}/opengee-extra/post-install.sh")
     preUninstall = file("${buildDir}/opengee-extra/pre-uninstall.sh")
@@ -1036,10 +1039,13 @@ task openGeeExtraDeb(type: GeeDeb, dependsOn: openGeeExtraInitScripts) {
     license = openGeeExtraRpm.license
     url = openGeeExtraRpm.url
 
-    // This package contains files that were in opengee-server and
-    // opengee-fusion in versions 5.3.4.1 and before.
-    conflicts('opengee-server', "5.3.4.1", LESS | EQUAL)
-    conflicts('opengee-fusion', "5.3.4.1", LESS | EQUAL)
+    // opengee-extra can be installed independently, but if Server or Fusion
+    // have been previously installed they must be upgraded before upgrading
+    // opengee-extra. This is because extra will use binaries installed by
+    // Server and Fusion if they are available to set up the tutorial volume
+    // and install example search.
+    conflicts('opengee-server', ospackage.version, LESS)
+    conflicts('opengee-fusion', ospackage.version, LESS)
 
     postInstallFile file("${buildDir}/opengee-extra/post-install.sh")
     preUninstallFile file("${buildDir}/opengee-extra/pre-uninstall.sh")

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -147,7 +147,10 @@ def stagedInstallDir_postgis_opt = new File(stagedInstallDir, 'postgis/opt')
 // Commands used in install-utils.sh:
 def packageSharedCommands = ['bash', 'flock', 'sed', 'xmllint']
 
-// Since </bin> is symlinked to </usr/bin> on Cent OS 7, some
+// Since some libraries (i.e., MrSid)  cannot be redistributed without
+// a license and are not packaged as an RPM, we need to filter these
+// out from the automatic 'requires' dependency generation.
+//     Since </bin> is symlinked to </usr/bin> on Cent OS 7, some
 // build scripts misdetect the location of interpreters and utilities,
 // such as `perl` and `sudo`.  The RPM packages for those utilities
 // only provide RPM capabilities at the canonical paths
@@ -157,6 +160,7 @@ def packageSharedCommands = ['bash', 'flock', 'sed', 'xmllint']
 // Capabilities mapped to `null` are removed from the dependency list.
 // The ones mapped to strings are rewritten.
 def rpmCapabilityMap = [
+    'libltidsdk.so()(64bit)': null,
     '/bin/perl': '/usr/bin/perl',
     '/bin/python': '/usr/bin/python',
     '/bin/sudo': '/usr/bin/sudo'

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -147,10 +147,7 @@ def stagedInstallDir_postgis_opt = new File(stagedInstallDir, 'postgis/opt')
 // Commands used in install-utils.sh:
 def packageSharedCommands = ['bash', 'flock', 'sed', 'xmllint']
 
-// Since some libraries (i.e., MrSid)  cannot be redistributed without
-// a license and are not packaged as an RPM, we need to filter these
-// out from the automatic 'requires' dependency generation.
-//     Since </bin> is symlinked to </usr/bin> on Cent OS 7, some
+// Since </bin> is symlinked to </usr/bin> on Cent OS 7, some
 // build scripts misdetect the location of interpreters and utilities,
 // such as `perl` and `sudo`.  The RPM packages for those utilities
 // only provide RPM capabilities at the canonical paths
@@ -160,7 +157,6 @@ def packageSharedCommands = ['bash', 'flock', 'sed', 'xmllint']
 // Capabilities mapped to `null` are removed from the dependency list.
 // The ones mapped to strings are rewritten.
 def rpmCapabilityMap = [
-    'libltidsdk.so()(64bit)': null,
     '/bin/perl': '/usr/bin/perl',
     '/bin/python': '/usr/bin/python',
     '/bin/sudo': '/usr/bin/sudo'

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -463,7 +463,6 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeCommonInitScripts) {
     requires('libstdc++6')
     requires('libtool')
     requires('libxml2-utils')
-    requires('openssl')
     requires('python-imaging')
     requires('python-lxml')
     requires('python-psycopg2')

--- a/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 The Open GEE Contributors
+# Copyright 2020 - 2021 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
@@ -18,7 +18,19 @@ umask 002
 
 main_postinstall()
 {
-    if [ -f "/etc/init.d/geserver" ]; then
+    # Check if opengee-fusion and opengee-server are the expected version. If
+    # not, we may be in the middle of an upgrade with incompatible libraries
+    # and binaries. In that case, we skip the steps below and let
+    # opengee-fusion and opengee-server take care of them.
+    EXTRA_VERSION="${CURRENT_VERSION}"
+    SERVER_VERSION=$(get_package_version opengee-server)
+    FUSION_VERSION=$(get_package_version opengee-fusion)
+
+    echo "${EXTRA_VERSION}"
+    echo "${SERVER_VERSION}"
+    echo "${FUSION_VERSION}"
+
+    if [ "$SERVER_VERSION" == "$EXTRA_VERSION" ]; then
         install_searchexample_database
 
         # Set up the ExampleSearch plugin. The opengee-server-core RPM does
@@ -27,12 +39,16 @@ main_postinstall()
         run_as_user "$GEPGUSER" "$BASEINSTALLDIR_OPT/bin/psql -q -d gesearch geuser -f $SQLDIR/examplesearch.sql"
 
         service geserver restart
+    else
+        echo "Skipping example search set up. It will be set up when opengee-server-${EXTRA_VERSION} is installed."
     fi
 
-    if [ -f "/etc/init.d/gefusion" ]; then
+    if [ "$FUSION_VERSION" == "$EXTRA_VERSION" ]; then
         service gefusion stop
         add_fusion_tutorial_volume
         service gefusion start
+    else
+        echo "Skipping tutorial volume set up. It will be set up when opengee-fusion-${EXTRA_VERSION} is installed."
     fi
 }
 

--- a/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-extra/snippets/post-install.sh
@@ -26,10 +26,6 @@ main_postinstall()
     SERVER_VERSION=$(get_package_version opengee-server)
     FUSION_VERSION=$(get_package_version opengee-fusion)
 
-    echo "${EXTRA_VERSION}"
-    echo "${SERVER_VERSION}"
-    echo "${FUSION_VERSION}"
-
     if [ "$SERVER_VERSION" == "$EXTRA_VERSION" ]; then
         install_searchexample_database
 

--- a/earth_enterprise/rpms/opengee-extra/src/post-install.sh.template
+++ b/earth_enterprise/rpms/opengee-extra/src/post-install.sh.template
@@ -2,6 +2,7 @@
     // Prefix variable definitions to install script:
     new File("${project.buildDir}/shared/install-utils.sh").text
 %>
+CURRENT_VERSION=<%= openGeeVersion %>-<%= openGeeRelease %>.x86_64
 <%= new File("${project.buildDir}/shared/searchexample.sh").text %>
 <%= new File("${project.buildDir}/shared/fusiontutorial.sh").text %>
 <%= new File(thisTemplateFile.parent, '../snippets/post-install.sh').text %>

--- a/earth_enterprise/rpms/shared/snippets/install-utils-main.sh
+++ b/earth_enterprise/rpms/shared/snippets/install-utils-main.sh
@@ -100,3 +100,18 @@ run_as_user()
         ( cd / ;sudo -u $1 $2 )
     fi
 }
+
+get_package_version()
+{
+    local PACKAGE_NAME="${1}"
+    # Declare variable first; otherwise $? will be the exit code of local,
+    # which is always 0
+    local FULL_VERSION
+    FULL_VERSION=`rpm -q "${PACKAGE_NAME}"`
+    if [ $? -eq 0 ]; then
+        # Strip off the package name and return just the version
+        echo ${FULL_VERSION#"$PACKAGE_NAME-"}
+    else
+        echo "None"
+    fi
+}

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -588,6 +588,9 @@ copy_files_to_target()
 	mkdir -p $BASEINSTALLDIR_OPT/share/fonts
 	mkdir -p $BASEINSTALLDIR_OPT/gepython
 	mkdir -p $BASEINSTALLDIR_OPT/lib
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/private
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/misc
+	mkdir -p $BASEINSTALLDIR_VAR/openssl/certs
 	mkdir -p $BASEINSTALLDIR_ETC/openldap
 	mkdir -p $BASEINSTALLDIR_VAR/run
 	mkdir -p $BASEINSTALLDIR_VAR/log
@@ -617,6 +620,19 @@ copy_files_to_target()
 	cp -f $TMPINSTALLDIR/fusion/etc/profile.d/ge-fusion.sh $BININSTALLPROFILEDIR
 	if [ $? -ne 0 ]; then error_on_copy=1; fi
 	cp -f $TMPINSTALLDIR/fusion/etc/init.d/gefusion $BININSTALLROOTDIR
+
+	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+
+	cp -f $TMPOPENSSLPATH/openssl.cnf $BASEINSTALLDIR_VAR/openssl
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf $TMPOPENSSLPATH/private $BASEINSTALLDIR_VAR/openssl
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f $TMPOPENSSLPATH/misc/tsget $BASEINSTALLDIR_VAR/openssl/misc
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -f $TMPOPENSSLPATH/misc/CA.pl $BASEINSTALLDIR_VAR/openssl/misc
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
+	cp -rf $TMPOPENSSLPATH/certs $BASEINSTALLDIR_VAR/openssl
+	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
 	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
 

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -588,9 +588,6 @@ copy_files_to_target()
 	mkdir -p $BASEINSTALLDIR_OPT/share/fonts
 	mkdir -p $BASEINSTALLDIR_OPT/gepython
 	mkdir -p $BASEINSTALLDIR_OPT/lib
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/private
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/misc
-	mkdir -p $BASEINSTALLDIR_VAR/openssl/certs
 	mkdir -p $BASEINSTALLDIR_ETC/openldap
 	mkdir -p $BASEINSTALLDIR_VAR/run
 	mkdir -p $BASEINSTALLDIR_VAR/log
@@ -620,29 +617,6 @@ copy_files_to_target()
 	cp -f $TMPINSTALLDIR/fusion/etc/profile.d/ge-fusion.sh $BININSTALLPROFILEDIR
 	if [ $? -ne 0 ]; then error_on_copy=1; fi
 	cp -f $TMPINSTALLDIR/fusion/etc/init.d/gefusion $BININSTALLROOTDIR
-
-	TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
-
-	cp -f $TMPOPENSSLPATH/openssl.cnf $BASEINSTALLDIR_VAR/openssl
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf $TMPOPENSSLPATH/private $BASEINSTALLDIR_VAR/openssl
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/CA.sh $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/tsget $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/c_name $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/CA.pl $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/c_issuer $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/c_info $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -f $TMPOPENSSLPATH/misc/c_hash $BASEINSTALLDIR_VAR/openssl/misc
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
-	cp -rf $TMPOPENSSLPATH/certs $BASEINSTALLDIR_VAR/openssl
-	if [ $? -ne 0 ]; then error_on_copy=1; fi
 
 	TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap
 
@@ -990,4 +964,3 @@ main_install
 # Post-Install Main
 #-----------------------------------------------------------------
 main_postinstall
-

--- a/earth_enterprise/src/installer/install_fusion.sh
+++ b/earth_enterprise/src/installer/install_fusion.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Copyright 2017 Google Inc.
-# Copyright 2018-2020 Open GEE Contributors
+# Copyright 2018-2021 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Google Inc., 2018-2019 Open GEE Contributors
+# Copyright 2017 Google Inc., 2018-2021 Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -428,9 +428,6 @@ copy_files_to_target()
   mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
   mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
   mkdir -p "$BASEINSTALLDIR_OPT/search"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
-  mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
   mkdir -p "$BASEINSTALLDIR_ETC/openldap"
   mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
 
@@ -490,29 +487,6 @@ copy_files_to_target()
   cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-
-  TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
-
-  cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/CA.sh" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_name" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_issuer" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_info" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -f "$TMPOPENSSLPATH/misc/c_hash" "$BASEINSTALLDIR_VAR/openssl/misc"
-  if [ $? -ne 0 ]; then error_on_copy=1; fi
-  cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
 
   TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap

--- a/earth_enterprise/src/installer/install_server.sh
+++ b/earth_enterprise/src/installer/install_server.sh
@@ -428,6 +428,9 @@ copy_files_to_target()
   mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/conf"
   mkdir -p "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
   mkdir -p "$BASEINSTALLDIR_OPT/search"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/private"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/misc"
+  mkdir -p "$BASEINSTALLDIR_VAR/openssl/certs"
   mkdir -p "$BASEINSTALLDIR_ETC/openldap"
   mkdir -p "$BASEINSTALLDIR_VAR/pgsql"
 
@@ -487,6 +490,19 @@ copy_files_to_target()
   cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/conf/gehttpd.conf" "$BASEINSTALLDIR_OPT/gehttpd/conf"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
   cp -rf "$TMPINSTALLDIR/server/opt/google/gehttpd/htdocs/shared_assets/images/location_pin.png" "$BASEINSTALLDIR_OPT/gehttpd/htdocs/shared_assets/images"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+
+  TMPOPENSSLPATH=$TMPINSTALLDIR/common/user_magic/var/opt/google/openssl
+
+  cp -f "$TMPOPENSSLPATH/openssl.cnf" "$BASEINSTALLDIR_VAR/openssl"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPOPENSSLPATH/private" "$BASEINSTALLDIR_VAR/openssl"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/tsget" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -f "$TMPOPENSSLPATH/misc/CA.pl" "$BASEINSTALLDIR_VAR/openssl/misc"
+  if [ $? -ne 0 ]; then error_on_copy=1; fi
+  cp -rf "$TMPOPENSSLPATH/certs" "$BASEINSTALLDIR_VAR/openssl"
   if [ $? -ne 0 ]; then error_on_copy=1; fi
 
   TMPOPENLDAPPATH=$TMPINSTALLDIR/common/user_magic/etc/opt/google/openldap

--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -1,6 +1,7 @@
 #-*- Python -*-
 #
 # Copyright 2017 Google Inc.
+# Copyright 2021 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -158,9 +158,6 @@ to_prune_http = ['man', 'error', 'bin/htdbm',
                  'htdocs/apache_pb.gif', 'htdocs/index.html'
                 ]
 
-# Note: used when compiling with crosstool
-# TODO: delete.
-#stdc = '/opt/google/lib64/libstdc++.so.6'
 apache_target = '%s/.install' % current_dir
 apache_install = apache_env.Command(
     apache_target, apache_configure,

--- a/earth_enterprise/src/third_party/openssl/SConscript
+++ b/earth_enterprise/src/third_party/openssl/SConscript
@@ -1,8 +1,9 @@
 #-*- Python -*-
 #
 # Copyright 2017 Google Inc.
+# Copyright 2021 The Open GEE Contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #

--- a/earth_enterprise/src/third_party/openssl/SConscript
+++ b/earth_enterprise/src/third_party/openssl/SConscript
@@ -49,19 +49,16 @@ else:
   env_opt = 'LDFLAGS=-shared-libgcc CFLAGS="-L%s" CXXFLAGS="-L%s" LDCMD=g++ CC=%s CXX=%s' % (
       build_root, build_root, third_party_env['ENV']['CC'], third_party_env['ENV']['CXX'])
 
-install_root = '%s/install' % current_dir
-install_prefix = install_root + "/opt/google"
-
 # [3] Configure openssl
 openssl_target = '%s/.configure' % current_dir
 openssl_configure = openssl_env.Command(
     openssl_target, openssl_extract,
     [openssl_env.MultiCommand(
         'cd %s\n'
-        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=%s '
-        '--openssldir=%s linux-x86_64 shared\n'
+        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=/opt/google '
+        '--openssldir=/var/opt/google/openssl linux-x86_64 shared\n'
         'touch %s' % (build_root, openssl_env['ENV']['mod_env'], env_opt,
-                      install_prefix, install_prefix, openssl_target))])
+                      openssl_target))])
 
 # [4] Build
 openssl_target = '%s/.build' % current_dir
@@ -81,7 +78,7 @@ openssl_install = openssl_env.Command(
     openssl_target, openssl_build,
     [openssl_env.MultiCommand(
         'cd %s\n'
-        'make INSTALL_PREFIX=%s install_sw\n'
+        'make DESTDIR=%s install_sw install_ssldirs\n'
         'cd %s\n'
         'if [ -d ./lib64 ]; then rsync -rltpvu ./lib64/ ./lib; rm -rf ./lib64; fi\n'
         'rm -rf lib/pkgconfig\n'
@@ -126,6 +123,10 @@ if 'install' in COMMAND_LINE_TARGETS:
       '%s/opt/google/share/' % install_root,
       '%s/opt/google/share/' % Dir(
           openssl_env.installdirs['common_root']).abspath,
+      openssl_install_build, 'install')
+  openssl_env.InstallFileOrDir(
+      '%s/var/' % install_root,
+      '%s/user_magic/var/' % openssl_env.installdirs['common_root'],
       openssl_install_build, 'install')
 
 Return('openssl_extract openssl_install_build')

--- a/earth_enterprise/src/third_party/openssl/SConscript
+++ b/earth_enterprise/src/third_party/openssl/SConscript
@@ -3,7 +3,7 @@
 # Copyright 2017 Google Inc.
 # Copyright 2021 The Open GEE Contributors
 #
-# # Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #

--- a/earth_enterprise/src/third_party/openssl/SConscript
+++ b/earth_enterprise/src/third_party/openssl/SConscript
@@ -59,7 +59,7 @@ openssl_configure = openssl_env.Command(
     [openssl_env.MultiCommand(
         'cd %s\n'
         '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=%s '
-        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=/opt/google '	        '--openssldir=%s linux-x86_64 shared\n'
+        '--openssldir=%s linux-x86_64 shared\n'
         'touch %s' % (build_root, openssl_env['ENV']['mod_env'], env_opt,
                       install_prefix, install_prefix, openssl_target))])
 

--- a/earth_enterprise/src/third_party/openssl/SConscript
+++ b/earth_enterprise/src/third_party/openssl/SConscript
@@ -19,7 +19,7 @@
 Import('third_party_env')
 import os
 
-openssl_version = 'openssl-1.0.2h'
+openssl_version = 'openssl-1.1.1i'
 ge_version = openssl_version.replace('openssl', 'openssl-ge')
 
 current_dir = Dir('.').abspath
@@ -49,17 +49,19 @@ else:
   env_opt = 'LDFLAGS=-shared-libgcc CFLAGS="-L%s" CXXFLAGS="-L%s" LDCMD=g++ CC=%s CXX=%s' % (
       build_root, build_root, third_party_env['ENV']['CC'], third_party_env['ENV']['CXX'])
 
+install_root = '%s/install' % current_dir
+install_prefix = install_root + "/opt/google"
+
 # [3] Configure openssl
 openssl_target = '%s/.configure' % current_dir
 openssl_configure = openssl_env.Command(
     openssl_target, openssl_extract,
     [openssl_env.MultiCommand(
         'cd %s\n'
-        'perl util/perlpath.pl /usr/bin/perl\n'
-        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=/opt/google '
-        '--openssldir=/var/opt/google/openssl linux-x86_64 shared\n'
+        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=%s '
+        '%s%s ./Configure -DSSL_ALLOW_ADH --prefix=/opt/google '	        '--openssldir=%s linux-x86_64 shared\n'
         'touch %s' % (build_root, openssl_env['ENV']['mod_env'], env_opt,
-                      openssl_target))])
+                      install_prefix, install_prefix, openssl_target))])
 
 # [4] Build
 openssl_target = '%s/.build' % current_dir
@@ -89,7 +91,7 @@ openssl_install = openssl_env.Command(
         'rm -rf share/doc/packages/%s\n'
         'mkdir -p share/doc/packages/%s\n'
         'cd -\n'
-        'cp -pr CHANGES CHANGES.SSLeay LICENSE NEWS README '
+        'cp -pr CHANGES LICENSE NEWS README '
         '%s/opt/google/share/doc/packages/%s\n'
         'touch %s' % (build_root, install_root, install_root_opt, ge_version,
                       ge_version, install_root, ge_version, openssl_target))])
@@ -124,10 +126,6 @@ if 'install' in COMMAND_LINE_TARGETS:
       '%s/opt/google/share/' % install_root,
       '%s/opt/google/share/' % Dir(
           openssl_env.installdirs['common_root']).abspath,
-      openssl_install_build, 'install')
-  openssl_env.InstallFileOrDir(
-      '%s/var/' % install_root,
-      '%s/user_magic/var/' % openssl_env.installdirs['common_root'],
       openssl_install_build, 'install')
 
 Return('openssl_extract openssl_install_build')

--- a/earth_enterprise/third_party/openssl/README.google
+++ b/earth_enterprise/third_party/openssl/README.google
@@ -1,5 +1,5 @@
 URL: http://www.openssl.org/
-Version: 1.0.2h
+Version: 1.1.1h
 License: bsd-ish, requires acknowledgment
 License File: LICENSE
 

--- a/earth_enterprise/third_party/openssl/openssl-1.0.2h.tar.gz
+++ b/earth_enterprise/third_party/openssl/openssl-1.0.2h.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
-size 5274412

--- a/earth_enterprise/third_party/openssl/openssl-1.1.1i.tar.gz
+++ b/earth_enterprise/third_party/openssl/openssl-1.1.1i.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+size 9808346


### PR DESCRIPTION
This PR upgrades our bundled version of Open SSL to the latest version. It also fixes some problems with the RPMs that were discovered during this upgrade. Specifically, some of the post-install scripts rely on Open GEE binaries, but in the middle of a yum upgrade you might be using old binaries that are trying to link to libraries that have already been upgraded, resulting in errors and crashes. Thus, this PR also includes code to force upgrades to happen in a safe order.

Fixes #1895