### PR TITLE
1954: Move assetItem pointer use after NULL check, remove unnecessary string conversion

### DIFF
--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -288,17 +288,17 @@ void AssetChooser::accept() {
         // pointer to initiate searching of item by name below.
         auto gname = getName();
         std::string san1 { shortAssetName(assetItem->getAssetHandle()
-                                          ->getName().toUtf8().constData()) } ,
-          san2 { shortAssetName(assetItem->getAssetHandle()
-                                ->getName().toStdString().c_str()) };
+                                          ->getName().toUtf8().constData()) };
+        std::strng san2 { shortAssetName(assetItem->getAssetHandle()
+                                         ->getName().toStdString().c_str()) };
 
-          if (san1 == san2) {
-            gname.clear();
-            gname = QString(san2.c_str());
-          }
-          if (gname != san2.c_str()) {
-            item = NULL;
-          }
+        if (san1 == san2) {
+          gname.clear();
+          gname = QString(san2.c_str());
+        }
+        if (gname != san2.c_str()) {
+          item = NULL;
+        }
       }
     }
 

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -428,10 +428,12 @@ void AssetChooser::nameChanged(const QString& str) {
     if (item != NULL) {
        // If name doesn't match with current item, then clear selection.
       AssetItem* assetItem = dynamic_cast<AssetItem*>(item);
-      std::string san = shortAssetName(assetItem->getAssetHandle()->getName().toStdString().c_str());
-      if (assetItem != NULL &&
-          getName() != san.c_str()) {
-        iconView->clearSelection();
+
+      if (assetItem != NULL) {
+          std::string san = shortAssetName(assetItem->getAssetHandle()->getName());
+          if (getName().toStdString() != san) {
+              iconView->clearSelection();
+          }
       }
     }
     ok_btn->setEnabled(true);

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -281,23 +281,24 @@ void AssetChooser::accept() {
     // whether it has been edited.
     QIconViewItem* item = iconView->currentItem();
     if (item != NULL) {
+
       AssetItem* assetItem = dynamic_cast<AssetItem*>(item);
-      // If name doesn't match with current item name, then reset item
-      // pointer to initiate searching of item by name below.
-      auto gname = getName();
-      std::string san1 { shortAssetName(assetItem->getAssetHandle()
-                         ->getName().toUtf8().constData()) } ,
-                  san2 { shortAssetName(assetItem->getAssetHandle()
-                         ->getName().toStdString().c_str()) };
+      if (assetItem != NULL) {
+        // If name doesn't match with current item name, then reset item
+        // pointer to initiate searching of item by name below.
+        auto gname = getName();
+        std::string san1 { shortAssetName(assetItem->getAssetHandle()
+                                          ->getName().toUtf8().constData()) } ,
+          san2 { shortAssetName(assetItem->getAssetHandle()
+                                ->getName().toStdString().c_str()) };
 
-      if (san1 == san2)
-      {
-          gname.clear();
-          gname = QString(san2.c_str());
-      }
-      if (assetItem != NULL && gname != san2.c_str()) {
-
-        item = NULL;
+          if (san1 == san2) {
+            gname.clear();
+            gname = QString(san2.c_str());
+          }
+          if (assetItem != NULL && gname != san2.c_str()) {
+            item = NULL;
+          }
       }
     }
 

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -296,7 +296,7 @@ void AssetChooser::accept() {
             gname.clear();
             gname = QString(san2.c_str());
           }
-          if (assetItem != NULL && gname != san2.c_str()) {
+          if (gname != san2.c_str()) {
             item = NULL;
           }
       }

--- a/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
+++ b/earth_enterprise/src/fusion/fusionui/AssetChooser.cpp
@@ -289,7 +289,7 @@ void AssetChooser::accept() {
         auto gname = getName();
         std::string san1 { shortAssetName(assetItem->getAssetHandle()
                                           ->getName().toUtf8().constData()) };
-        std::strng san2 { shortAssetName(assetItem->getAssetHandle()
+        std::string san2 { shortAssetName(assetItem->getAssetHandle()
                                          ->getName().toStdString().c_str()) };
 
         if (san1 == san2) {


### PR DESCRIPTION
This fixes a cppcheck warning, and since I was there, I removed a couple of unneeded .c_str() calls.

This fixes issue https://github.com/google/earthenterprise/issues/1954