### PR TITLE
Force RPM install order

### DIFF
--- a/earth_enterprise/BUILD_Ubuntu.md
+++ b/earth_enterprise/BUILD_Ubuntu.md
@@ -35,7 +35,7 @@ sudo apt-get install \
     libgdbm-dev libgeos-dev libgeos++-dev libgif-dev libgtest-dev \
     libjpeg-dev libjpeg8-dev libmng-dev libogdi3.2-dev \
     libperl4-corelibs-perl libpng12-0 libpng12-dev libpq-dev libproj-dev \
-    libstdc++6 libtool libgif-dev libtiff-dev libgtk2.0-dev libglib2.0-dev \
+    libstdc++6 libtool libtiff-dev libgtk2.0-dev libglib2.0-dev \
     libx11-dev libxcursor-dev libxerces-c-dev libxft-dev libxinerama-dev \
     libxml2-dev libxml2-utils libxmu-dev libxrandr-dev libyaml-cpp-dev \
     openssl libpcre3 libpcre3-dev \

--- a/earth_enterprise/rpms/build.gradle
+++ b/earth_enterprise/rpms/build.gradle
@@ -1,4 +1,4 @@
-// Copyright 2017 - 2020 the Open GEE Contributors
+// Copyright 2017 - 2021 the Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -258,7 +258,16 @@ task openGeePostGisRpm(type: GeeRpm) {
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
+    // In this case, opengee-postgis doesn't have a pre- or post-install script
+    // to worry about, but we do need to make sure that opengee-common's
+    // pre-install script runs first.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
+
     // The code in GeeRpm decides that this RPM should depend on proj, but
     // it actually depends on proj-devel.
     requires('proj-devel')
@@ -463,7 +472,6 @@ task openGeeCommonDeb (type: GeeDeb, dependsOn: openGeeCommonInitScripts) {
     requires('libstdc++6')
     requires('libtool')
     requires('libxml2-utils')
-    requires('openssl')
     requires('python-imaging')
     requires('python-lxml')
     requires('python-psycopg2')
@@ -536,9 +544,14 @@ task openGeeServerRpm(type: GeeRpm, dependsOn: openGeeServerInitScripts) {
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
     requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
     requires('opengee-postgis', '2.3.9', GREATER | EQUAL)
+    requiresPre('opengee-postgis', '2.3.9', GREATER | EQUAL)
     conflicts('opengee-postgis', '2.0', LESS )
     conflicts('opengee-postgis', '2.4', GREATER | EQUAL)
     requires('python-unittest2')
@@ -770,7 +783,12 @@ built from raster, vector, and location properties data.
     autoFindProvides = true
     autoFindRequires = true
 
+    // "requires" is for runtime dependencies. "requiresPre" is for pre-install
+    // script dependencies. We need both because pre- and post-install scripts
+    // call Open GEE binaries, and they may fail if a different version of
+    // common libraries is installed.
     requires('opengee-common', ospackage.version, GREATER | EQUAL)
+    requiresPre('opengee-common', ospackage.version, GREATER | EQUAL)
     requires('proj-devel') /* This dependency is not being picked up automatically by GeeRpm task */
     requires('/etc/rc.d/init.d/functions')
     requiresCommands(
@@ -914,6 +932,7 @@ task openGeeExtraInitScripts(type: Copy, dependsOn: openGeeSharedFiles) {
 
     CopySpecTemplates.expand(delegate, [
             'openGeeVersion': ospackage.version,
+            'openGeeRelease': ospackage.release,
             'project': project
         ])
 }

--- a/earth_enterprise/rpms/opengee-extra/src/post-install.sh.template
+++ b/earth_enterprise/rpms/opengee-extra/src/post-install.sh.template
@@ -2,6 +2,7 @@
     // Prefix variable definitions to install script:
     new File("${project.buildDir}/shared/install-utils.sh").text
 %>
+CURRENT_VERSION=<%= openGeeVersion %>-<%= openGeeRelease %>.x86_64
 <%= new File("${project.buildDir}/shared/searchexample.sh").text %>
 <%= new File("${project.buildDir}/shared/fusiontutorial.sh").text %>
 <%= new File(thisTemplateFile.parent, '../snippets/post-install.sh').text %>

--- a/earth_enterprise/rpms/shared/snippets/install-utils-main.sh
+++ b/earth_enterprise/rpms/shared/snippets/install-utils-main.sh
@@ -100,3 +100,18 @@ run_as_user()
         ( cd / ;sudo -u $1 $2 )
     fi
 }
+
+get_package_version()
+{
+    local PACKAGE_NAME="${1}"
+    # Declare variable first; otherwise $? will be the exit code of local,
+    # which is always 0
+    local FULL_VERSION
+    FULL_VERSION=`rpm -q "${PACKAGE_NAME}"`
+    if [ $? -eq 0 ]; then
+        # Strip off the package name and return just the version
+        echo ${FULL_VERSION#"$PACKAGE_NAME-"}
+    else
+        echo "None"
+    fi
+}

--- a/earth_enterprise/src/third_party/apache2/SConscript
+++ b/earth_enterprise/src/third_party/apache2/SConscript
@@ -1,6 +1,7 @@
 #-*- Python -*-
 #
 # Copyright 2017 Google Inc.
+# Copyright 2021 The Open GEE Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -158,9 +159,6 @@ to_prune_http = ['man', 'error', 'bin/htdbm',
                  'htdocs/apache_pb.gif', 'htdocs/index.html'
                 ]
 
-# Note: used when compiling with crosstool
-# TODO: delete.
-#stdc = '/opt/google/lib64/libstdc++.so.6'
 apache_target = '%s/.install' % current_dir
 apache_install = apache_env.Command(
     apache_target, apache_configure,


### PR DESCRIPTION
Forces RPMs to install in the required order so that pre- and post- install scripts are guaranteed to work. Also includes other minor fixes.

Fixes #1912