### PR TITLE
added vector size check after calling TokenizeString

### DIFF
--- a/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
@@ -297,8 +297,7 @@ std::string JsonUtils::LookAtJson(const std::string& lookAtSpec) {
 
   std::map<std::string, std::string> field_map;
 
-  if (tokens.size() >= 3)
-  {
+  if (tokens.size() >= 3) {
     double altitude = strtod(tokens[2].c_str(), NULL);
     int zoomLevel = AltitudeToZoomLevel(altitude);
 
@@ -307,9 +306,7 @@ std::string JsonUtils::LookAtJson(const std::string& lookAtSpec) {
     field_map["lng"] = tokens[0];
     field_map["zoom"] = Itoa(zoomLevel);
     field_map["altitude"] = DoubleToString(altitude);
-  }
-  else
-  {
+  } else {
     int zoomLevel = AltitudeToZoomLevel(0);
     field_map["lat"] = "0";
     field_map["lng"] = "0";

--- a/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils.cpp
@@ -295,15 +295,27 @@ std::string JsonUtils::LookAtJson(const std::string& lookAtSpec) {
   std::vector<std::string> tokens;
   TokenizeString(lookAtSpec, tokens, "|");
 
-  double altitude = strtod(tokens[2].c_str(), NULL);
-  int zoomLevel = AltitudeToZoomLevel(altitude);
-
-  // Create the map of field name-value pairs for the output JSON.
   std::map<std::string, std::string> field_map;
-  field_map["lat"] = tokens[1];
-  field_map["lng"] = tokens[0];
-  field_map["zoom"] = Itoa(zoomLevel);
-  field_map["altitude"] = DoubleToString(altitude);
+
+  if (tokens.size() >= 3)
+  {
+    double altitude = strtod(tokens[2].c_str(), NULL);
+    int zoomLevel = AltitudeToZoomLevel(altitude);
+
+    // Create the map of field name-value pairs for the output JSON.
+    field_map["lat"] = tokens[1];
+    field_map["lng"] = tokens[0];
+    field_map["zoom"] = Itoa(zoomLevel);
+    field_map["altitude"] = DoubleToString(altitude);
+  }
+  else
+  {
+    int zoomLevel = AltitudeToZoomLevel(0);
+    field_map["lat"] = "0";
+    field_map["lng"] = "0";
+    field_map["zoom"] = Itoa(zoomLevel);
+    field_map["altitude"] = "0";
+  }
   return JsonObject(field_map);
 }
 

--- a/earth_enterprise/src/fusion/autoingest/JsonUtils.h
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils.h
@@ -31,8 +31,6 @@ class QString;
 // JsonUtils is a static utility class for formatting JSON text for
 // Earth and Maps databases.
 class JsonUtils {
- private:
-  JsonUtils() {}  // Static class. Do not allow construction.
 
  public:
   // Create the JSON buffer for a Google Earth Database.
@@ -70,6 +68,10 @@ class JsonUtils {
     const std::string& locale);
 
  protected:
+  //this was private because the class was intended to be 
+  //"static" but made protected to allow for unit testing
+  JsonUtils() {}  
+
   // Create a JSON string for a set of search tabs.
   // search_tabs: the list of search tab definitions
   // return: the JSON string for the search tabs

--- a/earth_enterprise/src/fusion/autoingest/JsonUtils_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils_unittest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 the Open GEE Contributors
+// Copyright 2021 the Open GEE Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,36 +21,14 @@
 
 namespace {
 
-class JsonUtilsAccessor : public JsonUtils {
-  public:
-    std::string RunJsonBool(bool value) {
-      return JsonBool(value);
-    }
-  
-    std::string RunLookAtJson(const std::string& lookAtSpec){
-      return LookAtJson(lookAtSpec);
-    }
-
-    std::string RunJsonObject(const std::map<std::string, std::string>& field_map){
-      return JsonObject(field_map);
-    }
-
-    std::string RunJsonArray(const std::vector<std::string>& array_values){
-      return JsonArray(array_values);
-    }
-};
-
-
 class JsonUnitTest : public testing::Test, public JsonUtils {
-  public:
-    JsonUtilsAccessor jsonUtils;
 };
 
 // Testing the JsonBool function
 TEST_F(JsonUnitTest, JsonBoolTrue) {
     const bool trueBool = true;
     const std::string expectedTrue= "true";
-    std::string result = jsonUtils.RunJsonBool(trueBool);
+    std::string result = JsonBool(trueBool);
 
     EXPECT_EQ(expectedTrue, result);
 }
@@ -58,7 +36,7 @@ TEST_F(JsonUnitTest, JsonBoolTrue) {
 TEST_F(JsonUnitTest, JsonBoolFalse) {
     const bool falseBool = false;
     const std::string expectedFalse= "false";
-    std::string result = jsonUtils.RunJsonBool(falseBool);
+    std::string result = JsonBool(falseBool);
 
     EXPECT_EQ(expectedFalse, result);
 }
@@ -66,7 +44,7 @@ TEST_F(JsonUnitTest, JsonBoolFalse) {
 TEST_F(JsonUnitTest, LookAtValid) {
     const std::string lookAtString = "-93.02119299429238|38.88758732203867|4963567.527932385|0.4781091614682265|6.862074527538373";
     const std::string expectedJson= "{\naltitude : 4.96357e+06,\nlat : 38.88758732203867,\nlng : -93.02119299429238,\nzoom : 3\n}\n";
-    std::string result = jsonUtils.RunLookAtJson(lookAtString);
+    std::string result = LookAtJson(lookAtString);
 
     EXPECT_EQ(expectedJson, result);
 }
@@ -74,7 +52,7 @@ TEST_F(JsonUnitTest, LookAtValid) {
 TEST_F(JsonUnitTest, LookAtInvalid) {
     const std::string lookAtString = "-93.02119299429238|38.88758732203867";
     const std::string expectedJson= "{\naltitude : 0,\nlat : 0,\nlng : 0,\nzoom : 1\n}\n";
-    std::string result = jsonUtils.RunLookAtJson(lookAtString);
+    std::string result = LookAtJson(lookAtString);
 
     EXPECT_EQ(expectedJson, result);
 }
@@ -84,7 +62,7 @@ TEST_F(JsonUnitTest, BasicJsonObject) {
     field_map["foo"] = "bar";
     field_map["bar"] = "baz";
     const std::string expectedJson= "{\nbar : baz,\nfoo : bar\n}\n";
-    std::string result = jsonUtils.RunJsonObject(field_map);
+    std::string result = JsonObject(field_map);
 
     EXPECT_EQ(expectedJson, result);
 }
@@ -95,7 +73,7 @@ TEST_F(JsonUnitTest, BasicJsonArray) {
     array_values.push_back("bar");
     array_values.push_back("baz");
     const std::string expectedJson="\n[\nfoo,\nbar,\nbaz\n]\n";
-    std::string result = jsonUtils.RunJsonArray(array_values);
+    std::string result = JsonArray(array_values);
 
     EXPECT_EQ(expectedJson, result);
 }

--- a/earth_enterprise/src/fusion/autoingest/JsonUtils_unittest.cpp
+++ b/earth_enterprise/src/fusion/autoingest/JsonUtils_unittest.cpp
@@ -1,0 +1,110 @@
+// Copyright 2018 the Open GEE Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Unit tests for Js Utilities 
+
+#include <string>
+#include <gtest/gtest.h>
+#include "fusion/autoingest/JsonUtils.h"
+
+namespace {
+
+class JsonUtilsAccessor : public JsonUtils {
+  public:
+    std::string RunJsonBool(bool value) {
+      return JsonBool(value);
+    }
+  
+    std::string RunLookAtJson(const std::string& lookAtSpec){
+      return LookAtJson(lookAtSpec);
+    }
+
+    std::string RunJsonObject(const std::map<std::string, std::string>& field_map){
+      return JsonObject(field_map);
+    }
+
+    std::string RunJsonArray(const std::vector<std::string>& array_values){
+      return JsonArray(array_values);
+    }
+};
+
+
+class JsonUnitTest : public testing::Test, public JsonUtils {
+  public:
+    JsonUtilsAccessor jsonUtils;
+};
+
+// Testing the JsonBool function
+TEST_F(JsonUnitTest, JsonBoolTrue) {
+    const bool trueBool = true;
+    const std::string expectedTrue= "true";
+    std::string result = jsonUtils.RunJsonBool(trueBool);
+
+    EXPECT_EQ(expectedTrue, result);
+}
+
+TEST_F(JsonUnitTest, JsonBoolFalse) {
+    const bool falseBool = false;
+    const std::string expectedFalse= "false";
+    std::string result = jsonUtils.RunJsonBool(falseBool);
+
+    EXPECT_EQ(expectedFalse, result);
+}
+
+TEST_F(JsonUnitTest, LookAtValid) {
+    const std::string lookAtString = "-93.02119299429238|38.88758732203867|4963567.527932385|0.4781091614682265|6.862074527538373";
+    const std::string expectedJson= "{\naltitude : 4.96357e+06,\nlat : 38.88758732203867,\nlng : -93.02119299429238,\nzoom : 3\n}\n";
+    std::string result = jsonUtils.RunLookAtJson(lookAtString);
+
+    EXPECT_EQ(expectedJson, result);
+}
+
+TEST_F(JsonUnitTest, LookAtInvalid) {
+    const std::string lookAtString = "-93.02119299429238|38.88758732203867";
+    const std::string expectedJson= "{\naltitude : 0,\nlat : 0,\nlng : 0,\nzoom : 1\n}\n";
+    std::string result = jsonUtils.RunLookAtJson(lookAtString);
+
+    EXPECT_EQ(expectedJson, result);
+}
+
+TEST_F(JsonUnitTest, BasicJsonObject) {
+    std::map<std::string, std::string> field_map;
+    field_map["foo"] = "bar";
+    field_map["bar"] = "baz";
+    const std::string expectedJson= "{\nbar : baz,\nfoo : bar\n}\n";
+    std::string result = jsonUtils.RunJsonObject(field_map);
+
+    EXPECT_EQ(expectedJson, result);
+}
+
+TEST_F(JsonUnitTest, BasicJsonArray) {
+    std::vector<std::string> array_values;
+    array_values.push_back("foo");
+    array_values.push_back("bar");
+    array_values.push_back("baz");
+    const std::string expectedJson="\n[\nfoo,\nbar,\nbaz\n]\n";
+    std::string result = jsonUtils.RunJsonArray(array_values);
+
+    EXPECT_EQ(expectedJson, result);
+}
+
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/earth_enterprise/src/fusion/autoingest/SConscript
+++ b/earth_enterprise/src/fusion/autoingest/SConscript
@@ -233,6 +233,10 @@ env.test('JsUtils_unittest',
          'JsUtils_unittest.cpp',
          LIBS=['geautoingest', 'gemiscconfig', 'gtest'])
 
+env.test('JsonUtils_unittest',
+         'JsonUtils_unittest.cpp',
+         LIBS=['geautoingest', 'gemiscconfig', 'gtest'])
+
 env.test('StorageManager_unittest',
          'StorageManager_unittest.cpp',
          LIBS=['gecommon', 'gemiscconfig', 'gtest', 'QtCore', 'QtGui', 'xerces-c', 'gexml'])

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtomapproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtomapproject.cpp
@@ -131,8 +131,7 @@ main(int argc, char *argv[]) {
       std::string this_layer(arg);
       std::vector<std::string> tokens;
       TokenizeString(this_layer, tokens, " \f\n\r\v");
-      if (tokens.size() == 0)
-      {
+      if (tokens.size() == 0) {
         usage(progname, "<layername> cannot be an empty string");
       }
       std::string lref = AssetDefs::NormalizeAssetName(

--- a/earth_enterprise/src/fusion/autoingest/tools/geaddtomapproject.cpp
+++ b/earth_enterprise/src/fusion/autoingest/tools/geaddtomapproject.cpp
@@ -131,6 +131,10 @@ main(int argc, char *argv[]) {
       std::string this_layer(arg);
       std::vector<std::string> tokens;
       TokenizeString(this_layer, tokens, " \f\n\r\v");
+      if (tokens.size() == 0)
+      {
+        usage(progname, "<layername> cannot be an empty string");
+      }
       std::string lref = AssetDefs::NormalizeAssetName(
           tokens[0], AssetDefs::Map, kLayer);
       MapProjectConfig::LayerItem item(lref);


### PR DESCRIPTION
fixes #1943 

Add calls to std::vector::size prior to accessing vector elements in JsonUtils.cpp and geaddtomapproject.cpp