### PR TITLE
1961: Fusion and Server RPM post-install fixes.

### DIFF
--- a/earth_enterprise/rpms/opengee-fusion/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-fusion/snippets/post-install.sh
@@ -205,7 +205,7 @@ fix_file_permissions()
     if [ ! -d "$BASEINSTALLDIR_OPT/.users/$GEFUSIONUSER" ]; then
       mkdir -p "$BASEINSTALLDIR_OPT/.users/$GEFUSIONUSER"
     fi
-    chown -R "GEFUSIONUSER:$GEGROUP" "$BASEINSTALLDIR_OPT/.users/$GEFUSIONUSER"
+    chown -R "$GEFUSIONUSER:$GEGROUP" "$BASEINSTALLDIR_OPT/.users/$GEFUSIONUSER"
 
     # TODO: Disabled for now...
     #sgid enabled

--- a/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
+++ b/earth_enterprise/rpms/opengee-server/snippets/post-install.sh
@@ -169,15 +169,15 @@ sudo /opt/google/bin/geconfigurepublishroot --noprompt --chown --path=$PUBLISHER
     # Restrict permissions to uninstaller and installer logs
     chmod -R go-rwx "$BASEINSTALLDIR_OPT/install"
 
-    if [ ! -d "${GEINSTALLDIR_OPT}/.users/${GEPGUSER}" ]; then
-      mkdir -p "${GEINSTALLDIR_OPT}/.users/${GEPGUSER}"
+    if [ ! -d "${BASEINSTALLDIR_OPT}/.users/${GEPGUSER}" ]; then
+      mkdir -p "${BASEINSTALLDIR_OPT}/.users/${GEPGUSER}"
     fi
-    chown -R "${GEPGUSER}:${GEGROUP}" "${GEINSTALLDIR_OPT}/.users/${GEPGUSER}"
+    chown -R "${GEPGUSER}:${GEGROUP}" "${BASEINSTALLDIR_OPT}/.users/${GEPGUSER}"
 
-    if [ ! -d "${GEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}" ]; then
-      mkdir -p "${GEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}"
+    if [ ! -d "${BASEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}" ]; then
+      mkdir -p "${BASEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}"
     fi
-    chown -R "${GEAPACHEUSER}:${GEGROUP}" "${GEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}"
+    chown -R "${GEAPACHEUSER}:${GEGROUP}" "${BASEINSTALLDIR_OPT}/.users/${GEAPACHEUSER}"
 }
 
 reset_pgdb()


### PR DESCRIPTION
* Change `GEFUSIONUSER` to `$GEFUSIONUSER` in opengee-fusion's
  post-install.sh
* Change `${GEINSTALLDIR_OPT}` to `${BASEINSTALLDIR_OPT}` in
  opengee-server's post-install.sh

Fixes #1961