### PR TITLE
Fix vector overflows

### DIFF
--- a/earth_enterprise/src/fusion/rasterfuse/SConscript
+++ b/earth_enterprise/src/fusion/rasterfuse/SConscript
@@ -65,3 +65,6 @@ geraster2gigapxl = env.executable('geraster2gigapxl',
 env.install('fusion_bin', [gerasterimport, gepackgen, geraster2kml])
 env.install('tools_bin', [geraster2gigapxl])
 
+env.test('vipm_vector_unittest',
+         'vipm/vipm_vector_unittest.cpp',
+         LIBS=['gtest'])

--- a/earth_enterprise/src/fusion/rasterfuse/vipm/mesh.h
+++ b/earth_enterprise/src/fusion/rasterfuse/vipm/mesh.h
@@ -297,8 +297,4 @@ bool etMesh<V,T>::saveSMF(const char *fname) {
   return false;
 }
 
-
-/* template etMesh<etVec3f, etFace3i>; */
-
-
 #endif

--- a/earth_enterprise/src/fusion/rasterfuse/vipm/vector.h
+++ b/earth_enterprise/src/fusion/rasterfuse/vipm/vector.h
@@ -35,45 +35,6 @@ class etVec3 {
   etVec3(T v0, T v1, T v2)
   { elem[0] = v0; elem[1] = v1; elem[2] = v2; }
 
-  void set(T v)
-  { elem[0] = elem[1] = elem[2] = v; }
-
-  void set(const etVec3<T>& v)
-  { elem[0] = v.elem[0]; elem[1] = v.elem[1]; elem[2] = v.elem[2]; }
-
-  void set(T v0, T v1, T v2)
-  { elem[0] = v0; elem[1] = v1; elem[2] = v2; }
-
-  void get(etVec3<T>& v)
-  { v.elem[0] = elem[0]; v.elem[1] = elem[1]; v.elem[2] = elem[2]; }
-
-
-
-  inline void operator +=(const etVec3<T>& _v) {
-    set(elem[0]+_v.elem[0], elem[1]+_v.elem[1], elem[2]+_v.elem[2]);
-  };
-
-  inline void operator -=(const etVec3<T>& _v) {
-    set(elem[0]-_v.elem[0], elem[1]-_v.elem[1], elem[2]-_v.elem[2]);
-  };
-
-  inline void operator *=(const etVec3<T>& _v) {
-    set(elem[0]*_v.elem[0], elem[1]*_v.elem[1], elem[2]*_v.elem[2]);
-  };
-
-  inline void operator *=(const T _v) {
-    set(elem[0]*_v, elem[1]*_v, elem[2]*_v);
-  };
-
-  inline void operator +=(const T _v) {
-    set(elem[0]+_v, elem[1]+_v, elem[2]+_v);
-  };
-
-  inline void operator -=(const T _v) {
-    set(elem[0]-_v, elem[1]-_v, elem[2]-_v);
-  };
-
-
   inline T length2() {
     return (T)(elem[0]*elem[0]+elem[1]*elem[1]+elem[2]*elem[2]);
   }
@@ -102,11 +63,6 @@ class etVec3 {
   }
 
   // Dot product
-  T dot(const etVec3<T> &v1, const etVec3<T> &v2)
-  {
-    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
-  }
-
   T dot(const etVec3<T> &v)
   {
     return elem[0] * v[0] + elem[1] * v[1] + elem[2] * v[2];
@@ -114,178 +70,11 @@ class etVec3 {
 
   T& operator[](int index) { return elem[index]; }
   const T operator[](int index) const { return elem[index]; }
-
-  // Distance from segment
-  T segmentDist(const etVec3<T> &p1, const etVec3<T> &p2)
-  {
-    etVec3<T> V(p2);    V -= p1;
-    etVec3<T> W(*this); W -= p1;
-
-    T c1 = dot( W, V );
-    if( c1 <= 0 ) return dist(*this, p1);
-
-    T c2 = dot( V, V );
-    if ( c2 <= c1 ) return dist(*this, p2);
-
-    T b = c1 / c2;
-
-    V *= b;
-    V += p1;
-    return dist(*this, V);
-  }
-
-  // Distance between 2 points
-  T dist(const etVec3<T> &p1, const etVec3<T> &p2)
-  {
-    etVec3<T> p(p1); p -= p2;
-    return p.length();
-  }
-
-  inline T lengthXY2() {
-    return (T)(elem[0]*elem[0]+elem[1]*elem[1]);
-  }
-
-  inline T lengthXZ2() {
-    return (T)(elem[0]*elem[0]+elem[2]*elem[2]);
-  }
-
-  inline T lengthYZ2() {
-    return (T)(elem[1]*elem[1]+elem[2]*elem[2]);
-  }
 };
 
 typedef etVec3<float>  etVec3f;
 typedef etVec3<double> etVec3d;
-typedef etVec3<int>    etVec3i;
-typedef etVec3<short>  etVec3s;
 
-//////////////////////////////////////////////////////////////////////////////
-template <class T>
-class etVec4 {
- public:
-  T elem[4];
-
-  etVec4()
-  { elem[0] = elem[1] = elem[2] = elem[3] = 0; }
-
-  etVec4(T v)
-  { elem[0] = elem[1] = elem[2] = elem[3] = v; }
-
-  etVec4(T v0, T v1, T v2, T v3)
-  { elem[0] = v0; elem[1] = v1; elem[2] = v2; elem[3] = v3; }
-
-  void set(T v)
-  { elem[0] = elem[1] = elem[2] = elem[3] = v; }
-
-  void set(const etVec4<T>& v)
-  { elem[0] = v[0]; elem[1] = v[1]; elem[2] = v[2]; elem[3] = v[3]; }
-
-  void set(T v0, T v1, T v2, T v3)
-  { elem[0] = v0; elem[1] = v1; elem[2] = v2; elem[3] = v3; }
-
-  void get(etVec4<T>& v)
-  { v[0] = elem[0]; v[1] = elem[1]; v[2] = elem[2]; v[3] = elem[3]; }
-
-
-  inline void operator +=(const etVec4<T>& _v) {
-    set(elem[0]+_v.elem[0], elem[1]+_v.elem[1], elem[2]+_v.elem[2], elem[3]+_v.elem[3]);
-  };
-
-  inline void operator -=(const etVec3<T>& _v) {
-    set(elem[0]-_v.elem[0], elem[1]-_v.elem[1], elem[2]-_v.elem[2], elem[3]+_v.elem[3]);
-  };
-
-  inline void operator *=(const etVec3<T>& _v) {
-    set(elem[1]*_v.elem[2]-elem[2]*_v.elem[1],
-        elem[2]*_v.elem[3]-elem[3]*_v.elem[2],
-        elem[3]*_v.elem[0]-elem[0]*_v.elem[3],
-        elem[0]*_v.elem[1]-elem[1]*_v.elem[0]);
-  };
-
-  inline void operator *=(const T _v) {
-    set(elem[0]*_v, elem[1]*_v, elem[2]*_v, elem[3]*_v);
-  };
-
-  inline void operator +=(const T _v) {
-    set(elem[0]+_v, elem[1]+_v, elem[2]+_v, elem[3]+_v);
-  };
-
-  inline void operator -=(const T _v) {
-    set(elem[0]-_v, elem[1]-_v, elem[2]-_v, elem[3]-_v);
-  };
-
-  inline T length2() {
-    return (T)(elem[0]*elem[0]+elem[1]*elem[1]+elem[2]*elem[2]+elem[3]*elem[3]);
-  }
-
-  inline T length() {
-    return (T)sqrt(length2());
-  }
-
-  inline void normalize() {
-    T dst = (T)length();
-    if(dst > 0) {
-    } else
-      dst = 1.0 / dst;
-    elem[0] *= dst; elem[1] *= dst; elem[2] *= dst; elem[3] *= dst;
-    {
-      elem[0] = elem[1] = elem[2] = elem[3] = 0;
-    }
-  }
-
-  // Cross product
-  void cross(const etVec4<T> &v1, const etVec4<T> &v2)
-  {
-    elem[0] = v1[1] * v2[2] - v1[2] * v2[1];
-    elem[1] = v1[2] * v2[3] - v1[3] * v2[2];
-    elem[2] = v1[3] * v2[0] - v1[0] * v2[3];
-    elem[3] = v1[0] * v2[1] - v1[1] * v2[0];
-  }
-
-  // Dot product
-  T dot(const etVec4<T> &v1, const etVec4<T> &v2)
-  {
-    return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3];
-  }
-
-  T dot(const etVec4<T> &v)
-  {
-    return elem[0] * v[0] + elem[1] * v[1] + elem[2] * v[2] + elem[3] * v[3];
-  }
-
-
-  T& operator[](int index) { return elem[index]; }
-  const T operator[](int index) const { return elem[index]; }
-
-  // Distance from segment
-  T segmentDist(const etVec4<T> &p1, const etVec4<T> &p2)
-  {
-    etVec4<T> V(p2);    V -= p1;
-    etVec4<T> W(*this); W -= p1;
-
-    T c1 = dot( W, V );
-    if( c1 <= 0 ) return dist(*this, p1);
-
-    T c2 = dot( V, V );
-    if ( c2 <= c1 ) return dist(*this, p2);
-
-    T b = c1 / c2;
-
-    V *= b;
-    V += p1;
-    return dist(*this, V);
-  }
-
-  // Distance between 2 points
-  T dist(const etVec4<T> &p1, const etVec4<T> &p2)
-  {
-    etVec4<T> p(p1); p -= p2;
-    return p.length();
-  }
-};
-
-typedef etVec4<float> etVec4f;
-typedef etVec4<double> etVec4d;
 
 //////////////////////////////////////////////////////////////////////////////
 template <class T>
@@ -316,13 +105,8 @@ class etFace3 {
 
   T& operator[](int index) { return elem[index]; }
   const T operator[](int index) const { return elem[index]; }
-
-  inline bool isValid() {
-    return elem[0] != elem[1] && elem[0] != elem[2] && elem[1]!= elem[2];
-  }
 };
 
-typedef etFace3<short> etFace3s;
 typedef etFace3<int>   etFace3i;
 
 
@@ -350,18 +134,6 @@ class etBoundingBox3 {
     if(z > max[2]) max[2] = z;
     if(z < min[2]) min[2] = z;
   }
-
-  void center(T &x, T &y, T &z) {
-    x = 0.5 * (min[0] + max[0]);
-    y = 0.5 * (min[1] + max[1]);
-    z = 0.5 * (min[2] + max[2]);
-  }
-
-  void size(T &x, T &y, T &z) {
-    x = max[0] - min[0];
-    y = max[1] - min[1];
-    z = max[2] - min[2];
-  }
 };
 
 
@@ -374,32 +146,12 @@ class etMat3
  public:
   T elem[3][3];
 
-
   // constructors
   //  Declare an empty constructor so C++ do not fill with 0 by default
   etMat3(){};
 
-  // Explicit constructor
-  etMat3(T _m11, T _m12, T _m13, T _m21, T _m22, T _m23, T _m31, T _m32,
-         T _m33) {
-    inline_set(_m11, _m12, _m13,
-               _m21, _m22, _m23,
-               _m31, _m32, _m33);
-  };
-
   // Copy constructor
   etMat3(const etMat3<T>& _m) { memcpy(elem, _m.elem, sizeof(elem)); };
-
-  void set(T _m11, T _m12, T _m13,
-           T _m21, T _m22, T _m23,
-           T _m31, T _m32, T _m33);
-
-  inline void inline_set(T _m11, T _m12, T _m13, T _m21, T _m22, T _m23, T _m31,
-                         T _m32, T _m33) {
-    (*this)[0].inline_set(_m11, _m12, _m13);
-    (*this)[1].inline_set(_m21, _m22, _m23);
-    (*this)[2].inline_set(_m31, _m32, _m33);
-  }
 
   inline void setRow(const etVec3<T>& _v, int i) {
     assert(i<3);
@@ -409,127 +161,6 @@ class etMat3
   inline void setCol(const etVec3<T>& _v, int i) {
     assert(i<3);
     elem[0][i] = _v[0], elem[1][i] = _v[1], elem[2][i] = _v[2];
-  }
-
-
-  // operators
-  inline etVec3<T>& operator[](int i) {
-    assert(i<3);
-    return *(etVec3<T>*)elem[i];
-  }
-
-  inline const etVec3<T>& operator[](int i) const {
-    return *(etVec3<T> *) elem[i];
-  }
-
-  inline void operator=(const etMat3<T>& _m) {
-    memcpy(elem,_m.elem,sizeof(elem));
-  }
-
-  inline void operator+=(const etMat3<T>& _m) {
-    (*this)[0] += _m[0], (*this)[1] += _m[1], (*this)[2] += _m[2];
-  }
-
-  inline void operator-=(const etMat3<T>& _m) {
-    (*this)[0] -= _m[0], (*this)[1] -= _m[1], (*this)[2] -= _m[2];
-  }
-
-  inline void operator*=(const T _s) { mul(*this, _s); }
-
-  inline void operator*=(const etMat3<T>& _m) { mul(*this, _m); }
-
-  inline void operator/=(const T _s) { mul(*this, (1 / _s)); }
-
-  // methods modifying 'this'
-  inline void add(const etMat3<T>& _m1, const etMat3<T>& _m2) {
-    (*this)[0].add(_m1[0],_m2[0]);
-    (*this)[1].add(_m1[1],_m2[1]);
-    (*this)[2].add(_m1[2],_m2[2]);
-  }
-
-  inline void sub(const etMat3<T>& _m1, const etMat3<T>& _m2) {
-    (*this)[0].sub(_m1[0],_m2[0]);
-    (*this)[1].sub(_m1[1],_m2[1]);
-    (*this)[2].sub(_m1[2],_m2[2]);
-  }
-
-  inline void mul(const etMat3<T>& _m, T _sx, T _sy, T _sz) {
-    (*this)[0].mul(_m[0],_sx);
-    (*this)[1].mul(_m[1],_sy);
-    (*this)[2].mul(_m[2],_sz);
-  }
-
-  inline void mul(const etMat3<T>& _m, T _s) { mul(_m, _s, _s, _s); }
-
-  // matrix product
-  inline void mul(const etMat3<T>& _m1, const etMat3<T>& _m2) {
-    set(_m1[0][0]*_m2[0][0]+_m1[0][1]*_m2[1][0]+_m1[0][2]*_m2[2][0],
-        _m1[0][0]*_m2[0][1]+_m1[0][1]*_m2[1][1]+_m1[0][2]*_m2[2][1],
-        _m1[0][0]*_m2[0][2]+_m1[0][1]*_m2[1][2]+_m1[0][2]*_m2[2][2],
-        _m1[1][0]*_m2[0][0]+_m1[1][1]*_m2[1][0]+_m1[1][2]*_m2[2][0],
-        _m1[1][0]*_m2[0][1]+_m1[1][1]*_m2[1][1]+_m1[1][2]*_m2[2][1],
-        _m1[1][0]*_m2[0][2]+_m1[1][1]*_m2[1][2]+_m1[1][2]*_m2[2][2],
-        _m1[2][0]*_m2[0][0]+_m1[2][1]*_m2[1][0]+_m1[2][2]*_m2[2][0],
-        _m1[2][0]*_m2[0][1]+_m1[2][1]*_m2[1][1]+_m1[2][2]*_m2[2][1],
-        _m1[2][0]*_m2[0][2]+_m1[2][1]*_m2[1][2]+_m1[2][2]*_m2[2][2]);
-  }
-
-  // fast one
-  inline void mul_inline(const etMat3<T>& _m1, const etMat3<T>& _m2) {
-    inline_set(_m1[0][0]*_m2[0][0]+_m1[0][1]*_m2[1][0]+_m1[0][2]*_m2[2][0],
-               _m1[0][0]*_m2[0][1]+_m1[0][1]*_m2[1][1]+_m1[0][2]*_m2[2][1],
-               _m1[0][0]*_m2[0][2]+_m1[0][1]*_m2[1][2]+_m1[0][2]*_m2[2][2],
-               _m1[1][0]*_m2[0][0]+_m1[1][1]*_m2[1][0]+_m1[1][2]*_m2[2][0],
-               _m1[1][0]*_m2[0][1]+_m1[1][1]*_m2[1][1]+_m1[1][2]*_m2[2][1],
-               _m1[1][0]*_m2[0][2]+_m1[1][1]*_m2[1][2]+_m1[1][2]*_m2[2][2],
-               _m1[2][0]*_m2[0][0]+_m1[2][1]*_m2[1][0]+_m1[2][2]*_m2[2][0],
-               _m1[2][0]*_m2[0][1]+_m1[2][1]*_m2[1][1]+_m1[2][2]*_m2[2][1],
-               _m1[2][0]*_m2[0][2]+_m1[2][1]*_m2[1][2]+_m1[2][2]*_m2[2][2]);
-  }
-
-  inline void transpose(const etMat3<T>& _m) {
-    T tmp;
-
-    // diagonal first
-    elem[0][0] = _m[0][0], elem[1][1] = _m[1][1], elem[2][2] = _m[2][2];
-
-    // then upper triangle
-    tmp = _m[0][1], elem[0][1] = _m[1][0], elem[1][0] = tmp;
-    tmp = _m[0][2], elem[0][2] = _m[2][0], elem[2][0] = tmp;
-    tmp = _m[1][2], elem[1][2] = _m[2][1], elem[2][1] = tmp;
-  }
-
-  inline void div(const etMat3<T>& _m, double _s) { mul(_m, (1 / _s)); }
-
-  // cofactors, determinants, inverse
-  inline T cofactor(int r, int c) const {
-    static const int index[3][2] = { {1,2}, {0,2}, {0,1} };
-    int i0=index[r][0], i1=index[r][1];
-    int j0=index[c][0], j1=index[c][1];
-    return (((r+c)&1) ? -1.l: 1.l) * (elem[i0][j0]*elem[i1][j1]-elem[i0][j1]*elem[i1][j0]);
-  }
-
-  // reducing methods which result is a double
-  inline T det(void) const {
-    return elem[0][0] * cofactor(0,0) +
-      elem[0][1] * cofactor(0,1) +
-      elem[0][2] * cofactor(0,2);
-  }
-
-  // warning: no inline here !
-  inline void adjoint(const etMat3<T>& _m) {
-    set(_m.cofactor(0,0),_m.cofactor(1,0),_m.cofactor(2,0),
-        _m.cofactor(0,1),_m.cofactor(1,1),_m.cofactor(2,1),
-        _m.cofactor(0,2),_m.cofactor(1,2),_m.cofactor(2,2));
-  }
-
-  // try a adjoint divided by deteminant
-  inline bool inverse(const etMat3<T>& _m) {
-    T d=_m.det();
-    if (ABS(d) < -1E99) return false;
-    adjoint(_m);
-    *this /= d;
-    return true;
   }
 
   inline void transform(const etVec3<T> &in, etVec3<T> &out)
@@ -546,7 +177,6 @@ class etMat3
   }
 };
 
-typedef etMat3<float>  etMat3f;
 typedef etMat3<double> etMat3d;
 
 #endif

--- a/earth_enterprise/src/fusion/rasterfuse/vipm/vipm_vector_unittest.cpp
+++ b/earth_enterprise/src/fusion/rasterfuse/vipm/vipm_vector_unittest.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Open GEE Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "vector.h"
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}

--- a/earth_enterprise/src/fusion/rasterfuse/vipm/vipm_vector_unittest.cpp
+++ b/earth_enterprise/src/fusion/rasterfuse/vipm/vipm_vector_unittest.cpp
@@ -18,6 +18,234 @@
 
 #include "vector.h"
 
+//////////////////////////////////////////////////////////////////////////////
+// etVec3
+
+TEST(etVec3, Construct) {
+  etVec3d v1;
+  EXPECT_EQ(0, v1.elem[0]);
+  EXPECT_EQ(0, v1.elem[1]);
+  EXPECT_EQ(0, v1.elem[2]);
+
+  etVec3d v2(3, 4, 5);
+  EXPECT_EQ(3, v2.elem[0]);
+  EXPECT_EQ(4, v2.elem[1]);
+  EXPECT_EQ(5, v2.elem[2]);
+
+  etVec3d v3(8);
+  EXPECT_EQ(8, v3.elem[0]);
+  EXPECT_EQ(8, v3.elem[1]);
+  EXPECT_EQ(8, v3.elem[2]);
+}
+
+TEST(etVec3, Length) {
+  etVec3d v1(3, 4, 5);
+  EXPECT_FLOAT_EQ(7.0710678, v1.length());
+  EXPECT_EQ(50, v1.length2());
+
+  etVec3d v2;
+  EXPECT_EQ(0, v2.length());
+  EXPECT_EQ(0, v2.length2());
+}
+
+TEST(etVec3, Normalize) {
+  etVec3d v1(8, 9, 10);
+  v1.normalize();
+  EXPECT_FLOAT_EQ(0.51110125, v1.elem[0]);
+  EXPECT_FLOAT_EQ(0.57498891, v1.elem[1]);
+  EXPECT_FLOAT_EQ(0.63887656, v1.elem[2]);
+
+  etVec3d v2;
+  v2.normalize();
+  EXPECT_FLOAT_EQ(0, v2.elem[0]);
+  EXPECT_FLOAT_EQ(0, v2.elem[1]);
+  EXPECT_FLOAT_EQ(0, v2.elem[2]);
+}
+
+TEST(etVec3, CrossProd) {
+  etVec3d v1(1, 2, 3);
+  etVec3d v2(4, 9, 3);
+  etVec3d v3;
+  v3.cross(v1, v2);
+  EXPECT_EQ(-21, v3.elem[0]);
+  EXPECT_EQ(9, v3.elem[1]);
+  EXPECT_EQ(1, v3.elem[2]);
+}
+
+TEST(etVec3, DotProd) {
+  etVec3d v1(9, 8, 7);
+  etVec3d v2(3, 7, 9);
+  double dot = v1.dot(v2);
+  EXPECT_EQ(146, dot);
+}
+
+TEST(etVec3, SubscriptOperators) {
+  etVec3d v1(2, 3, 4);
+  EXPECT_EQ(3, v1[1]);
+  const etVec3d v2(v1);
+  EXPECT_EQ(4, v2[2]);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// etFace3
+
+TEST(etFace3, Construct) {
+  etFace3i f1;
+  EXPECT_EQ(0, f1[0]);
+  EXPECT_EQ(0, f1[1]);
+  EXPECT_EQ(0, f1[2]);
+
+  etFace3i f2(8, 7, 5);
+  EXPECT_EQ(8, f2[0]);
+  EXPECT_EQ(7, f2[1]);
+  EXPECT_EQ(5, f2[2]);
+
+  etFace3i f3(12);
+  EXPECT_EQ(12, f3[0]);
+  EXPECT_EQ(12, f3[1]);
+  EXPECT_EQ(12, f3[2]);
+}
+
+TEST(etFace3, Set) {
+  etFace3i f1;
+  f1.set(5);
+  EXPECT_EQ(5, f1[0]);
+  EXPECT_EQ(5, f1[1]);
+  EXPECT_EQ(5, f1[2]);
+
+  f1.set(4, 3, 2);
+  EXPECT_EQ(4, f1[0]);
+  EXPECT_EQ(3, f1[1]);
+  EXPECT_EQ(2, f1[2]);
+
+  etFace3i f2(7, 8, 9);
+  f1.set(f2);
+  EXPECT_EQ(7, f1[0]);
+  EXPECT_EQ(8, f1[1]);
+  EXPECT_EQ(9, f1[2]);
+}
+
+TEST(etFace3, Get) {
+  etFace3i f1(7, 2, 4);
+  etFace3i f2;
+  f1.get(f2);
+  EXPECT_EQ(7, f2[0]);
+  EXPECT_EQ(2, f2[1]);
+  EXPECT_EQ(4, f2[2]);
+}
+
+TEST(etFace3, SubscriptOperators) {
+  etFace3i f1(2, 3, 4);
+  EXPECT_EQ(3, f1[1]);
+  const etFace3i f2(f1);
+  EXPECT_EQ(4, f2[2]);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// etBoundingBox3
+
+TEST(etBoundingBox3, Construct) {
+  etBoundingBox3<double> b1;
+  EXPECT_LT(0, b1.min[0]);
+  EXPECT_LT(0, b1.min[1]);
+  EXPECT_LT(0, b1.min[2]);
+  EXPECT_GT(0, b1.max[0]);
+  EXPECT_GT(0, b1.max[1]);
+  EXPECT_GT(0, b1.max[2]);
+}
+
+TEST(etBoundingBox3, Add) {
+  etBoundingBox3<double> b1;
+  b1.add(1, 1, 1);
+  EXPECT_FLOAT_EQ(1, b1.min[0]);
+  EXPECT_FLOAT_EQ(1, b1.min[1]);
+  EXPECT_FLOAT_EQ(1, b1.min[2]);
+  EXPECT_FLOAT_EQ(1, b1.max[0]);
+  EXPECT_FLOAT_EQ(1, b1.max[1]);
+  EXPECT_FLOAT_EQ(1, b1.max[2]);
+
+  b1.add(-1, -2, -3);
+  EXPECT_FLOAT_EQ(-1, b1.min[0]);
+  EXPECT_FLOAT_EQ(-2, b1.min[1]);
+  EXPECT_FLOAT_EQ(-3, b1.min[2]);
+  EXPECT_FLOAT_EQ(1, b1.max[0]);
+  EXPECT_FLOAT_EQ(1, b1.max[1]);
+  EXPECT_FLOAT_EQ(1, b1.max[2]);
+
+  b1.add(-5, 4, -2);
+  EXPECT_FLOAT_EQ(-5, b1.min[0]);
+  EXPECT_FLOAT_EQ(-2, b1.min[1]);
+  EXPECT_FLOAT_EQ(-3, b1.min[2]);
+  EXPECT_FLOAT_EQ(1, b1.max[0]);
+  EXPECT_FLOAT_EQ(4, b1.max[1]);
+  EXPECT_FLOAT_EQ(1, b1.max[2]);
+
+  // Adding the same vector should leave the bounding box the same
+  b1.add(-5, 4, -2);
+  EXPECT_FLOAT_EQ(-5, b1.min[0]);
+  EXPECT_FLOAT_EQ(-2, b1.min[1]);
+  EXPECT_FLOAT_EQ(-3, b1.min[2]);
+  EXPECT_FLOAT_EQ(1, b1.max[0]);
+  EXPECT_FLOAT_EQ(4, b1.max[1]);
+  EXPECT_FLOAT_EQ(1, b1.max[2]);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// etMat3
+
+TEST(etMat3, ConstructAndSetRow) {
+  // This constructor sets nothing, so there are no guarantees to check
+  etMat3d m1;
+
+  etMat3d m2;
+  m2.setRow(etVec3d(1, 2, 3), 0);
+  m2.setRow(etVec3d(4, 5, 6), 1);
+  m2.setRow(etVec3d(7, 8, 9), 2);
+  EXPECT_EQ(1, m2.elem[0][0]);
+  EXPECT_EQ(2, m2.elem[0][1]);
+  EXPECT_EQ(3, m2.elem[0][2]);
+  EXPECT_EQ(4, m2.elem[1][0]);
+  EXPECT_EQ(5, m2.elem[1][1]);
+  EXPECT_EQ(6, m2.elem[1][2]);
+  EXPECT_EQ(7, m2.elem[2][0]);
+  EXPECT_EQ(8, m2.elem[2][1]);
+  EXPECT_EQ(9, m2.elem[2][2]);
+
+  etMat3d m3(m2);
+  EXPECT_EQ(1, m3.elem[0][0]);
+  EXPECT_EQ(2, m3.elem[0][1]);
+  EXPECT_EQ(3, m3.elem[0][2]);
+  EXPECT_EQ(4, m3.elem[1][0]);
+  EXPECT_EQ(5, m3.elem[1][1]);
+  EXPECT_EQ(6, m3.elem[1][2]);
+  EXPECT_EQ(7, m3.elem[2][0]);
+  EXPECT_EQ(8, m3.elem[2][1]);
+  EXPECT_EQ(9, m3.elem[2][2]);
+}
+
+TEST(etMat3, SetColAndTransform) {
+  etMat3d m1;
+  m1.setCol(etVec3d(1, 2, 3), 0);
+  m1.setCol(etVec3d(4, 5, 6), 1);
+  m1.setCol(etVec3d(7, 8, 9), 2);
+  EXPECT_EQ(1, m1.elem[0][0]);
+  EXPECT_EQ(2, m1.elem[1][0]);
+  EXPECT_EQ(3, m1.elem[2][0]);
+  EXPECT_EQ(4, m1.elem[0][1]);
+  EXPECT_EQ(5, m1.elem[1][1]);
+  EXPECT_EQ(6, m1.elem[2][1]);
+  EXPECT_EQ(7, m1.elem[0][2]);
+  EXPECT_EQ(8, m1.elem[1][2]);
+  EXPECT_EQ(9, m1.elem[2][2]);
+
+  etVec3d v1(-1, -2, -3);
+  etVec3d v2;
+  m1.transform(v1, v2);
+  EXPECT_EQ(-30, v2.elem[0]);
+  EXPECT_EQ(-36, v2.elem[1]);
+  EXPECT_EQ(-42, v2.elem[2]);
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc,argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
This fixes some vector overflows where the 4th element of a 3-element vector was accessed. The problem code wasn't used, so I simply deleted it. I also removed some other unused functions and added unit tests. I tried to only remove functions such that the compiler would catch any errors except that I removed `operator=` from `etMat3` because it's only used in one place so it was easy to determine that it wasn't needed.

Fixes #1934