### PR TITLE
Add instructions for building gtest from source

### DIFF
--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -181,7 +181,7 @@ wget https://github.com/google/googletest/archive/refs/tags/release-1.8.0.tar.gz
 tar xvf release-1.8.0.tar.gz
 cd googletest-release-1.8.0 && mkdir build && cd build
 cmake -DMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make && sudo make install
-cd .. && ln -s `pwd`/googletest /usr/src/gtest
+cd .. && sudo ln -s `pwd`/googletest /usr/src/gtest
 ```
 
 ### RHEL 6 and CentOS 6

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -174,6 +174,16 @@ GTest is included in the EPEL and RHEL Extra Repositories. Install the RPM with:
 sudo yum install -y gtest-devel
 ```
 
+If you prefer to build GTest from source, you can try the following procedure:
+
+```bash
+wget https://github.com/google/googletest/archive/refs/tags/release-1.8.0.tar.gz
+tar xvf release-1.8.0.tar.gz
+cd googletest-release-1.8.0 && mkdir build && cd build
+cmake -DMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make && sudo make install
+cd .. && ln -s `pwd`/googletest /usr/src/gtest
+```
+
 ### RHEL 6 and CentOS 6
 
 You will need to compile, package, and install an updated version of GTest as an

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -180,7 +180,7 @@ If you prefer to build GTest from source, you can try the following procedure:
 wget https://github.com/google/googletest/archive/refs/tags/release-1.8.0.tar.gz
 tar xvf release-1.8.0.tar.gz
 cd googletest-release-1.8.0 && mkdir build && cd build
-cmake -DMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make && sudo make install
+cmake -DMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make && sudo make install
 cd .. && sudo ln -s `pwd`/googletest /usr/src/gtest
 ```
 

--- a/earth_enterprise/BUILD_RHEL_CentOS.md
+++ b/earth_enterprise/BUILD_RHEL_CentOS.md
@@ -182,6 +182,7 @@ tar xvf release-1.8.0.tar.gz
 cd googletest-release-1.8.0 && mkdir build && cd build
 cmake -DMAKE_POSITION_INDEPENDENT_CODE=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr .. && make && sudo make install
 cd .. && sudo ln -s `pwd`/googletest /usr/src/gtest
+sudo ldconfig
 ```
 
 ### RHEL 6 and CentOS 6


### PR DESCRIPTION
Adds instructions for building GTest 1.8 from source if desired.
